### PR TITLE
.NET Standard 2.0 versions of selected SIPSorcery libraries

### DIFF
--- a/sipsorcery-core/SIPSorcery-Core.sln
+++ b/sipsorcery-core/SIPSorcery-Core.sln
@@ -65,6 +65,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shims", "Shims\Shims.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.Persistence.Standard", "SIPSorcery.Persistence.Standard\SIPSorcery.Persistence.Standard.csproj", "{1A037032-9E66-411F-B41E-15B7947D308B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.CRM.Standard", "SIPSorcery.CRM.Standard\SIPSorcery.CRM.Standard.csproj", "{88B77F1B-6895-4BF1-A661-69EDBDC03D38}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -363,6 +365,18 @@ Global
 		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x64.Build.0 = Release|Any CPU
 		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x86.ActiveCfg = Release|Any CPU
 		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x86.Build.0 = Release|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Debug|x64.Build.0 = Debug|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Debug|x86.Build.0 = Debug|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Release|x64.ActiveCfg = Release|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Release|x64.Build.0 = Release|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Release|x86.ActiveCfg = Release|Any CPU
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -383,6 +397,7 @@ Global
 		{CB5A2A55-947D-4628-B228-6D7C098E1E78} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 		{80154454-E668-4A06-AA43-50A2171F3EDD} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 		{1A037032-9E66-411F-B41E-15B7947D308B} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+		{88B77F1B-6895-4BF1-A661-69EDBDC03D38} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7AED29C-520F-4F82-95C6-AF2B97B66FFC}

--- a/sipsorcery-core/SIPSorcery-Core.sln
+++ b/sipsorcery-core/SIPSorcery-Core.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B7CB4A2-B101-473E-B5A8-3B746A232647}"
 	ProjectSection(SolutionItems) = preProject
@@ -50,6 +50,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.Web.Services.Test", "Tests\SIPSorcery.Web.Services.Test\SIPSorcery.Web.Services.Test.csproj", "{0E37C7C5-D19B-4D55-B4F0-F95FED155AE3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.Entities.IntegrationTests", "Tests\SIPSorcery.Entities.IntegrationTests\SIPSorcery.Entities.IntegrationTests.csproj", "{3853A052-236B-4A7F-B55A-804E9DCBAA93}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netstandard", "netstandard", "{E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.Sys.Standard", "SIPSorcery.Sys.Standard\SIPSorcery.Sys.Standard.csproj", "{959BE749-1F3D-4758-A4C6-F7C3BBD36480}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.SIP.Core.Standard", "SIPSorcery.SIP.Core.Standard\SIPSorcery.SIP.Core.Standard.csproj", "{6849BC63-B334-40CE-9486-AF76E68926E8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.Net.Standard", "SIPSorcery.Net.Standard\SIPSorcery.Net.Standard.csproj", "{EC6B3411-A1BD-4701-BBCF-1BA60332F776}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -277,6 +285,42 @@ Global
 		{3853A052-236B-4A7F-B55A-804E9DCBAA93}.Release|x64.Build.0 = Release|Any CPU
 		{3853A052-236B-4A7F-B55A-804E9DCBAA93}.Release|x86.ActiveCfg = Release|Any CPU
 		{3853A052-236B-4A7F-B55A-804E9DCBAA93}.Release|x86.Build.0 = Release|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Debug|x64.Build.0 = Debug|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Debug|x86.Build.0 = Debug|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Release|Any CPU.Build.0 = Release|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Release|x64.ActiveCfg = Release|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Release|x64.Build.0 = Release|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Release|x86.ActiveCfg = Release|Any CPU
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480}.Release|x86.Build.0 = Release|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Debug|x64.Build.0 = Debug|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Debug|x86.Build.0 = Debug|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Release|x64.ActiveCfg = Release|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Release|x64.Build.0 = Release|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Release|x86.ActiveCfg = Release|Any CPU
+		{6849BC63-B334-40CE-9486-AF76E68926E8}.Release|x86.Build.0 = Release|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x64.Build.0 = Release|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -291,6 +335,12 @@ Global
 		{8A2CFE65-422F-4F16-8841-B44067BAB59F} = {5A855FE1-8B93-429D-95A5-B8215CF62A9D}
 		{0E37C7C5-D19B-4D55-B4F0-F95FED155AE3} = {5A855FE1-8B93-429D-95A5-B8215CF62A9D}
 		{3853A052-236B-4A7F-B55A-804E9DCBAA93} = {5A855FE1-8B93-429D-95A5-B8215CF62A9D}
+		{959BE749-1F3D-4758-A4C6-F7C3BBD36480} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+		{6849BC63-B334-40CE-9486-AF76E68926E8} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+		{EC6B3411-A1BD-4701-BBCF-1BA60332F776} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F7AED29C-520F-4F82-95C6-AF2B97B66FFC}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = SIPSorcery-Core.vsmdi

--- a/sipsorcery-core/SIPSorcery-Core.sln
+++ b/sipsorcery-core/SIPSorcery-Core.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2010
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B7CB4A2-B101-473E-B5A8-3B746A232647}"
 	ProjectSection(SolutionItems) = preProject
