### PR TITLE
Fixed exception with mutex in FindNextAvailableUDPPort

### DIFF
--- a/src/sys/Net/FreePort.cs
+++ b/src/sys/Net/FreePort.cs
@@ -82,7 +82,7 @@ namespace SIPSorcery.Sys
             bool isAvailable = true;
 
             var mutex = new Mutex(false,
-                string.Concat("Global/", PortReleaseGuid));
+                string.Concat("Global\\", PortReleaseGuid));
             mutex.WaitOne();
             try
             {


### PR DESCRIPTION
This fixes exception with global mutex on OSX.

`Exception has occurred: CLR/System.IO.IOException
An unhandled exception of type 'System.IO.IOException' occurred in System.Private.CoreLib.dll: 'The filename, directory name, or volume label syntax is incorrect. : 'Global/8875BD8E-4D5B-11DE-B2F4-691756D89593''
   at System.Threading.Mutex.CreateMutexCore(Boolean initiallyOwned, String name, Boolean& createdNew)
   at System.Threading.Mutex..ctor(Boolean initiallyOwned, String name)
   at SIPSorcery.Sys.FreePort.FindNextAvailableUDPPort(Int32 startPort) in /Users/dtarasov/Documents/projects/graphone/sipsorcery/src/sys/Net/FreePort.cs:line 84
   .............`