### PR TITLE
Sipudpchannel close fix

### DIFF
--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -202,13 +202,6 @@ namespace SIPSorcery.SIP.App
 
                     m_exit = true;
                     m_waitForRegistrationMRE.Set();
-
-                    if (m_isRegistered)
-                    {
-                        m_attempts = 0;
-                        m_expiry = 0;
-                        ThreadPool.QueueUserWorkItem(delegate { SendInitialRegister(); });
-                    }
                 }
             }
             catch (Exception excp)

--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -202,6 +202,13 @@ namespace SIPSorcery.SIP.App
 
                     m_exit = true;
                     m_waitForRegistrationMRE.Set();
+
+                    if (m_isRegistered)
+                    {
+                        m_attempts = 0;
+                        m_expiry = 0;
+                        ThreadPool.QueueUserWorkItem(delegate { SendInitialRegister(); });
+                    }
                 }
             }
             catch (Exception excp)

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -73,7 +73,7 @@ namespace SIPSorcery.SIP
                 try
                 {
                     var receiveResult = await m_sipConn.ReceiveAsync();
-                    if (receiveResult.Buffer != null && receiveResult.Buffer.Length > 0)
+                    if (receiveResult.Buffer?.Length > 0)
                     {
                         SIPMessageReceived?.Invoke(this, new SIPEndPoint(SIPProtocolsEnum.udp, receiveResult.RemoteEndPoint), receiveResult.Buffer);
                     }


### PR DESCRIPTION
There is a problem in SIPUDPChannel closing. When you create SIPUDPChannel it starts a new thread to listen for incoming packets with `buffer = m_sipConn.Receive()` Then when you want to stop channel you call `SIPUDPChannel.Close()` with `m_sipConn.Close()` inside it from another thread. You think that it should interrupt `m_sipConn.Receive()` but it will not. It will stuck on `m_sipConn.Close()` until `m_sipConn.Receive()` returns.

To see this problem in action you can make a little change in UserAgentRegister example. Just change code in the end of `Main()` on
`
            // Start the thread to perform the initial registration and then periodically resend it.
            regUserAgent.Start();

            taskCompleteMre.WaitOne();

            Thread.Sleep(2000); // <- This is the interesting part

            regUserAgent.Stop();
            if (sipTransport != null)
            {
                SIPSorcery.Sys.Log.Logger.LogInformation("Shutting down SIP transport...");
                sipTransport.Shutdown();
            }
            SIPSorcery.Net.DNSManager.Stop();
`

After all registrations it will stuck in `sipTransport.Shutdown()`

As bonus I removed hack from SIPRegistrationUserAgent that triggered SIPUDPSocket to exit from Receive call.