### PR TITLE
Fix V3127

### DIFF
--- a/sipsorcery-core/SIPSorcery.Net/RTSP/Mjpeg.cs
+++ b/sipsorcery-core/SIPSorcery.Net/RTSP/Mjpeg.cs
@@ -293,7 +293,7 @@ namespace SIPSorcery.Net
                     i++;
 
                     //Chroma
-                    BitConverter.GetBytes(NetConvert.DoReverseEndian((ushort)Math.Min(Math.Max((defaultQuantizers[i] * q + 50) / 100, 1), byte.MaxValue))).CopyTo(resultTables, j);
+                    BitConverter.GetBytes(NetConvert.DoReverseEndian((ushort)Math.Min(Math.Max((defaultQuantizers[j] * q + 50) / 100, 1), byte.MaxValue))).CopyTo(resultTables, j);
                     j++;
                 }
             }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Two similar code fragments were found. Perhaps, this is a typo and 'j' variable should be used instead of 'i' SIPSorcery.Net Mjpeg.cs 296