### PR TITLE
Fix V3093

### DIFF
--- a/sipsorcery-core/SIPSorcery.Persistence/StorageLayer.cs
+++ b/sipsorcery-core/SIPSorcery.Persistence/StorageLayer.cs
@@ -405,7 +405,7 @@ namespace SIPSorcery.Persistence
             {
                 return false;
             }
-            else if (column.ToString() == "1" | column.ToString() == "t" ||  column.ToString() == "T" || Regex.Match(column.ToString(), "true", RegexOptions.IgnoreCase).Success)
+            else if (column.ToString() == "1" || column.ToString() == "t" ||  column.ToString() == "T" || Regex.Match(column.ToString(), "true", RegexOptions.IgnoreCase).Success)
             {
                 return true;
             }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The '|' operator evaluates both operands. Perhaps a short-circuit '||' operator should be used instead. SIPSorcery.Persistence StorageLayer.cs 408