### PR TITLE
Added net452 target to TargetFrameworks list for wider compatibility

### DIFF
--- a/sipsorcery-core/SIPSorcery/SIPSorcery.csproj
+++ b/sipsorcery-core/SIPSorcery/SIPSorcery.csproj
@@ -5,11 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-  <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+  <TargetFrameworks>netstandard2.0;net452;net472</TargetFrameworks>
 	<Version>3.0.1.0</Version>
 	<Authors>Aaron Clauson</Authors>
 	<Copyright>Copyright © 2010-2019 Aaron Clauson</Copyright>

--- a/sipsorcery-core/SIPSorcery/SIPSorcery.csproj
+++ b/sipsorcery-core/SIPSorcery/SIPSorcery.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-  <TargetFrameworks>netstandard2.0;net452;net472</TargetFrameworks>
+  <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
 	<Version>3.0.1.0</Version>
 	<Authors>Aaron Clauson</Authors>
 	<Copyright>Copyright © 2010-2019 Aaron Clauson</Copyright>

--- a/sipsorcery-core/Tests/SIPSorcery.UnitTests/SIPSorcery.UnitTests.csproj
+++ b/sipsorcery-core/Tests/SIPSorcery.UnitTests/SIPSorcery.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This allows to reference `SIPSorcery` assembly in projects which are targeted .NET 4.5.2.

Also changed `SIPSorcery.UnitTests` project `TargetFramework` property to `netcoreapp2.0` to support this project in Visual Studio 2017 without additional SDKs.
