### PR TITLE
Fix V3127

### DIFF
--- a/sipsorcery-core/SIPSorcery.Sys/Auth/SIPSorcerySecurityHeader.cs
+++ b/sipsorcery-core/SIPSorcery.Sys/Auth/SIPSorcerySecurityHeader.cs
@@ -43,7 +43,7 @@ namespace SIPSorcery.Sys.Auth
             if (!APIKey.IsNullOrBlank())
             {
                 writer.WriteStartElement(SECURITY_PREFIX, APIKEY_ELEMENT_NAME, SECURITY_NAMESPACE);
-                writer.WriteString(AuthID);
+                writer.WriteString(APIKey);
                 writer.WriteEndElement();
             }
         }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Two similar code fragments were found. Perhaps, this is a typo and 'APIKey' variable should be used instead of 'AuthID' SIPSorcery.Sys SIPSorcerySecurityHeader.cs 46