@@ -58,6 +58,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.SIP.Core.Standard", "SIPSorcery.SIP.Core.Standard\SIPSorcery.SIP.Core.Standard.csproj", "{6849BC63-B334-40CE-9486-AF76E68926E8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.Net.Standard", "SIPSorcery.Net.Standard\SIPSorcery.Net.Standard.csproj", "{EC6B3411-A1BD-4701-BBCF-1BA60332F776}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.SIP.App.Standard", "SIPSorcery.SIP.App.Standard\SIPSorcery.SIP.App.Standard.csproj", "{CB5A2A55-947D-4628-B228-6D7C098E1E78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shims", "Shims\Shims.csproj", "{80154454-E668-4A06-AA43-50A2171F3EDD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -321,6 +325,30 @@ Global
 		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x64.Build.0 = Release|Any CPU
 		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x86.ActiveCfg = Release|Any CPU
 		{EC6B3411-A1BD-4701-BBCF-1BA60332F776}.Release|x86.Build.0 = Release|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Release|x64.Build.0 = Release|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78}.Release|x86.Build.0 = Release|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Debug|x64.Build.0 = Debug|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Debug|x86.Build.0 = Debug|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x64.ActiveCfg = Release|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x64.Build.0 = Release|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x86.ActiveCfg = Release|Any CPU
+		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -338,6 +366,8 @@ Global
 		{959BE749-1F3D-4758-A4C6-F7C3BBD36480} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 		{6849BC63-B334-40CE-9486-AF76E68926E8} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 		{EC6B3411-A1BD-4701-BBCF-1BA60332F776} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+		{CB5A2A55-947D-4628-B228-6D7C098E1E78} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+		{80154454-E668-4A06-AA43-50A2171F3EDD} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7AED29C-520F-4F82-95C6-AF2B97B66FFC}

--- a/sipsorcery-core/SIPSorcery-Core.sln
+++ b/sipsorcery-core/SIPSorcery-Core.sln
@@ -59,9 +59,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.SIP.Core.Standar
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.Net.Standard", "SIPSorcery.Net.Standard\SIPSorcery.Net.Standard.csproj", "{EC6B3411-A1BD-4701-BBCF-1BA60332F776}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.SIP.App.Standard", "SIPSorcery.SIP.App.Standard\SIPSorcery.SIP.App.Standard.csproj", "{CB5A2A55-947D-4628-B228-6D7C098E1E78}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery.SIP.App.Standard", "SIPSorcery.SIP.App.Standard\SIPSorcery.SIP.App.Standard.csproj", "{CB5A2A55-947D-4628-B228-6D7C098E1E78}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shims", "Shims\Shims.csproj", "{80154454-E668-4A06-AA43-50A2171F3EDD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shims", "Shims\Shims.csproj", "{80154454-E668-4A06-AA43-50A2171F3EDD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIPSorcery.Persistence.Standard", "SIPSorcery.Persistence.Standard\SIPSorcery.Persistence.Standard.csproj", "{1A037032-9E66-411F-B41E-15B7947D308B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -349,6 +351,18 @@ Global
 		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x64.Build.0 = Release|Any CPU
 		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x86.ActiveCfg = Release|Any CPU
 		{80154454-E668-4A06-AA43-50A2171F3EDD}.Release|x86.Build.0 = Release|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Debug|x64.Build.0 = Debug|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Debug|x86.Build.0 = Debug|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x64.ActiveCfg = Release|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x64.Build.0 = Release|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x86.ActiveCfg = Release|Any CPU
+		{1A037032-9E66-411F-B41E-15B7947D308B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -368,6 +382,7 @@ Global
 		{EC6B3411-A1BD-4701-BBCF-1BA60332F776} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 		{CB5A2A55-947D-4628-B228-6D7C098E1E78} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 		{80154454-E668-4A06-AA43-50A2171F3EDD} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
+		{1A037032-9E66-411F-B41E-15B7947D308B} = {E7431B63-0BC0-4C5F-BCE1-6A3E582ACDD6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7AED29C-520F-4F82-95C6-AF2B97B66FFC}

--- a/sipsorcery-core/SIPSorcery.CRM.Standard/SIPSorcery.CRM.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.CRM.Standard/SIPSorcery.CRM.Standard.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <AssemblyName>SIPSorcery.CRM</AssemblyName>
+    <RootNamespace>SIPSorcery.CRM</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Shims/Shims.csproj" />
+    <ProjectReference Include="../SIPSorcery.Persistence.Standard/SIPSorcery.Persistence.Standard.csproj" />
+    <ProjectReference Include="../SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj" />
+    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SIPSorcery.CRM/**/*.cs" Exclude="../SIPSorcery.CRM/obj/**/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/sipsorcery-core/SIPSorcery.CRM.Standard/SIPSorcery.CRM.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.CRM.Standard/SIPSorcery.CRM.Standard.csproj
@@ -8,15 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Shims/Shims.csproj" />
     <ProjectReference Include="../SIPSorcery.Persistence.Standard/SIPSorcery.Persistence.Standard.csproj" />
-    <ProjectReference Include="../SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj" />
-    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sipsorcery-core/SIPSorcery.Net.Standard/SIPSorcery.Net.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.Net.Standard/SIPSorcery.Net.Standard.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
   </ItemGroup>
 

--- a/sipsorcery-core/SIPSorcery.Net.Standard/SIPSorcery.Net.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.Net.Standard/SIPSorcery.Net.Standard.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <AssemblyName>SIPSorcery.Net</AssemblyName>
+    <RootNamespace>SIPSorcery.Net</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SIPSorcery.Net/**/*.cs" Exclude="../SIPSorcery.Net/obj/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="../SIPSorcery.Net/RTP/RTPReceiver.cs" />
+  </ItemGroup>
+
+</Project>

--- a/sipsorcery-core/SIPSorcery.Net/AssemblyInfo.cs
+++ b/sipsorcery-core/SIPSorcery.Net/AssemblyInfo.cs
@@ -4,4 +4,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("Helper classes for SIP related protocols.")]
 [assembly: AssemblyCompany("SIP Sorcery PTY LTD")]
 [assembly: AssemblyCopyright("Aaron Clauson")]
+#if NETSTANDARD2_0
+[assembly: AssemblyVersion("1.5.6")]
+#else
 [assembly: AssemblyVersion("1.5.6.*")]
+#endif

--- a/sipsorcery-core/SIPSorcery.Net/DNS/DNSManager.cs
+++ b/sipsorcery-core/SIPSorcery.Net/DNS/DNSManager.cs
@@ -55,7 +55,11 @@ namespace SIPSorcery.Net
         private const string SIP_TLS_QUERY_PREFIX = "_sip._tls.";
         private const string SIPS_TCP_QUERY_PREFIX = "_sips._tcp.";
 
+#if NETSTANDARD2_0
+        private static ILog logger = LogManager.GetLogger(SIPSorcery.Sys.AppState.LoggerRepository.Name, LOOKUP_THREAD_NAME);
+#else
         private static ILog logger = LogManager.GetLogger(LOOKUP_THREAD_NAME);
+#endif
 
         //private static Dictionary<string, DNSResponse> m_dnsResponses = new Dictionary<string, DNSResponse>();  // DNS query responses that have been looked up and stored.
 

--- a/sipsorcery-core/SIPSorcery.Net/DNS/Resolver.cs
+++ b/sipsorcery-core/SIPSorcery.Net/DNS/Resolver.cs
@@ -25,9 +25,12 @@ using System.Text;
 using System.Net.Sockets;
 using System.Net.NetworkInformation;
 using System.Diagnostics;
-using System.Runtime.Remoting.Messaging;
 using SIPSorcery.Sys;
 using log4net;
+
+#if !NETSTANDARD2_0
+using System.Runtime.Remoting.Messaging;
+#endif
 
 /*
  * Network Working Group                                     P. Mockapetris
@@ -806,6 +809,7 @@ namespace Heijden.DNS
                 return MakeEntry(hostNameOrAddress, DEFAULT_TIMEOUT);
         }
 
+#if !NETSTANDARD2_0
         private delegate IPHostEntry GetHostEntryViaIPDelegate(IPAddress ip);
         private delegate IPHostEntry GetHostEntryDelegate(string hostNameOrAddress);
 
@@ -873,7 +877,7 @@ namespace Heijden.DNS
             }
             return null;
         }
-
+#endif
         private IPEndPoint GetActiveDNSServer()
         {
             if (m_DnsServers == null)

--- a/sipsorcery-core/SIPSorcery.Net/RTCP/RTCP.cs
+++ b/sipsorcery-core/SIPSorcery.Net/RTCP/RTCP.cs
@@ -239,8 +239,11 @@ namespace SIPSorcery.Net
         private const int CHECK_FORSAMPLE_PERIOD = 3000;
         private const string RTCP_FORMAT_STRING = "syncsrc={0}, ts={1} ,te={2} , dur={3} ,seqs={4,-5:S} ,seqe={5,-5:S} ,pkttot={6,-3:S} ,jitmax={7,-3:S}, jitavg={8,-4:S} " + 
                                     ",transit={9,-5:S} ,pktrate={10,-5:S} ,bytestot={11,-5:S} ,bw={12,-9:S} ,drops={13} ,jitdrops={14} ,duplicates={15} ,outoforder={16}";
-
-		private static ILog logger = log4net.LogManager.GetLogger("rtcp");
+#if NETSTANDARD2_0
+        private static ILog logger = log4net.LogManager.GetLogger(AppState.LoggerRepository.Name, "rtcp");
+#else
+        private static ILog logger = log4net.LogManager.GetLogger("rtcp");
+#endif
 
 		public int JitterBufferMilliseconds = 150;	// The size of a the theoretical jitter buffer.
 		public int ReportSampleDuration = 1500;		// Sample time in milliseconds after which a new sample is generated.

--- a/sipsorcery-core/SIPSorcery.Net/STUN/STUNAppState.cs
+++ b/sipsorcery-core/SIPSorcery.Net/STUN/STUNAppState.cs
@@ -62,7 +62,11 @@ namespace SIPSorcery.Net
 			try
 			{
 				// Configure logging.
-				logger = log4net.LogManager.GetLogger(LOGGER_NAME);
+#if NETSTANDARD2_0
+                logger = log4net.LogManager.GetLogger(SIPSorcery.Sys.AppState.LoggerRepository.Name, LOGGER_NAME);
+#else
+                logger = log4net.LogManager.GetLogger(LOGGER_NAME);
+#endif
 			}
 			catch(Exception excp)
 			{

--- a/sipsorcery-core/SIPSorcery.Persistence.Standard/SIPSorcery.Persistence.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.Persistence.Standard/SIPSorcery.Persistence.Standard.csproj
@@ -8,16 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Shims/Shims.csproj" />
     <ProjectReference Include="../SIPSorcery.SIP.App.Standard/SIPSorcery.SIP.App.Standard.csproj" />
-    <ProjectReference Include="../SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj" />
-    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sipsorcery-core/SIPSorcery.Persistence.Standard/SIPSorcery.Persistence.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.Persistence.Standard/SIPSorcery.Persistence.Standard.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <AssemblyName>SIPSorcery.Persistence</AssemblyName>
+    <RootNamespace>SIPSorcery.Persistence</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Shims/Shims.csproj" />
+    <ProjectReference Include="../SIPSorcery.SIP.App.Standard/SIPSorcery.SIP.App.Standard.csproj" />
+    <ProjectReference Include="../SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj" />
+    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SIPSorcery.Persistence/**/*.cs" Exclude="../SIPSorcery.Persistence/obj/**/*.cs" />
+  </ItemGroup>
+  
+</Project>

--- a/sipsorcery-core/SIPSorcery.Persistence/DynamicLinq.cs
+++ b/sipsorcery-core/SIPSorcery.Persistence/DynamicLinq.cs
@@ -229,7 +229,7 @@ namespace System.Linq.Dynamic
 
         private ClassFactory() {
             AssemblyName name = new AssemblyName("DynamicClasses");
-            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
 #if ENABLE_LINQ_PARTIAL_TRUST
             new ReflectionPermission(PermissionState.Unrestricted).Assert();
 #endif
@@ -274,7 +274,7 @@ namespace System.Linq.Dynamic
                     FieldInfo[] fields = GenerateProperties(tb, properties);
                     GenerateEquals(tb, fields);
                     GenerateGetHashCode(tb, fields);
-                    Type result = tb.CreateType();
+                    Type result = tb.CreateTypeInfo();
                     classCount++;
                     return result;
                 }

--- a/sipsorcery-core/SIPSorcery.Persistence/Properties/AssemblyInfo.cs
+++ b/sipsorcery-core/SIPSorcery.Persistence/Properties/AssemblyInfo.cs
@@ -4,4 +4,8 @@
 [assembly: AssemblyDescription("Manages persistence of assets to databases or other storage options.")]
 [assembly: AssemblyCompany("SIP Sorcery PTY LTD")]
 [assembly: AssemblyCopyright("Aaron Clauson")]
+#if NETSTANDARD2_0
+[assembly: AssemblyVersion("1.5.6")]
+#else
 [assembly: AssemblyVersion("1.5.6.*")]
+#endif

--- a/sipsorcery-core/SIPSorcery.Persistence/SIPAssetPersistorFactory.cs
+++ b/sipsorcery-core/SIPSorcery.Persistence/SIPAssetPersistorFactory.cs
@@ -59,30 +59,29 @@ namespace SIPSorcery.Persistence
                 //    }
                 //    return new SIPAssetXMLPersistor<T>(storageConnectionStr + filename);
                 //}
+#if !NETSTANDARD2_0
                 if (storageType == StorageTypes.SQLLinqMySQL)
                 {
                     return new SQLAssetPersistor<T>(MySql.Data.MySqlClient.MySqlClientFactory.Instance, storageConnectionStr);
                 }
-                //else if (storageType == StorageTypes.SQLLinqPostgresql)
+#endif
+                //if (storageType == StorageTypes.SQLLinqPostgresql)
                 //{
                 //    return new SQLAssetPersistor<T>(Npgsql.NpgsqlFactory.Instance, storageConnectionStr);
                 //}
-                //else if (storageType == StorageTypes.SimpleDBLinq)
+                //if (storageType == StorageTypes.SimpleDBLinq)
                 //{
                 //    return new SimpleDBAssetPersistor<T>(storageConnectionStr);
                 //}
-                //else if (storageType == StorageTypes.SQLLinqMSSQL)
-                //{
-                //    return new MSSQLAssetPersistor<T>(System.Data.SqlClient.SqlClientFactory.Instance, storageConnectionStr);
-                //}
-                //else if (storageType == StorageTypes.SQLLinqOracle)
+                if (storageType == StorageTypes.SQLLinqMSSQL)
+                {
+                    return new SQLAssetPersistor<T>(System.Data.SqlClient.SqlClientFactory.Instance, storageConnectionStr);
+                }
+                //if (storageType == StorageTypes.SQLLinqOracle)
                 //{
                 //    return new SQLAssetPersistor<T>(Oracle.DataAccess.Client.OracleClientFactory.Instance, storageConnectionStr);
                 //}
-                else
-                {
-                    throw new ApplicationException(storageType + " is not supported as a CreateSIPAssetPersistor option.");
-                }
+                throw new ApplicationException(storageType + " is not supported as a CreateSIPAssetPersistor option.");
             }
             catch (Exception excp)
             {

--- a/sipsorcery-core/SIPSorcery.Persistence/StorageLayer.cs
+++ b/sipsorcery-core/SIPSorcery.Persistence/StorageLayer.cs
@@ -22,8 +22,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Odbc;
-using System.Data.OleDb;
 using System.Data.SqlClient;
 using System.IO;
 using System.Net.Sockets;
@@ -31,9 +29,14 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using SIPSorcery.Sys;
 using log4net;
+
+#if !NETSTANDARD2_0
+using System.Data.Odbc;
+using System.Data.OleDb;
 using MySql.Data.MySqlClient;
 using Npgsql;
 using NpgsqlTypes;
+#endif
 
 #if UNITTEST
 using NUnit.Framework;
@@ -204,101 +207,102 @@ namespace SIPSorcery.Persistence
             }
 		}
 
-		//public int StoreLargeObject(Stream largeObjectStream)
-		//{
-		//	return StoreLargeObject(m_storageType, m_dbConnStr, largeObjectStream);
-		//}
-		
-		//public int StoreLargeObject(StorageTypes storageType, string dbConnString, Stream largeObjectStream)
-		//{
-		//	try
-		//	{
-		//		if(storageType == StorageTypes.Postgresql)
-		//		{
-		//			NpgsqlConnection connPgsql = new NpgsqlConnection(dbConnString);
-		//			connPgsql.Open();
+        //public int StoreLargeObject(Stream largeObjectStream)
+        //{
+        //	return StoreLargeObject(m_storageType, m_dbConnStr, largeObjectStream);
+        //}
 
-		//			NpgsqlTransaction t = connPgsql.BeginTransaction();
-				
-		//			LargeObjectManager lbm = new LargeObjectManager(connPgsql);
+        //public int StoreLargeObject(StorageTypes storageType, string dbConnString, Stream largeObjectStream)
+        //{
+        //	try
+        //	{
+        //		if(storageType == StorageTypes.Postgresql)
+        //		{
+        //			NpgsqlConnection connPgsql = new NpgsqlConnection(dbConnString);
+        //			connPgsql.Open();
 
-		//			int noid = lbm.Create(LargeObjectManager.READWRITE);
-		//			LargeObject lo =  lbm.Open(noid, LargeObjectManager.READWRITE);
+        //			NpgsqlTransaction t = connPgsql.BeginTransaction();
 
-		//			long offset = 0;
+        //			LargeObjectManager lbm = new LargeObjectManager(connPgsql);
 
-		//			while(offset < largeObjectStream.Length)
-		//			{
-		//				long bytesToWrite = (largeObjectStream.Length - offset > 1024) ? 1024 : largeObjectStream.Length - offset;
-						
-		//				byte[] buf = new byte[bytesToWrite];
-		//				largeObjectStream.Read(buf, 0, (int)bytesToWrite);
+        //			int noid = lbm.Create(LargeObjectManager.READWRITE);
+        //			LargeObject lo =  lbm.Open(noid, LargeObjectManager.READWRITE);
 
-		//				lo.Write(buf);
-		//				offset += bytesToWrite;
-		//			}
+        //			long offset = 0;
 
-		//			lo.Close();
-		//			t.Commit();
-					
-		//			// If using the Npgsql pooling close the connection to place it back in the pool.
-		//			connPgsql.Close();
+        //			while(offset < largeObjectStream.Length)
+        //			{
+        //				long bytesToWrite = (largeObjectStream.Length - offset > 1024) ? 1024 : largeObjectStream.Length - offset;
 
-		//			return noid;
-		//		}
-		//		else
-		//		{
-		//			throw new ApplicationException("Not supported in StorageLayer.StoreLargeObject");
-		//		}
-		//	}
-		//	catch(Exception excp)
-		//	{
-		//		logger.Error("Exception StoreLargeObject. " + excp.Message);
-		//		throw excp;
-		//	}
-		//}
-	
-		//public byte[] GetLargeObject(int largeObjectId)
-		//{
-		//	return GetLargeObject(m_storageType, m_dbConnStr, largeObjectId);
-		//}
-	
-		//public byte[] GetLargeObject(StorageTypes storageType, string dbConnString, int largeObjectId)
-		//{
-		//	try
-		//	{
-		//		if(storageType == StorageTypes.Postgresql)
-		//		{
-		//			NpgsqlConnection connPgsql = new NpgsqlConnection(dbConnString);
-		//			connPgsql.Open();
+        //				byte[] buf = new byte[bytesToWrite];
+        //				largeObjectStream.Read(buf, 0, (int)bytesToWrite);
 
-		//			NpgsqlTransaction t = connPgsql.BeginTransaction();
+        //				lo.Write(buf);
+        //				offset += bytesToWrite;
+        //			}
 
-		//			LargeObjectManager lbm = new LargeObjectManager(connPgsql);
-		//			LargeObject lo =  lbm.Open(largeObjectId, LargeObjectManager.READWRITE);
-        
-		//			byte[] buffer = lo.Read(lo.Size());
+        //			lo.Close();
+        //			t.Commit();
 
-		//			lo.Close();
-		//			t.Commit();
+        //			// If using the Npgsql pooling close the connection to place it back in the pool.
+        //			connPgsql.Close();
 
-		//			// If using the Npgsql pooling close the connection to place it back in the pool.
-		//			connPgsql.Close();
+        //			return noid;
+        //		}
+        //		else
+        //		{
+        //			throw new ApplicationException("Not supported in StorageLayer.StoreLargeObject");
+        //		}
+        //	}
+        //	catch(Exception excp)
+        //	{
+        //		logger.Error("Exception StoreLargeObject. " + excp.Message);
+        //		throw excp;
+        //	}
+        //}
 
-		//			return buffer;
-		//		}
-		//		else
-		//		{
-		//			throw new ApplicationException("Not supported in StorageLayer.StoreLargeObject");
-		//		}
-		//	}
-		//	catch(Exception excp)
-		//	{
-		//		logger.Error("Exception StoreLargeObject. " + excp.Message);
-		//		throw excp;
-		//	}
-		//}
+        //public byte[] GetLargeObject(int largeObjectId)
+        //{
+        //	return GetLargeObject(m_storageType, m_dbConnStr, largeObjectId);
+        //}
 
+        //public byte[] GetLargeObject(StorageTypes storageType, string dbConnString, int largeObjectId)
+        //{
+        //	try
+        //	{
+        //		if(storageType == StorageTypes.Postgresql)
+        //		{
+        //			NpgsqlConnection connPgsql = new NpgsqlConnection(dbConnString);
+        //			connPgsql.Open();
+
+        //			NpgsqlTransaction t = connPgsql.BeginTransaction();
+
+        //			LargeObjectManager lbm = new LargeObjectManager(connPgsql);
+        //			LargeObject lo =  lbm.Open(largeObjectId, LargeObjectManager.READWRITE);
+
+        //			byte[] buffer = lo.Read(lo.Size());
+
+        //			lo.Close();
+        //			t.Commit();
+
+        //			// If using the Npgsql pooling close the connection to place it back in the pool.
+        //			connPgsql.Close();
+
+        //			return buffer;
+        //		}
+        //		else
+        //		{
+        //			throw new ApplicationException("Not supported in StorageLayer.StoreLargeObject");
+        //		}
+        //	}
+        //	catch(Exception excp)
+        //	{
+        //		logger.Error("Exception StoreLargeObject. " + excp.Message);
+        //		throw excp;
+        //	}
+        //}
+
+#if !NETSTANDARD2_0
         public void StoreByteA(string query, byte[] buffer)
         {
             QuerySecurityCheck(query);
@@ -342,6 +346,7 @@ namespace SIPSorcery.Persistence
                 throw excp;
             }
         }
+#endif
 
 		/// <summary>
 		/// Used to determine whethe Npgsql will treat a connection string as pooling or not.
@@ -416,77 +421,76 @@ namespace SIPSorcery.Persistence
         }
 
         public static IDbConnection GetDbConnection(StorageTypes storageType, string dbConnStr) {
+#if !NETSTANDARD2_0
             if (storageType == StorageTypes.Postgresql) {
                 return new NpgsqlConnection(dbConnStr);
             }
-            else if (storageType == StorageTypes.MySQL) {
+            if (storageType == StorageTypes.MySQL) {
                 return new MySqlConnection(dbConnStr);
             }
-            else if (storageType == StorageTypes.MSSQL)
+#endif
+            if (storageType == StorageTypes.MSSQL)
             {
                 return new SqlConnection(dbConnStr);
             }
-            else
-            {
-                throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbConnection.");
-            }
+            throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbConnection.");
         }
 
-        public static IDbCommand GetDbCommand(StorageTypes storageType, IDbConnection dbConn, string cmdText) {
+        public static IDbCommand GetDbCommand(StorageTypes storageType, IDbConnection dbConn, string cmdText)
+        {
+#if !NETSTANDARD2_0
             if (storageType == StorageTypes.Postgresql) {
                 return new NpgsqlCommand(cmdText, (NpgsqlConnection)dbConn);
             }
-            else if (storageType == StorageTypes.MySQL) {
+            if (storageType == StorageTypes.MySQL) {
                 return new MySqlCommand(cmdText, (MySqlConnection)dbConn);
             }
-            else if (storageType == StorageTypes.MSSQL)
+#endif
+            if (storageType == StorageTypes.MSSQL)
             {
                 return new SqlCommand(cmdText, (SqlConnection)dbConn);
             }
-            else
-            {
-                throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbConnection.");
-            }
+            throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbConnection.");
         }
 
-        private IDataAdapter GetDataAdapter(StorageTypes storageType, IDbConnection dbConn, string cmdText) {
+        private IDataAdapter GetDataAdapter(StorageTypes storageType, IDbConnection dbConn, string cmdText)
+        {
+#if !NETSTANDARD2_0
             if (storageType == StorageTypes.Postgresql) {
                 return new NpgsqlDataAdapter(cmdText, (NpgsqlConnection)dbConn);
             }
-            else if (storageType == StorageTypes.MySQL) {
+            if (storageType == StorageTypes.MySQL) {
                 return new MySqlDataAdapter(cmdText, (MySqlConnection)dbConn);
             }
-            else if (storageType == StorageTypes.MSSQL)
+#endif
+            if (storageType == StorageTypes.MSSQL)
             {
                 return new SqlDataAdapter(cmdText, (SqlConnection)dbConn);
             }
-            else
-            {
-                throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbConnection.");
-            }
+            throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbConnection.");
         }
 
-        public static IDataParameter GetDbParameter(StorageTypes storageType, string name, object value) {
+        public static IDataParameter GetDbParameter(StorageTypes storageType, string name, object value)
+        {
+#if !NETSTANDARD2_0
             if (storageType == StorageTypes.Postgresql) {
                 return new NpgsqlParameter(name, value);
             }
-            else if (storageType == StorageTypes.MySQL) {
+            if (storageType == StorageTypes.MySQL) {
                 return new MySqlParameter(name, value);
             }
-            else if (storageType == StorageTypes.MSSQL)
+#endif
+            if (storageType == StorageTypes.MSSQL)
             {
                 return new SqlParameter(name, value);
             }
-            else
-            {
-                throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbParameter.");
-            }
+            throw new ApplicationException("Storage type " + storageType + " is not supported by GetDbParameter.");
         }
 
 
-        #region Unit tests.
+#region Unit tests.
 		
-		#if UNITTEST
+#if UNITTEST
 
 		[TestFixture]
 		public class StorageLayerUnitTests
@@ -549,8 +553,8 @@ namespace SIPSorcery.Persistence
 
 		}
 
-		#endif
+#endif
 
-		#endregion
+#endregion
 	}
 }

--- a/sipsorcery-core/SIPSorcery.SIP.App.Standard/SIPSorcery.SIP.App.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.SIP.App.Standard/SIPSorcery.SIP.App.Standard.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <AssemblyName>SIPSorcery.SIP.App</AssemblyName>
+    <RootNamespace>SIPSorcery.SIP.App</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Shims/Shims.csproj" />
+    <ProjectReference Include="../SIPSorcery.Net.Standard/SIPSorcery.Net.Standard.csproj" />
+    <ProjectReference Include="../SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj" />
+    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SIPSorcery.SIP.App/**/*.cs" Exclude="../SIPSorcery.SIP.App/obj/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="../SIPSorcery.SIP.App/SilverlightPolicyServer.cs" />
+    <Compile Remove="../SIPSorcery.SIP.App/SIPCallDispatcherFile.cs" />
+    <Compile Remove="../SIPSorcery.SIP.App/SIPDNS/SIPDNSLookupResult.cs" />
+    <Compile Remove="../SIPSorcery.SIP.App/SIPUserAgents/JingleUserAgent.cs" />
+  </ItemGroup>
+
+</Project>

--- a/sipsorcery-core/SIPSorcery.SIP.App.Standard/SIPSorcery.SIP.App.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.SIP.App.Standard/SIPSorcery.SIP.App.Standard.csproj
@@ -8,14 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../Shims/Shims.csproj" />
     <ProjectReference Include="../SIPSorcery.Net.Standard/SIPSorcery.Net.Standard.csproj" />
     <ProjectReference Include="../SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj" />
-    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +22,8 @@
     <Compile Remove="../SIPSorcery.SIP.App/SIPCallDispatcherFile.cs" />
     <Compile Remove="../SIPSorcery.SIP.App/SIPDNS/SIPDNSLookupResult.cs" />
     <Compile Remove="../SIPSorcery.SIP.App/SIPUserAgents/JingleUserAgent.cs" />
+    <!-- Files below ARE included in the corresponding .NET Framework project! -->
+    <Compile Remove="../SIPSorcery.SIP.App/Monitoring/ISIPMonitorPublisher.cs" />
   </ItemGroup>
 
 </Project>

--- a/sipsorcery-core/SIPSorcery.SIP.App/AssemblyInfo.cs
+++ b/sipsorcery-core/SIPSorcery.SIP.App/AssemblyInfo.cs
@@ -30,5 +30,9 @@ using System.Reflection;
 [assembly: AssemblyTitle("SIPSorcery.SIP.App")]
 [assembly: AssemblyCompany("SIP Sorcery PTY LTD")]
 [assembly: AssemblyDescription("Application layer classes that provide common use casses for SIP protocol.")]
-[assembly: AssemblyCopyright("Aaron Clauson")]		
+[assembly: AssemblyCopyright("Aaron Clauson")]
+#if NETSTANDARD2_0
+[assembly: AssemblyVersion("1.5.6")]
+#else
 [assembly: AssemblyVersion("1.5.6.*")]
+#endif

--- a/sipsorcery-core/SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
   </ItemGroup>
 

--- a/sipsorcery-core/SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.SIP.Core.Standard/SIPSorcery.SIP.Core.Standard.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <AssemblyName>SIPSorcery.SIP.Core</AssemblyName>
+    <RootNamespace>SIPSorcery.SIP</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SIPSorcery.SIP.Core/**/*.cs" Exclude="../SIPSorcery.SIP.Core/obj/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="../SIPSorcery.SIP.Core/SIP\SIPTransportConcurrent.cs" />
+  </ItemGroup>
+
+</Project>

--- a/sipsorcery-core/SIPSorcery.SIP.Core/AssemblyInfo.cs
+++ b/sipsorcery-core/SIPSorcery.SIP.Core/AssemblyInfo.cs
@@ -31,4 +31,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("Implementation of SIP protocol.")]
 [assembly: AssemblyCompany("SIP Sorcery PTY LTD")]
 [assembly: AssemblyCopyright("Aaron Clauson")]
+#if NETSTANDARD2_0
+[assembly: AssemblyVersion("1.5.6")]
+#else
 [assembly: AssemblyVersion("1.5.6.*")]
+#endif

--- a/sipsorcery-core/SIPSorcery.SIP.Core/SIP/SIPTransport.cs
+++ b/sipsorcery-core/SIPSorcery.SIP.Core/SIP/SIPTransport.cs
@@ -1221,7 +1221,7 @@ namespace SIPSorcery.SIP
                         {
                             STUNRequestReceived(sipChannel.SIPChannelEndPoint.GetIPEndPoint(), remoteEndPoint.GetIPEndPoint(), buffer, buffer.Length);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                             if (PerformanceMonitorPrefix != null)
                             {
                                 SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_STUN_REQUESTS_PER_SECOND_SUFFIX);
@@ -1239,7 +1239,7 @@ namespace SIPSorcery.SIP
                             SIPResponse tooLargeResponse = GetResponse(sipChannel.SIPChannelEndPoint, remoteEndPoint, SIPResponseStatusCodesEnum.MessageTooLarge, null);
                             SendResponse(tooLargeResponse);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                             if (PerformanceMonitorPrefix != null)
                             {
                                 SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_BAD_MESSAGES_PER_SECOND_SUFFIX);
@@ -1254,7 +1254,7 @@ namespace SIPSorcery.SIP
                                 // An emptry transmission has been received. More than likely this is a NAT keep alive and can be disregarded.
                                 //FireSIPBadRequestInTraceEvent(sipChannel.SIPChannelEndPoint, remoteEndPoint, "No printable characters, length " + buffer.Length + " bytes.", SIPValidationFieldsEnum.Unknown, null);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                                 if (PerformanceMonitorPrefix != null)
                                 {
                                     // SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_BAD_MESSAGES_PER_SECOND_SUFFIX);
@@ -1267,7 +1267,7 @@ namespace SIPSorcery.SIP
                             {
                                 FireSIPBadRequestInTraceEvent(sipChannel.SIPChannelEndPoint, remoteEndPoint, "Missing SIP string.", SIPValidationFieldsEnum.NoSIPString, rawSIPMessage);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                                 if (PerformanceMonitorPrefix != null)
                                 {
                                     SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_BAD_MESSAGES_PER_SECOND_SUFFIX);
@@ -1287,7 +1287,7 @@ namespace SIPSorcery.SIP
 
                                     try
                                     {
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                                         if (PerformanceMonitorPrefix != null)
                                         {
                                             SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_RESPONSES_PER_SECOND_SUFFIX);
@@ -1337,7 +1337,7 @@ namespace SIPSorcery.SIP
                                 {
                                     #region SIP Request.
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                                     if (PerformanceMonitorPrefix != null)
                                     {
                                         SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_REQUESTS_PER_SECOND_SUFFIX);
@@ -1454,7 +1454,7 @@ namespace SIPSorcery.SIP
                             {
                                 FireSIPBadRequestInTraceEvent(sipChannel.SIPChannelEndPoint, remoteEndPoint, "Not parseable as SIP message.", SIPValidationFieldsEnum.Unknown, rawSIPMessage);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                                 if (PerformanceMonitorPrefix != null)
                                 {
                                     SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_BAD_MESSAGES_PER_SECOND_SUFFIX);
@@ -1469,7 +1469,7 @@ namespace SIPSorcery.SIP
             {
                 FireSIPBadRequestInTraceEvent(sipChannel.SIPChannelEndPoint, remoteEndPoint, "Exception SIPTransport. " + excp.Message, SIPValidationFieldsEnum.Unknown, rawSIPMessage);
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
                 if (PerformanceMonitorPrefix != null)
                 {
                     SIPSorceryPerformanceMonitor.IncrementCounter(PerformanceMonitorPrefix + SIPSorceryPerformanceMonitor.SIP_TRANSPORT_SIP_BAD_MESSAGES_PER_SECOND_SUFFIX);

--- a/sipsorcery-core/SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj
@@ -10,8 +10,6 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0-preview1-25914-04" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,9 +21,11 @@
     <Compile Remove="../SIPSorcery.Sys/Crypto.cs" />
     <Compile Remove="../SIPSorcery.Sys/Crypto/RandomNumberProxy.cs" />
     <Compile Remove="../SIPSorcery.Sys/Net/DNSResolver.cs" />
-	<!-- Files below ARE included in the corresponding .NET Framework project! -->
+    <!-- Files below ARE included in the corresponding .NET Framework project! -->
     <Compile Remove="../SIPSorcery.Sys/Auth/ServiceAuthToken.cs" />
+    <Compile Remove="../SIPSorcery.Sys/Auth/SIPSorcerySecurityHeader.cs" />
     <Compile Remove="../SIPSorcery.Sys/WCFUtility.cs" />
+    <Compile Remove="../SIPSorcery.Sys/SIPSorceryPerformanceMonitor.cs" />
     <Compile Remove="../SIPSorcery.Sys/WrapperImpersonationContext.cs" />
   </ItemGroup>
 

--- a/sipsorcery-core/SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj
+++ b/sipsorcery-core/SIPSorcery.Sys.Standard/SIPSorcery.Sys.Standard.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+	<GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+	<AssemblyName>SIPSorcery.Sys</AssemblyName>
+	<RootNamespace>SIPSorcery.Sys</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0-preview1-25914-04" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SIPSorcery.Sys/**/*.cs" Exclude="../SIPSorcery.Sys/obj/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="../SIPSorcery.Sys/AuditLog.cs" />
+    <Compile Remove="../SIPSorcery.Sys/Crypto.cs" />
+    <Compile Remove="../SIPSorcery.Sys/Crypto/RandomNumberProxy.cs" />
+    <Compile Remove="../SIPSorcery.Sys/Net/DNSResolver.cs" />
+	<!-- Files below ARE included in the corresponding .NET Framework project! -->
+    <Compile Remove="../SIPSorcery.Sys/Auth/ServiceAuthToken.cs" />
+    <Compile Remove="../SIPSorcery.Sys/WCFUtility.cs" />
+    <Compile Remove="../SIPSorcery.Sys/WrapperImpersonationContext.cs" />
+  </ItemGroup>
+
+</Project>

--- a/sipsorcery-core/SIPSorcery.Sys/AppState.cs
+++ b/sipsorcery-core/SIPSorcery.Sys/AppState.cs
@@ -26,11 +26,16 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using log4net;
+using log4net.Repository;
 
 namespace SIPSorcery.Sys
 {
     public class AppState : IConfigurationSectionHandler
     {
+#if NETSTANDARD2_0
+        public static readonly ILoggerRepository LoggerRepository = LogManager.GetRepository(System.Reflection.Assembly.GetEntryAssembly());
+#endif
+
         public const string CRLF = "\r\n";
         public const string DEFAULT_ERRRORLOG_FILE = @"c:\temp\appstate.error.log";
         public const string ENCRYPTED_SETTING_PREFIX = "$#";
@@ -55,7 +60,11 @@ namespace SIPSorcery.Sys
                 {
                     // Initialise logging functionality from an XML node in the app.config file.
                     Console.WriteLine("Starting logging initialisation.");
+#if NETSTANDARD2_0
+                    log4net.Config.XmlConfigurator.Configure(LoggerRepository, new FileInfo("log4net.config"));
+#else
                     log4net.Config.XmlConfigurator.Configure();
+#endif
                 }
                 catch
                 {
@@ -79,7 +88,11 @@ namespace SIPSorcery.Sys
                 {
                     try
                     {
+#if NETSTANDARD2_0
+                        logger = log4net.LogManager.GetLogger(LoggerRepository.Name, APP_LOGGING_ID);
+#else
                         logger = log4net.LogManager.GetLogger(APP_LOGGING_ID);
+#endif
                         logger.Debug("Logging initialised.");
                     }
                     catch (Exception excp)
@@ -105,7 +118,11 @@ namespace SIPSorcery.Sys
 
         public static ILog GetLogger(string logName)
         {
+#if NETSTANDARD2_0
+            return log4net.LogManager.GetLogger(LoggerRepository.Name, logName);
+#else
             return log4net.LogManager.GetLogger(logName);
+#endif
         }
 
         /// <summary>
@@ -120,7 +137,11 @@ namespace SIPSorcery.Sys
             log4net.Layout.ILayout fallbackLayout = new log4net.Layout.PatternLayout("%m%n");
             appender.Layout = fallbackLayout;
 
+#if NETSTANDARD2_0
+            log4net.Config.BasicConfigurator.Configure(LoggerRepository, appender);
+#else
             log4net.Config.BasicConfigurator.Configure(appender);
+#endif
         }
 
         /// <summary>

--- a/sipsorcery-core/SIPSorcery.Sys/AppState.cs
+++ b/sipsorcery-core/SIPSorcery.Sys/AppState.cs
@@ -33,9 +33,8 @@ namespace SIPSorcery.Sys
     public class AppState : IConfigurationSectionHandler
     {
 #if NETSTANDARD2_0
-        public static readonly ILoggerRepository LoggerRepository = LogManager.GetRepository(System.Reflection.Assembly.GetEntryAssembly());
+        public static readonly ILoggerRepository LoggerRepository;
 #endif
-
         public const string CRLF = "\r\n";
         public const string DEFAULT_ERRRORLOG_FILE = @"c:\temp\appstate.error.log";
         public const string ENCRYPTED_SETTING_PREFIX = "$#";
@@ -61,6 +60,10 @@ namespace SIPSorcery.Sys
                     // Initialise logging functionality from an XML node in the app.config file.
                     Console.WriteLine("Starting logging initialisation.");
 #if NETSTANDARD2_0
+                    var assembly = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetExecutingAssembly();
+                    LoggerRepository = LogManager.GetRepository(assembly);
+                    if (LoggerRepository == null) LoggerRepository = LogManager.CreateRepository("SIPSorcery.Sys.AppState");
+
                     log4net.Config.XmlConfigurator.Configure(LoggerRepository, new FileInfo("log4net.config"));
 #else
                     log4net.Config.XmlConfigurator.Configure();

--- a/sipsorcery-core/SIPSorcery.Sys/AssemblyInfo.cs
+++ b/sipsorcery-core/SIPSorcery.Sys/AssemblyInfo.cs
@@ -3,5 +3,9 @@ using System.Reflection;
 [assembly: AssemblyTitle("SIPSorcery.Sys")]
 [assembly: AssemblyDescription("Handles application configuration and state. Provides utility functions.")]
 [assembly: AssemblyCompany("SIP Sorcery PTY LTD")]
-[assembly: AssemblyCopyright("Aaron Clauson")]	
+[assembly: AssemblyCopyright("Aaron Clauson")]
+#if NETSTANDARD2_0
+[assembly: AssemblyVersion("1.5.6")]
+#else
 [assembly: AssemblyVersion("1.5.6.*")]
+#endif

--- a/sipsorcery-core/SIPSorcery.Sys/Net/FreePort.cs
+++ b/sipsorcery-core/SIPSorcery.Sys/Net/FreePort.cs
@@ -32,8 +32,20 @@ namespace SIPSorcery.Sys.Net
             int port = startPort;
             bool isAvailable = true;
 
+#if NETSTANDARD2_0
+            Mutex mutex;
+            try
+            {
+                mutex = new Mutex(false, string.Concat("Global/", PortReleaseGuid));
+            }
+            catch (NotSupportedException)
+            {
+                mutex = new Mutex(false);
+            }
+#else
             var mutex = new Mutex(false,
                 string.Concat("Global/", PortReleaseGuid));
+#endif
             mutex.WaitOne();
             try
             {
@@ -81,8 +93,20 @@ namespace SIPSorcery.Sys.Net
             int port = startPort;
             bool isAvailable = true;
 
+#if NETSTANDARD2_0
+            Mutex mutex;
+            try
+            {
+                mutex = new Mutex(false, string.Concat("Global/", PortReleaseGuid));
+            }
+            catch (NotSupportedException)
+            {
+                mutex = new Mutex(false);
+            }
+#else
             var mutex = new Mutex(false,
                 string.Concat("Global/", PortReleaseGuid));
+#endif
             mutex.WaitOne();
             try
             {

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/AttributeMappingSource.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/AttributeMappingSource.cs
@@ -1,0 +1,13 @@
+namespace System.Data.Linq.Mapping
+{
+    /// <summary>
+    /// Mock class. Usage of class in executed code will result in exception!
+    /// </summary>
+    public sealed class AttributeMappingSource : MappingSource
+    {
+        protected override MetaModel CreateModel(Type dataContextType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/AutoSync.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/AutoSync.cs
@@ -1,0 +1,41 @@
+//
+// AutoSync.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace System.Data.Linq.Mapping
+{
+    public enum AutoSync
+    {
+        Default,
+        Always,
+        Never,
+        OnInsert,
+        OnUpdate
+    }
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/ColumnAttribute.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/ColumnAttribute.cs
@@ -1,0 +1,52 @@
+//
+// ColumnAttribute.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+
+namespace System.Data.Linq.Mapping
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class ColumnAttribute : DataAttribute
+    {
+        public ColumnAttribute()
+        {
+            CanBeNull = true;
+        }
+
+        public AutoSync AutoSync { get; set; }
+        public bool CanBeNull { get; set; }
+        public string DbType { get; set; }
+        public string Expression { get; set; }
+        public bool IsDbGenerated { get; set; }
+        public bool IsDiscriminator { get; set; }
+        public bool IsPrimaryKey { get; set; }
+        public bool IsVersion { get; set; }
+        public UpdateCheck UpdateCheck { get; set; }
+    }
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/DataAttribute.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/DataAttribute.cs
@@ -1,0 +1,39 @@
+//
+// DataAttribute.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+
+namespace System.Data.Linq.Mapping
+{
+    public abstract class DataAttribute : Attribute
+    {
+        public string Name { get; set; }
+        public string Storage { get; set; }
+    }
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MappingSource.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MappingSource.cs
@@ -1,0 +1,56 @@
+//
+// MappingSource.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MappingSource
+	{
+		Dictionary<Type, MetaModel> sources = new Dictionary<Type, MetaModel> ();
+
+		protected abstract MetaModel CreateModel (Type dataContextType);
+
+		public MetaModel GetModel (Type dataContextType)
+		{
+			MetaModel m;
+			if (!sources.TryGetValue (dataContextType, out m)) {
+				m = CreateModel (dataContextType);
+				sources [dataContextType] = m;
+			}
+			return m;
+		}
+
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaAccessor.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaAccessor.cs
@@ -1,0 +1,57 @@
+//
+// MetaAccessor.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaAccessor
+	{
+		public abstract Type Type { get; }
+
+		public abstract object GetBoxedValue (object instance);
+
+		public virtual bool HasAssignedValue (object instance)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual bool HasLoadedValue (object instance)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual bool HasValue (object instance)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public abstract void SetBoxedValue (ref object instance, object value);
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaAssociation.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaAssociation.cs
@@ -1,0 +1,51 @@
+//
+// MetaAssociation.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.ObjectModel;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaAssociation
+	{
+		public abstract bool DeleteOnNull { get; }
+		public abstract string DeleteRule { get; }
+		public abstract bool IsForeignKey { get; }
+		public abstract bool IsMany { get; }
+		public abstract bool IsNullable { get; }
+		public abstract bool IsUnique { get; }
+		public abstract ReadOnlyCollection<MetaDataMember> OtherKey { get; }
+		public abstract bool OtherKeyIsPrimaryKey { get; }
+		public abstract MetaDataMember OtherMember { get; }
+		public abstract MetaType OtherType { get; }
+		public abstract ReadOnlyCollection<MetaDataMember> ThisKey { get; }
+		public abstract bool ThisKeyIsPrimaryKey { get; }
+		public abstract MetaDataMember ThisMember { get; }
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaDataMember.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaDataMember.cs
@@ -1,0 +1,66 @@
+//
+// MetaDataMember.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaDataMember
+	{
+		public abstract MetaAssociation Association { get; }
+		public abstract AutoSync AutoSync { get; }
+		public abstract bool CanBeNull { get; }
+		public abstract string DbType { get; }
+		public abstract MetaType DeclaringType { get; }
+		public abstract MetaAccessor DeferredSourceAccessor { get; }
+		public abstract MetaAccessor DeferredValueAccessor { get; }
+		public abstract string Expression { get; }
+		public abstract bool IsAssociation { get; }
+		public abstract bool IsDbGenerated { get; }
+		public abstract bool IsDeferred { get; }
+		public abstract bool IsDiscriminator { get; }
+		public abstract bool IsPersistent { get; }
+		public abstract bool IsPrimaryKey { get; }
+		public abstract bool IsVersion { get; }
+		public abstract MethodInfo LoadMethod { get; }
+		public abstract string MappedName { get; }
+		public abstract MemberInfo Member { get; }
+		public abstract MetaAccessor MemberAccessor { get; }
+		public abstract string Name { get; }
+		public abstract int Ordinal { get; }
+		public abstract MetaAccessor StorageAccessor { get; }
+		public abstract MemberInfo StorageMember { get; }
+		public abstract Type Type { get; }
+		public abstract UpdateCheck UpdateCheck { get; }
+
+		public abstract bool IsDeclaredBy (MetaType type);
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaFunction.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaFunction.cs
@@ -1,0 +1,48 @@
+//
+// MetaFunction.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaFunction
+	{
+		public abstract bool HasMultipleResults { get; }
+		public abstract bool IsComposable { get; }
+		public abstract string MappedName { get; }
+		public abstract MethodInfo Method { get; }
+		public abstract MetaModel Model { get; }
+		public abstract string Name { get; }
+		public abstract ReadOnlyCollection<MetaParameter> Parameters { get; }
+		public abstract ReadOnlyCollection<MetaType> ResultRowTypes { get; }
+		public abstract MetaParameter ReturnParameter { get; }
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaModel.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaModel.cs
@@ -1,0 +1,49 @@
+//
+// MetaModel.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaModel
+	{
+		public abstract Type ContextType { get; }
+		public abstract string DatabaseName { get; }
+		public abstract MappingSource MappingSource { get; }
+		public abstract Type ProviderType { get; }
+
+		public abstract MetaFunction GetFunction (MethodInfo method);
+		public abstract IEnumerable<MetaFunction> GetFunctions ();
+		public abstract MetaType GetMetaType (Type type);
+		public abstract MetaTable GetTable (Type rowType);
+		public abstract IEnumerable<MetaTable> GetTables ();
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaParameter.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaParameter.cs
@@ -1,0 +1,44 @@
+//
+// MetaParameter.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaParameter
+	{
+		public abstract string DbType { get; }
+		public abstract string MappedName { get; }
+		public abstract string Name { get; }
+		public abstract ParameterInfo Parameter { get; }
+		public abstract Type ParameterType { get; }
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaTable.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaTable.cs
@@ -1,0 +1,45 @@
+//
+// MetaTable.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaTable
+	{
+		public abstract MethodInfo DeleteMethod { get; }
+		public abstract MethodInfo InsertMethod { get; }
+		public abstract MetaModel Model { get; }
+		public abstract MetaType RowType { get; }
+		public abstract string TableName { get; }
+		public abstract MethodInfo UpdateMethod { get; }
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/MetaType.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/MetaType.cs
@@ -1,0 +1,71 @@
+//
+// MetaType.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace System.Data.Linq.Mapping
+{
+	public abstract class MetaType
+	{
+		public abstract ReadOnlyCollection<MetaAssociation> Associations { get; }
+		public abstract bool CanInstantiate { get; }
+		public abstract ReadOnlyCollection<MetaDataMember> DataMembers { get; }
+		public abstract MetaDataMember DBGeneratedIdentityMember { get; }
+		public abstract ReadOnlyCollection<MetaType> DerivedTypes { get; }
+		public abstract MetaDataMember Discriminator { get; }
+		public abstract bool HasAnyLoadMethod { get; }
+		public abstract bool HasAnyValidateMethod { get; }
+		public abstract bool HasInheritance { get; }
+		public abstract bool HasInheritanceCode { get; }
+		public abstract bool HasUpdateCheck { get; }
+		public abstract ReadOnlyCollection<MetaDataMember> IdentityMembers { get; }
+		public abstract MetaType InheritanceBase { get; }
+		public abstract object InheritanceCode { get; }
+		public abstract MetaType InheritanceDefault { get; }
+		public abstract MetaType InheritanceRoot { get; }
+		public abstract ReadOnlyCollection<MetaType> InheritanceTypes { get; }
+		public abstract bool IsEntity { get; }
+		public abstract bool IsInheritanceDefault { get; }
+		public abstract MetaModel Model { get; }
+		public abstract string Name { get; }
+		public abstract MethodInfo OnLoadedMethod { get; }
+		public abstract MethodInfo OnValidateMethod { get; }
+		public abstract ReadOnlyCollection<MetaDataMember> PersistentDataMembers { get; }
+		public abstract MetaTable Table { get; }
+		public abstract Type Type { get; }
+		public abstract MetaDataMember VersionMember { get; }
+
+		public abstract MetaDataMember GetDataMember (MemberInfo member);
+		public abstract MetaType GetInheritanceType (Type type);
+		public abstract MetaType GetTypeForInheritanceCode (object code);
+	}
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/TableAttribute.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/TableAttribute.cs
@@ -1,0 +1,39 @@
+//
+// TableAttribute.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+
+namespace System.Data.Linq.Mapping
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class TableAttribute : Attribute
+    {
+        public string Name { get; set; }
+    }
+}

--- a/sipsorcery-core/Shims/Data/Linq/Mapping/UpdateCheck.cs
+++ b/sipsorcery-core/Shims/Data/Linq/Mapping/UpdateCheck.cs
@@ -1,0 +1,39 @@
+//
+// UpdateCheck.cs
+//
+// Author:
+//   Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc.
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace System.Data.Linq.Mapping
+{
+    public enum UpdateCheck
+    {
+        Always,
+        Never,
+        WhenChanged
+    }
+}

--- a/sipsorcery-core/Shims/Shims.csproj
+++ b/sipsorcery-core/Shims/Shims.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>System</RootNamespace>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
For my upcoming Xamarin Forms project, I have examined the possibility of building some of the core class libraries targeting .NET Standard (2.0).

The libraries I have been able to successfully build so far are these:

* SIPSorcery.Sys
* SIPSorcery.Net
* SIPSorcery.SIP.Core
* SIPSorcery.SIP.App
* SIPSorcery.Persistence
* SIPSorcery.CRM

I have been forced to make a few changes and shortcuts.

#### System.Data.Linq
This assembly is currently not supported in .NET Standard, and I have therefore copied required classes from the *Mono* codebase and placed in a separate class library denoted *Shims*. Current limitation is that the class `AttributeMappingSource`, which is used in the *Persistence* library, does not come with a valid implementation.

#### Log4Net
Logger repository needs to be explicitly selected e.g. when calling `GetLogger`. It is set to the `GetEntryAssembly()` repository in `AppState`.

#### AssemblyInfo
.NET Standard does not support assembly version wildcards.

#### Sys
The following types from the corresponding .NET Framework project are **not** included:
* SIPSorceryPerformanceMonitor
* ServiceAuthToken
* SIPSorcerySecurityHeader
* WCFUtility
* WrapperImpersonationContext

#### SIP.App
The following (server directed?) interface from the corresponding .NET Framework project is **not** included:
* ISIPMonitorPublisher

#### Net
Excluded asynchronous IP host entry get methods in `DNS/Resolver`.

#### Persistence
Excluded MYSQL and Postgres support in `StorageLayer` and `SIPAssetPersistorFactory`. Re-enabled (potentially working?) support for generating `SQLAssetPersistor` for SQL Client in `SIPAssetPersistorFactory`.

I have still too little experience with SIP signalling and *SIPSorcery* to sufficiently judge how big of an impact these limitations will have, so please do not hesitate to give your feedback regarding this porting attempt.