### PR TITLE
Several fixes for sipsorcery-softphonev2 example application

### DIFF
--- a/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/App.config
+++ b/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <configSections>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net"/>
-    <section name="sipsoftphone" type="SIPSorcery.Sys.AppState, SIPSorcery.Sys"/>
+    <section name="sipsoftphone" type="SIPSorcery.Sys.AppState, sipsorcery-softphone"/>
   </configSections>
   <log4net>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">

--- a/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/SIPSorcery.SoftPhone.csproj
+++ b/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/SIPSorcery.SoftPhone.csproj
@@ -90,8 +90,8 @@
     <Reference Include="NAudio, Version=1.8.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
     </Reference>
-    <Reference Include="SIPSorcery, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIPSorcery.3.0.0\lib\netstandard2.0\SIPSorcery.dll</HintPath>
+    <Reference Include="SIPSorcery, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SIPSorcery.3.0.1\lib\net472\SIPSorcery.dll</HintPath>
     </Reference>
     <Reference Include="SIPSorceryMedia, Version=2.0.0.33779, Culture=neutral, processorArchitecture=x86">
       <HintPath>..\packages\SIPSorceryMedia.2.0.0\lib\net47\SIPSorceryMedia.dll</HintPath>

--- a/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/Signalling/SIPClient.cs
+++ b/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/Signalling/SIPClient.cs
@@ -319,8 +319,15 @@ namespace SIPSorcery.SoftPhone
         {
             if (m_uac != null && m_uac.SIPDialogue != null)
             {
+                // It was outgoing call.
                 m_uac.SIPDialogue.Hangup(m_sipTransport, null);
             }
+            else if (m_uas != null && m_uas.SIPDialogue != null)
+            {
+                // It was incoming call.
+                m_uas.SIPDialogue.Hangup(m_sipTransport, null);
+            }
+
             CallFinished();
         }
 

--- a/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/packages.config
+++ b/examples/sipsorcery-softphonev2/SIPSorcery.SoftPhone/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="NAudio" version="1.8.4" targetFramework="net47" />
-  <package id="SIPSorcery" version="3.0.0" targetFramework="net472" />
+  <package id="SIPSorcery" version="3.0.1" targetFramework="net472" />
   <package id="SIPSorceryMedia" version="2.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.PerformanceCounter" version="4.5.0" targetFramework="net472" />
   <package id="System.ServiceModel.Primitives" version="4.5.3" targetFramework="net472" />


### PR DESCRIPTION
* Fixed `App.config` assembly name in `section` attribute (for `SIPSorcery.Sys.AppState` type)
* Proper closing of established incoming SIP call (should fix https://github.com/sipsorcery/sipsorcery/issues/77)
* Updated nuget package [SIPSorcery](https://www.nuget.org/packages/SIPSorcery/) to latest version 3.0.1