### PR TITLE
Adds a new channel for outbound web socket connections

### DIFF
--- a/examples/AllExamples.sln
+++ b/examples/AllExamples.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CallHoldAndTransfer", "Call
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AttendedTransfer", "AttendedTransfer\AttendedTransfer.csproj", "{3DF64A03-A03F-4875-8364-3CEBD158F866}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery", "..\src\SIPSorcery.csproj", "{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,14 @@ Global
 		{3DF64A03-A03F-4875-8364-3CEBD158F866}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3DF64A03-A03F-4875-8364-3CEBD158F866}.Release|x64.ActiveCfg = Release|Any CPU
 		{3DF64A03-A03F-4875-8364-3CEBD158F866}.Release|x64.Build.0 = Release|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Debug|x64.Build.0 = Debug|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Release|Any CPU.Build.0 = Release|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Release|x64.ActiveCfg = Release|Any CPU
+		{783237BA-A4B7-4F7A-9B8F-F25DC42E2569}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/UserAgentClient/Program.cs
+++ b/examples/UserAgentClient/Program.cs
@@ -65,8 +65,8 @@ namespace SIPSorcery
 
             // Set up a default SIP transport.
             var sipTransport = new SIPTransport();
-            sipTransport.AddSIPChannel(new SIPUDPChannel(new IPEndPoint(IPAddress.Any, 0)));
-            sipTransport.AddSIPChannel(new SIPClientWebSocketChannel(true));
+            //sipTransport.AddSIPChannel(new SIPUDPChannel(new IPEndPoint(IPAddress.Any, 0)));
+            //sipTransport.AddSIPChannel(new SIPClientWebSocketChannel());
 
             EnableTraceLogs(sipTransport);
 

--- a/examples/UserAgentClient/Properties/launchSettings.json
+++ b/examples/UserAgentClient/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "UserAgentClient": {
       "commandName": "Project",
-      "commandLineArgs": "sips:[::1]"
+      "commandLineArgs": "127.0.0.1;transport=tcp"
     }
   }
 }

--- a/examples/UserAgentClient/UserAgentClient.csproj
+++ b/examples/UserAgentClient/UserAgentClient.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="SIPSorcery" Version="4.0.4-rc" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SIPSorcery.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/examples/UserAgentServer/UserAgentServer.csproj
+++ b/examples/UserAgentServer/UserAgentServer.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\SIPSorcery.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="localhost.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/examples/sipcmdline/Program.cs
+++ b/examples/sipcmdline/Program.cs
@@ -149,11 +149,10 @@ namespace SIPSorcery
                             sipChannel = new SIPUDPChannel(new IPEndPoint(localAddress, DEFAULT_SIP_CLIENT_PORT));
                             break;
                         case SIPProtocolsEnum.ws:
-                            sipChannel = new SIPWebSocketChannel(new IPEndPoint(localAddress, DEFAULT_SIP_CLIENT_PORT), null);
+                            sipChannel = new SIPClientWebSocketChannel();
                             break;
                         case SIPProtocolsEnum.wss:
-                            var wsCertificate = new X509Certificate2(@"localhost.pfx", "");
-                            sipChannel = new SIPWebSocketChannel(new IPEndPoint(localAddress, DEFAULT_SIP_CLIENT_PORT), wsCertificate);
+                            sipChannel = new SIPClientWebSocketChannel();
                             break;
                         default:
                             throw new ApplicationException($"Don't know how to create SIP channel for transport {dstEp.Protocol}.");

--- a/examples/sipcmdline/Program.cs
+++ b/examples/sipcmdline/Program.cs
@@ -150,10 +150,10 @@ namespace SIPSorcery
                             sipChannel = new SIPUDPChannel(new IPEndPoint(localAddress, DEFAULT_SIP_CLIENT_PORT));
                             break;
                         case SIPProtocolsEnum.ws:
-                            sipChannel = new SIPClientWebSocketChannel(false);
+                            sipChannel = new SIPClientWebSocketChannel();
                             break;
                         case SIPProtocolsEnum.wss:
-                            sipChannel = new SIPClientWebSocketChannel(true);
+                            sipChannel = new SIPClientWebSocketChannel();
                             break;
                         default:
                             throw new ApplicationException($"Don't know how to create SIP channel for transport {dstEp.Protocol}.");

--- a/examples/sipcmdline/Program.cs
+++ b/examples/sipcmdline/Program.cs
@@ -67,6 +67,7 @@ namespace SIPSorcery
     {
         private const int DEFAULT_SIP_CLIENT_PORT = 0;
         private const int DEFAULT_SIPS_CLIENT_PORT = 0;
+        private const int DEFAULT_RESPONSE_TIMEOUT_SECONDS = 5;
 
         private static Microsoft.Extensions.Logging.ILogger logger;
 
@@ -76,7 +77,7 @@ namespace SIPSorcery
                 HelpText = "The destination SIP end point in the form [(udp|tcp|tls|sip|sips):]<host|ipaddress>[:port] e.g. udp:67.222.131.147:5060.")]
             public string Destination { get; set; }
 
-            [Option('t', "timeout", Required = false, Default = 5, HelpText = "The timeout in seconds for the SIP command to complete.")]
+            [Option('t', "timeout", Required = false, Default = DEFAULT_RESPONSE_TIMEOUT_SECONDS, HelpText = "The timeout in seconds for the SIP command to complete.")]
             public int Timeout { get; set; }
 
             [Option('c', "count", Required = false, Default = 1, HelpText = "The number of requests to send.")]
@@ -149,10 +150,10 @@ namespace SIPSorcery
                             sipChannel = new SIPUDPChannel(new IPEndPoint(localAddress, DEFAULT_SIP_CLIENT_PORT));
                             break;
                         case SIPProtocolsEnum.ws:
-                            sipChannel = new SIPClientWebSocketChannel();
+                            sipChannel = new SIPClientWebSocketChannel(false);
                             break;
                         case SIPProtocolsEnum.wss:
-                            sipChannel = new SIPClientWebSocketChannel();
+                            sipChannel = new SIPClientWebSocketChannel(true);
                             break;
                         default:
                             throw new ApplicationException($"Don't know how to create SIP channel for transport {dstEp.Protocol}.");
@@ -288,7 +289,7 @@ namespace SIPSorcery
                 {
                     if (sipResponse.Header.CSeqMethod == SIPMethodsEnum.OPTIONS && sipResponse.Header.CallId == optionsRequest.Header.CallId)
                     {
-                        logger.LogDebug($"Expected response received {localSIPEndPoint.ToString()}<-{remoteEndPoint.ToString()}: {sipResponse.ShortDescription}");
+                        logger.LogDebug($"Expected response received {localSIPEndPoint}<-{remoteEndPoint}: {sipResponse.ShortDescription}");
                         tcs.SetResult(true);
                     }
                 };

--- a/examples/sipcmdline/Properties/launchSettings.json
+++ b/examples/sipcmdline/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "sipcmdline": {
       "commandName": "Project",
-      "commandLineArgs": "-d 192.168.11.49"
+      "commandLineArgs": "-d ws:127.0.0.1:80"
     },
     "Docker": {
       "commandName": "Docker"

--- a/examples/sipcmdline/sipcmdline.csproj
+++ b/examples/sipcmdline/sipcmdline.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\SIPSorcery.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="localhost.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -20,6 +20,18 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Net.WebSockets.Client">
+      <Version>4.3.2</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="System.Net.WebSockets.Client">
+      <Version>4.3.2</Version>
+    </PackageReference>
+  </ItemGroup>
   
   <PropertyGroup>
   <TargetFrameworks>netstandard2.0;net452;netcoreapp3.0</TargetFrameworks>

--- a/src/core/SIP/Channels/SIPChannel.cs
+++ b/src/core/SIP/Channels/SIPChannel.cs
@@ -65,7 +65,6 @@ namespace SIPSorcery.SIP
             RemoteEndPoint = remoteEndPoint;
             Buffer = buffer;
             ReceivedAt = DateTime.Now;
-
         }
     }
 
@@ -78,7 +77,7 @@ namespace SIPSorcery.SIP
         protected static int CHANNEL_ID_LENGTH = 3;         // Length of the random numeric string to use for channel ID's.
         private static int CREATE_CHANNELID_ATTEMPTS = 10; // Number of attempts to make at creating a random channel ID.
 
-        private static ConcurrentDictionary<int, int> _inUseChannelIDs = new ConcurrentDictionary<int, int>(); // Make sure don't create dulpicate channel ID's.
+        private static ConcurrentDictionary<int, int> _inUseChannelIDs = new ConcurrentDictionary<int, int>(); // Make sure we don't create dulpicate channel ID's.
 
         protected ILogger logger = Log.Logger;
 
@@ -144,14 +143,6 @@ namespace SIPSorcery.SIP
         /// The type of SIP protocol (udp, tcp, tls or web socket) for this channel.
         /// </summary>
         public SIPProtocolsEnum SIPProtocol { get; protected set; }
-
-        /// <summary>
-        /// Whether the channel is IPv4 or IPv6.
-        /// </summary>
-        public AddressFamily AddressFamily
-        {
-            get { return ListeningIPAddress.AddressFamily; }
-        }
 
         /// <summary>
         /// Indicates whether close has been called on the SIP channel. Once closed a SIP channel can no longer be used
@@ -223,7 +214,7 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// Synchronous wrapper for <see cref="SendSecureAsync"/>
         /// </summary>
-        public abstract void SendSecure(IPEndPoint destinationEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint = null);
+        //public abstract void SendSecure(IPEndPoint destinationEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint = null);
 
         /// <summary>
         /// Asynchronous SIP message send to a remote end point.
@@ -259,6 +250,18 @@ namespace SIPSorcery.SIP
         /// <param name="remoteEndPoint">The remote end point to check for an existing connection.</param>
         /// <returns>True if a match is found or false if not.</returns>
         public abstract bool HasConnection(IPEndPoint remoteEndPoint);
+
+        /// <summary>
+        /// Checks whether a web socket based SIP channel has an existing connection to a server URI.
+        /// </summary>
+        /// <param name="serverUri">The remote server URI to check for an existing connection.</param>
+        /// <returns>True if a match is found or false if not.</returns>
+        public abstract bool HasConnection(Uri serverUri);
+
+        /// <summary>
+        /// Returns true if the channel supports the requested address family.
+        /// </summary>
+        public abstract bool IsAddressFamilySupported(AddressFamily addresFamily);
 
         /// <summary>
         /// Gets the local IP address this SIP channel will use for communicating with the destination

--- a/src/core/SIP/Channels/SIPChannel.cs
+++ b/src/core/SIP/Channels/SIPChannel.cs
@@ -264,6 +264,11 @@ namespace SIPSorcery.SIP
         public abstract bool IsAddressFamilySupported(AddressFamily addresFamily);
 
         /// <summary>
+        /// Returns true if the channel supports the requested transport layer protocol.
+        /// </summary>
+        public abstract bool IsProtocolSupported(SIPProtocolsEnum protocol);
+
+        /// <summary>
         /// Gets the local IP address this SIP channel will use for communicating with the destination
         /// IP address.
         /// </summary>

--- a/src/core/SIP/Channels/SIPChannel.cs
+++ b/src/core/SIP/Channels/SIPChannel.cs
@@ -274,7 +274,7 @@ namespace SIPSorcery.SIP
         /// </summary>
         /// <param name="dst">The destination IP address.</param>
         /// <returns>The local IP address this channel selects to use for connecting to the destination.</returns>
-        private IPAddress GetLocalIPAddressForDestination(IPAddress dst)
+        protected IPAddress GetLocalIPAddressForDestination(IPAddress dst)
         {
             IPAddress localAddress = ListeningIPAddress;
 
@@ -288,13 +288,14 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
-        /// Get the local SIPEndPoint this channel will use for communicating with the destination IP address,
+        /// Get the local SIPEndPoint this channel will use for communicating with the destination SIP end point.
         /// </summary>
-        /// <param name="dst">The destination IP address.</param>
+        /// <param name="dstEndPoint">The destination SIP end point.</param>
         /// <returns>The local SIP end points this channel selects to use for connecting to the destination.</returns>
-        internal SIPEndPoint GetLocalSIPEndPointForDestination(IPAddress dst)
+        internal virtual SIPEndPoint GetLocalSIPEndPointForDestination(SIPEndPoint dstEndPoint)
         {
-            IPAddress localAddress = GetLocalIPAddressForDestination(dst);
+            IPAddress dstAddress = dstEndPoint.GetIPEndPoint().Address;
+            IPAddress localAddress = GetLocalIPAddressForDestination(dstAddress);
             return new SIPEndPoint(SIPProtocol, localAddress, Port, ID, null);
         }
 
@@ -305,11 +306,11 @@ namespace SIPSorcery.SIP
         /// send to a desintation address on the internet will result in a different URI.
         /// </summary>
         /// <param name="scheme">The SIP scheme to use for the Contact URI.</param>
-        /// <param name="dst">The destination address the Contact URI is for. For a SIPChannel using
+        /// <param name="dstEndPoint">The destination SIP end point the Contact URI is for. For a SIPChannel using
         /// IPAddress.Any the desintation needs to be known so it can select the correct local address.</param>
-        public SIPURI GetContactURI(SIPSchemesEnum scheme, IPAddress dst)
+        public SIPURI GetContactURI(SIPSchemesEnum scheme, SIPEndPoint dstEndPoint)
         {
-            return new SIPURI(scheme, GetLocalSIPEndPointForDestination(dst));
+            return new SIPURI(scheme, GetLocalSIPEndPointForDestination(dstEndPoint));
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPChannel.cs
+++ b/src/core/SIP/Channels/SIPChannel.cs
@@ -209,7 +209,7 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// Synchronous wrapper for <see cref="SendAsync"/>
         /// </summary>
-        public abstract void Send(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint = null);
+        public abstract void Send(SIPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint = null);
 
         /// <summary>
         /// Synchronous wrapper for <see cref="SendSecureAsync"/>
@@ -219,21 +219,21 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// Asynchronous SIP message send to a remote end point.
         /// </summary>
-        /// <param name="destinationEndPoint">The remote end point to send the message to.</param>
+        /// <param name="dstEndPoint">The remote end point to send the message to.</param>
         /// <param name="buffer">The data to send.</param>
         /// <param name="connectionID">Optional ID of the specific client connection that the message should be sent on. It's only
         /// a hint so if the connection has been closed a new one will be attempted.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
-        public abstract Task<SocketError> SendAsync(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint = null);
+        public abstract Task<SocketError> SendAsync(SIPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint = null);
 
         /// <summary>
         /// Asynchronous SIP message send over a secure TLS connetion to a remote end point.
         /// </summary>
-        /// <param name="destinationEndPoint">The remote end point to send the message to.</param>
+        /// <param name="dstEndPoint">The remote end point to send the message to.</param>
         /// <param name="buffer">The data to send.</param>
         /// <param name="serverCertificateName">If the send is over SSL the required common name of the server's X509 certificate.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
-        public abstract Task<SocketError> SendSecureAsync(IPEndPoint destinationEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint = null);
+        public abstract Task<SocketError> SendSecureAsync(SIPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint = null);
 
         /// <summary>
         /// Checks whether the SIP channel has a connection matching a unique connection ID.
@@ -249,7 +249,7 @@ namespace SIPSorcery.SIP
         /// </summary>
         /// <param name="remoteEndPoint">The remote end point to check for an existing connection.</param>
         /// <returns>True if a match is found or false if not.</returns>
-        public abstract bool HasConnection(IPEndPoint remoteEndPoint);
+        public abstract bool HasConnection(SIPEndPoint remoteEndPoint);
 
         /// <summary>
         /// Checks whether a web socket based SIP channel has an existing connection to a server URI.

--- a/src/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -287,6 +287,20 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
+        /// Get the local SIPEndPoint this channel will use for communicating with the destination SIP end point.
+        /// </summary>
+        /// <param name="dstEndPoint">The destination SIP end point.</param>
+        /// <returns>The local SIP end points this channel selects to use for connecting to the destination.</returns>
+        internal override SIPEndPoint GetLocalSIPEndPointForDestination(SIPEndPoint dstEndPoint)
+        {
+            IPAddress dstAddress = dstEndPoint.GetIPEndPoint().Address;
+            IPAddress localAddress = GetLocalIPAddressForDestination(dstAddress);
+
+            // Need to return ws or wss to match the destination.
+            return new SIPEndPoint(dstEndPoint.Protocol, localAddress, Port, ID, null);
+        }
+
+        /// <summary>
         /// Closes all web socket connections.
         /// </summary>
         public override void Close()

--- a/src/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -1,0 +1,359 @@
+//-----------------------------------------------------------------------------
+// Filename: SIPClientWebSocketChannel.cs
+//
+// Description: SIP channel for egress web socket connections. These are
+// connections initiated by us to a remote web socket server.
+//
+// Note: The TCP port used to establish the connection is pseudo-randomly 
+// chosen by the .Net framework (or OS).
+//
+// Author(s):
+// Aaron Clauson (aaron@sipsorcery.com)
+//
+// History:
+// 18 Dec 2019  Aaron Clauson   Created, Dublin, Ireland.
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Sys;
+
+namespace SIPSorcery.SIP
+{
+    /// <summary>
+    ///  A SIP transport Channel for establishing an outbound connection  over a Web Socket communications layer as per RFC7118.
+    ///  The channel can manage multiple connections. All SIP clients wishing to initate a connection to a SIP web socket
+    ///  server should use a single instance of this class.
+    ///  
+    /// <code>
+    /// 
+    /// </code>
+    /// </summary>
+    public class SIPClientWebSocketChannel : SIPChannel
+    {
+        /// <summary>
+        /// Holds the state for a current web socket client connection.
+        /// </summary>
+        private struct ClientWebSocketConnection
+        {
+            public Uri ServerUri;
+            public string ConnectionID;
+            public ArraySegment<byte> ReceiveBuffer;
+            public Task<WebSocketReceiveResult> ReceiveTask;
+            public ClientWebSocket Client;
+        }
+
+        public const string SIP_Sec_WebSocket_Protocol = "sip"; // Web socket protocol string for SIP as defined in RFC7118.
+        public const string WEB_SOCKET_URI_PREFIX = "ws://";
+        public const string WEB_SOCKET_SECURE_URI_PREFIX = "wss://";
+
+        /// <summary>
+        /// Maintains a list of current egresss web socket connections (one's that have been initiated by us).
+        /// </summary>
+        private ConcurrentDictionary<string, ClientWebSocketConnection> m_egressConnections = new ConcurrentDictionary<string, ClientWebSocketConnection>();
+
+        /// <summary>
+        /// Cancellation source passed to all async operations in this class.
+        /// </summary>
+        private CancellationTokenSource m_cts = new CancellationTokenSource();
+
+        /// <summary>
+        /// Indicates whether the receive thread that monitors the receive tasks for each web socket client is running.
+        /// </summary>
+        private bool m_isReceiveTaskRunning = false;
+
+        /// <summary>
+        /// Creates a SIP channel to establish outbound connections and send SIP messages 
+        /// over a web socket communications layer.
+        /// </summary>
+        public SIPClientWebSocketChannel() : base()
+        {
+            IsReliable = true;
+            SIPProtocol = SIPProtocolsEnum.ws;
+
+            // TODO: These values need to be adjusted. The problem is the source end point isn't available from
+            // the client web socket connection.
+            ListeningIPAddress = IPAddress.Any;
+            Port = 80;
+        }
+
+        /// <summary>
+        /// Ideally sends on the web socket channel should specify the connection ID. But if there's
+        /// a good reason not to we can check if there is an existing client connection with the
+        /// requested remote end point and use it.
+        /// </summary>
+        /// <param name="destinationEndPoint">The remote destination end point to send the data to.</param>
+        /// <param name="buffer">The data to send.</param>
+        /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
+        public async override void Send(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
+        {
+            if (destinationEndPoint == null)
+            {
+                throw new ApplicationException("An empty destination was specified to Send in SIPClientWebSocketChannel.");
+            }
+            else if (buffer == null || buffer.Length == 0)
+            {
+                throw new ArgumentException("buffer", "The buffer must be set and non empty for Send in SIPClientWebSocketChannel.");
+            }
+
+            await SendAsync(destinationEndPoint, buffer, connectionIDHint);
+        }
+
+        /// <summary>
+        /// Ideally sends on the web socket channel should specify the connection ID. But if there's
+        /// a good reason not to we can check if there is an existing client connection with the
+        /// requested remote end point and use it.
+        /// </summary>
+        /// <param name="destinationEndPoint">The remote destination end point to send the data to.</param>
+        /// <param name="buffer">The data to send.</param>
+        /// <param name="connectionIDHint">The ID of the specific web socket connection to try and send the message on.</param>
+        /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
+        public override Task<SocketError> SendAsync(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
+        {
+            if (destinationEndPoint == null)
+            {
+                throw new ApplicationException("An empty destination was specified to Send in SIPClientWebSocketChannel.");
+            }
+            else if (buffer == null || buffer.Length == 0)
+            {
+                throw new ArgumentException("buffer", "The buffer must be set and non empty for Send in SIPClientWebSocketChannel.");
+            }
+
+            var serverUri = new Uri($"{WEB_SOCKET_URI_PREFIX}{destinationEndPoint}");
+            return SendAsync(serverUri, buffer);
+        }
+
+        /// <summary>
+        /// Send to a secure web socket server.
+        /// </summary>
+        public override Task<SocketError> SendSecureAsync(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
+        {
+            if (dstEndPoint == null)
+            {
+                throw new ApplicationException("An empty destination was specified to SendSecure in SIPClientWebSocketChannel.");
+            }
+            else if (buffer == null || buffer.Length == 0)
+            {
+                throw new ArgumentException("buffer", "The buffer must be set and non empty for SendSecure in SIPClientWebSocketChannel.");
+            }
+
+            var serverUri = new Uri($"{WEB_SOCKET_SECURE_URI_PREFIX}{dstEndPoint}");
+            return SendAsync(serverUri, buffer);
+        }
+
+        /// <summary>
+        /// Attempts a send to a remote web socket server. If there is an existing connection it will be used
+        /// otherwise an attempt will made to establish a new one.
+        /// </summary>
+        /// <param name="serverUri">The remote web socket server URI to send to.</param>
+        /// <param name="buffer">The data buffer to send.</param>
+        /// <returns>A success value or an error for failure.</returns>
+        private async Task<SocketError> SendAsync(Uri serverUri, byte[] buffer)
+        {
+            try
+            {
+                string connectionID = GetConnectionID(serverUri);
+
+                if (m_egressConnections.TryGetValue(connectionID, out var connection))
+                {
+                    ArraySegment<byte> segmentBuffer = new ArraySegment<byte>(buffer);
+                    await connection.Client.SendAsync(segmentBuffer, WebSocketMessageType.Text, true, m_cts.Token);
+
+                    return SocketError.Success;
+                }
+                else
+                {
+                    // Attempt a new connection.
+                    ClientWebSocket clientWebSocket = new ClientWebSocket();
+                    await clientWebSocket.ConnectAsync(serverUri, m_cts.Token);
+
+                    logger.LogDebug($"Successfully connected web socket client to {serverUri}.");
+
+                    ArraySegment<byte> segmentBuffer = new ArraySegment<byte>(buffer);
+                    await clientWebSocket.SendAsync(segmentBuffer, WebSocketMessageType.Text, true, m_cts.Token);
+
+                    var recvBuffer = new ArraySegment<byte>(new byte[2 * SIPStreamConnection.MaxSIPTCPMessageSize]);
+                    Task<WebSocketReceiveResult> receiveTask = clientWebSocket.ReceiveAsync(recvBuffer, m_cts.Token);
+
+                    ClientWebSocketConnection conn = new ClientWebSocketConnection
+                    {
+                        ServerUri = serverUri,
+                        ConnectionID = connectionID,
+                        ReceiveBuffer = recvBuffer,
+                        ReceiveTask = receiveTask,
+                        Client = clientWebSocket
+                    };
+
+                    if (!m_egressConnections.TryAdd(connectionID, conn))
+                    {
+                        logger.LogError($"Could not added web socket client connected to {serverUri} to channel collection, closing.");
+
+                        _ = Close(connectionID, clientWebSocket);
+                    }
+                    else
+                    {
+                        if (!m_isReceiveTaskRunning)
+                        {
+                            m_isReceiveTaskRunning = true;
+                            _ = Task.Run((Action)MonitorReceiveTasks);
+                        }
+                    }
+
+                    return SocketError.Success;
+                }
+            }
+            catch (SocketException sockExcp)
+            {
+                return sockExcp.SocketErrorCode;
+            }
+        }
+
+        /// <summary>
+        /// Checks whether the web socket SIP channel has a connection matching a unique connection ID.
+        /// </summary>
+        /// <param name="connectionID">The connection ID to check for a match on.</param>
+        /// <returns>True if a match is found or false if not.</returns>
+        public override bool HasConnection(string connectionID)
+        {
+            return m_egressConnections.ContainsKey(connectionID);
+        }
+
+        /// <summary>
+        /// Not implemented for the WebSocket channel.
+        /// </summary>
+        public override bool HasConnection(IPEndPoint serverEndPoint)
+        {
+            throw new NotImplementedException("This HasConnection method is not available in the SIP Client Web Socket channel, please use an alternative overload.");
+        }
+
+        /// <summary>
+        /// Checks whether there is an existing client web socket connection for a remote end point.
+        /// </summary>
+        /// <param name="serverUri">The server URI to check for an existing connection.</param>
+        /// <returns>True if there is a connection or false if not.</returns>
+        public override bool HasConnection(Uri serverUri)
+        {
+            return m_egressConnections.ContainsKey(GetConnectionID(serverUri));
+        }
+
+        /// <summary>
+        /// Checks whether the specified address family is supported.
+        /// </summary>
+        /// <param name="addresFamily">The address family to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsAddressFamilySupported(AddressFamily addresFamily)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Closes all web socket connections.
+        /// </summary>
+        public override void Close()
+        {
+            try
+            {
+                logger.LogDebug($"Closing SIP Client Web Socket Channel.");
+
+                Closed = true;
+                m_cts.Cancel();
+
+                foreach (var conn in m_egressConnections)
+                {
+                    _ = Close(conn.Key, conn.Value.Client);
+                }
+            }
+            catch (Exception excp)
+            {
+                logger.LogWarning("Exception SIPClientWebSocketChannel Close. " + excp.Message);
+            }
+        }
+
+        /// <summary>
+        /// Calls close on the channel when it is disposed.
+        /// </summary>
+        public override void Dispose()
+        {
+            this.Close();
+        }
+
+        /// <summary>
+        /// Closes a single web socket client connection.
+        /// </summary>
+        /// <param name="client">The client to close.</param>
+        private Task Close(string connectionID, ClientWebSocket client)
+        {
+            if (!Closed)
+            {
+                // Don't touch the lists if the whole channel is being closed. At that point
+                // The connection list is being iterated.
+                m_egressConnections.TryRemove(connectionID, out _);
+            }
+
+            return client.CloseAsync(WebSocketCloseStatus.NormalClosure, null, m_cts.Token);
+        }
+
+        /// <summary>
+        /// Gets the connection ID for a server URI.
+        /// </summary>
+        /// <param name="serverUri">The web socket server URI for the connection.</param>
+        /// <returns>A string connection ID.</returns>
+        private string GetConnectionID(Uri serverUri)
+        {
+            return Crypto.GetSHAHashAsString(serverUri.ToString());
+        }
+
+        /// <summary>
+        /// Monitors the client web socket tasks for new receives.
+        /// </summary>
+        private async void MonitorReceiveTasks()
+        {
+            try
+            {
+                while (!Closed && m_egressConnections.Count > 0)
+                {
+                    try
+                    {
+                        Task<WebSocketReceiveResult> receiveTask = await Task.WhenAny(m_egressConnections.Select(x => x.Value.ReceiveTask));
+                        var conn = m_egressConnections.Where(x => x.Value.ReceiveTask.Id == receiveTask.Id).Single().Value;
+
+                        if (receiveTask.IsCompleted)
+                        {
+                            logger.LogDebug($"Client web socket connection to {conn.ServerUri} received {receiveTask.Result.Count} bytes.");
+                            SIPMessageReceived(this, null, null, conn.ReceiveBuffer.Take(receiveTask.Result.Count).ToArray());
+                            conn.ReceiveTask = conn.Client.ReceiveAsync(conn.ReceiveBuffer, m_cts.Token);
+                            break;
+                        }
+                        else
+                        {
+                            logger.LogWarning($"Client web socket connection to {conn.ServerUri} returned without completeing, closing.");
+                            _ = Close(conn.ConnectionID, conn.Client);
+                        }
+                    }
+                    catch (Exception excp)
+                    {
+                        logger.LogError($"Exception SIPCLientWebSocketChannel processing receive tasks. {excp.Message}");
+                    }
+                }
+            }
+            catch (Exception excp)
+            {
+                logger.LogError($"Exception SIPCLientWebSocketChannel.MonitorReceiveTasks. {excp.Message}");
+            }
+            finally
+            {
+                m_isReceiveTaskRunning = false;
+            }
+        }
+    }
+}

--- a/src/core/SIP/Channels/SIPTCPChannel.cs
+++ b/src/core/SIP/Channels/SIPTCPChannel.cs
@@ -418,17 +418,12 @@ namespace SIPSorcery.SIP
         /// </summary>
         /// <param name="dstEndPoint">The remote end point to send to.</param>
         /// <param name="buffer">The data to send.</param>
-        public override async void Send(IPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
+        public override async void Send(SIPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
         {
             await SendAsync(dstEndPoint, buffer, connectionIDHint);
         }
 
-        //public override async void SendSecure(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
-        //{
-        //    await SendSecureAsync(dstEndPoint, buffer, serverCertificateName, connectionIDHint);
-        //}
-
-        public override Task<SocketError> SendAsync(IPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
+        public override Task<SocketError> SendAsync(SIPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
         {
             return SendSecureAsync(dstEndPoint, buffer, null, connectionIDHint);
         }
@@ -443,7 +438,7 @@ namespace SIPSorcery.SIP
         /// that is expected for the remote SSL server.</param>
         /// <param name="connectionIDHint">Optional. The ID of the specific TCP connection to try and the send the message on.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
-        public override async Task<SocketError> SendSecureAsync(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
+        public override Task<SocketError> SendSecureAsync(SIPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
         {
             try
             {
@@ -478,17 +473,17 @@ namespace SIPSorcery.SIP
                     if (sipStreamConn != null)
                     {
                         SendOnConnected(sipStreamConn, buffer);
-                        return SocketError.Success;
+                        return Task.FromResult(SocketError.Success);
                     }
                     else
                     {
-                        return await ConnectClientAsync(dstEndPoint, buffer, serverCertificateName);
+                        return ConnectClientAsync(dstEndPoint.GetIPEndPoint(), buffer, serverCertificateName);
                     }
                 }
             }
             catch (SocketException sockExcp)
             {
-                return sockExcp.SocketErrorCode;
+                return Task.FromResult(sockExcp.SocketErrorCode);
             }
             catch (ApplicationException)
             {
@@ -604,9 +599,9 @@ namespace SIPSorcery.SIP
         /// </summary>
         /// <param name="remoteEndPoint">The remote end point to check for an existing connection.</param>
         /// <returns>True if there is a connection or false if not.</returns>
-        public override bool HasConnection(IPEndPoint remoteEndPoint)
+        public override bool HasConnection(SIPEndPoint remoteEndPoint)
         {
-            return m_connections.Any(x => x.Value.RemoteEndPoint.Equals(remoteEndPoint));
+            return m_connections.Any(x => x.Value.RemoteEndPoint.Equals(remoteEndPoint.GetIPEndPoint()));
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPTCPChannel.cs
+++ b/src/core/SIP/Channels/SIPTCPChannel.cs
@@ -628,6 +628,16 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
+        /// Checks whether the specified protocol is supported.
+        /// </summary>
+        /// <param name="protocol">The protocol to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsProtocolSupported(SIPProtocolsEnum protocol)
+        {
+            return protocol == SIPProtocolsEnum.tcp;
+        }
+
+        /// <summary>
         /// Closes the channel and any open sockets.
         /// </summary>
         public override void Close()

--- a/src/core/SIP/Channels/SIPTCPChannel.cs
+++ b/src/core/SIP/Channels/SIPTCPChannel.cs
@@ -423,14 +423,14 @@ namespace SIPSorcery.SIP
             await SendAsync(dstEndPoint, buffer, connectionIDHint);
         }
 
-        public override async void SendSecure(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
-        {
-            await SendSecureAsync(dstEndPoint, buffer, serverCertificateName, connectionIDHint);
-        }
+        //public override async void SendSecure(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
+        //{
+        //    await SendSecureAsync(dstEndPoint, buffer, serverCertificateName, connectionIDHint);
+        //}
 
-        public override async Task<SocketError> SendAsync(IPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
+        public override Task<SocketError> SendAsync(IPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
         {
-            return await SendSecureAsync(dstEndPoint, buffer, null, connectionIDHint);
+            return SendSecureAsync(dstEndPoint, buffer, null, connectionIDHint);
         }
 
         /// <summary>
@@ -607,6 +607,24 @@ namespace SIPSorcery.SIP
         public override bool HasConnection(IPEndPoint remoteEndPoint)
         {
             return m_connections.Any(x => x.Value.RemoteEndPoint.Equals(remoteEndPoint));
+        }
+
+        /// <summary>
+        /// Not implemented for the TCP channel.
+        /// </summary>
+        public override bool HasConnection(Uri serverUri)
+        {
+            throw new NotImplementedException("This HasConnection method is not available in the SIP TCP channel, please use an alternative overload.");
+        }
+
+        /// <summary>
+        /// Checks whether the specified address family is supported.
+        /// </summary>
+        /// <param name="addresFamily">The address family to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsAddressFamilySupported(AddressFamily addresFamily)
+        {
+            return addresFamily == ListeningIPAddress.AddressFamily;
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/core/SIP/Channels/SIPTLSChannel.cs
@@ -176,6 +176,16 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
+        /// Checks whether the specified protocol is supported.
+        /// </summary>
+        /// <param name="protocol">The protocol to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsProtocolSupported(SIPProtocolsEnum protocol)
+        {
+            return protocol == SIPProtocolsEnum.tls;
+        }
+
+        /// <summary>
         /// Attempt to retrieve a certificate from the Windows local machine certificate store.
         /// </summary>
         /// <param name="subjName">The subject name of the certificate to retrieve.</param>

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -247,6 +247,16 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
+        /// Checks whether the specified protocol is supported.
+        /// </summary>
+        /// <param name="protocol">The protocol to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsProtocolSupported(SIPProtocolsEnum protocol)
+        {
+            return protocol == SIPProtocolsEnum.tcp;
+        }
+
+        /// <summary>
         /// Closes the channel's UDP socket.
         /// </summary>
         public override void Close()

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -253,7 +253,7 @@ namespace SIPSorcery.SIP
         /// <returns>True if supported, false if not.</returns>
         public override bool IsProtocolSupported(SIPProtocolsEnum protocol)
         {
-            return protocol == SIPProtocolsEnum.tcp;
+            return protocol == SIPProtocolsEnum.udp;
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -137,12 +137,12 @@ namespace SIPSorcery.SIP
             }
         }
 
-        public override async void Send(IPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
+        public override async void Send(SIPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
         {
             await SendAsync(dstEndPoint, buffer, connectionIDHint);
         }
 
-        public override Task<SocketError> SendAsync(IPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
+        public override Task<SocketError> SendAsync(SIPEndPoint dstEndPoint, byte[] buffer, string connectionIDHint)
         {
             if (dstEndPoint == null)
             {
@@ -155,7 +155,7 @@ namespace SIPSorcery.SIP
 
             try
             {
-                m_udpSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint, EndSendTo, dstEndPoint);
+                m_udpSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint.GetIPEndPoint(), EndSendTo, dstEndPoint);
                 return Task.FromResult(SocketError.Success);
             }
             catch (ObjectDisposedException) // Thrown when socket is closed. Can be safely ignored.
@@ -207,7 +207,7 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// This method is not implemented for the SIP UDP channel.
         /// </summary>
-        public override Task<SocketError> SendSecureAsync(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
+        public override Task<SocketError> SendSecureAsync(SIPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
         {
             throw new NotImplementedException("This Send method is not available in the SIP UDP channel, please use an alternative overload.");
         }
@@ -223,7 +223,7 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// The UDP channel does not support connections. Always returns false.
         /// </summary>
-        public override bool HasConnection(IPEndPoint remoteEndPoint)
+        public override bool HasConnection(SIPEndPoint remoteEndPoint)
         {
             return false;
         }

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -199,10 +199,10 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// This method is not implemented for the SIP UDP channel.
         /// </summary>
-        public override void SendSecure(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
-        {
-            throw new NotImplementedException("This Send method is not available in the SIP UDP channel, please use an alternative overload.");
-        }
+        //public override void SendSecure(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
+        //{
+        //    throw new NotImplementedException("This Send method is not available in the SIP UDP channel, please use an alternative overload.");
+        //}
 
         /// <summary>
         /// This method is not implemented for the SIP UDP channel.
@@ -226,6 +226,24 @@ namespace SIPSorcery.SIP
         public override bool HasConnection(IPEndPoint remoteEndPoint)
         {
             return false;
+        }
+
+        /// <summary>
+        /// The UDP channel does not support connections. Always returns false.
+        /// </summary>
+        public override bool HasConnection(Uri serverUri)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether the specified address family is supported.
+        /// </summary>
+        /// <param name="addresFamily">The address family to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsAddressFamilySupported(AddressFamily addresFamily)
+        {
+             return addresFamily == ListeningIPAddress.AddressFamily;
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -177,8 +177,6 @@ namespace SIPSorcery.SIP
         {
             try
             {
-                IPEndPoint dstEndPoint = (IPEndPoint)ar.AsyncState;
-
                 int bytesSent = m_udpSocket.EndSendTo(ar);
             }
             catch (SocketException sockExcp)

--- a/src/core/SIP/Channels/SIPWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPWebSocketChannel.cs
@@ -6,14 +6,14 @@
 //
 // Note: At the time of writing the .Net Code Libraries (CoreFX) did have some rudimentary
 // Web Socket support. Unfortunately the support was limited to some Web Socket Protocol
-// classes and a Web Socket Client. There was no Web Socekt Server. For the latter it
+// classes and a Web Socket Client. There was no Web Socket Server. For the latter it
 // is likely the decision was to rely on support in Kestrel and IIS.
 //
 // Author(s):
 // Aaron Clauson (aaron@sipsorcery.com)
 //
 // History:
-// 17 Oct 2005	Aaron Clauson	Created, Dublin, Ireland.
+// 17 Oct 2019	Aaron Clauson	Created, Dublin, Ireland.
 //
 // License: 
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using WebSocketSharp;
@@ -126,10 +127,12 @@ namespace SIPSorcery.SIP
         private WebSocketServer m_webSocketServer;
 
         /// <summary>
-        /// Maintains a list of current web socket connections across for this web socket server. This allows the SIP transport
+        /// Maintains a list of current ingress web socket connections across for this web socket server. This allows the SIP transport
         /// layer to quickly match a channel where the same connection must be re-used.
         /// </summary>
-        private ConcurrentDictionary<string, SIPMessagWebSocketBehavior> m_clientConnections = new ConcurrentDictionary<string, SIPMessagWebSocketBehavior>();
+        private ConcurrentDictionary<string, SIPMessagWebSocketBehavior> m_ingressConnections = new ConcurrentDictionary<string, SIPMessagWebSocketBehavior>();
+
+        private CancellationTokenSource m_cts = new CancellationTokenSource();
 
         /// <summary>
         /// Creates a SIP channel to listen for and send SIP messages over a web socket communications layer.
@@ -170,7 +173,7 @@ namespace SIPSorcery.SIP
                 behaviour.Channel = this;
                 behaviour.Logger = this.logger;
 
-                behaviour.OnClientClose += (id) => m_clientConnections.TryRemove(id, out _);
+                behaviour.OnClientClose += (id) => m_ingressConnections.TryRemove(id, out _);
             });
 
             m_webSocketServer.Start();
@@ -200,7 +203,7 @@ namespace SIPSorcery.SIP
         /// <param name="client">The web socket client.</param>
         private void AddClientConnection(string id, SIPMessagWebSocketBehavior client)
         {
-            m_clientConnections.TryAdd(id, client);
+            m_ingressConnections.TryAdd(id, client);
         }
 
         /// <summary>
@@ -208,7 +211,7 @@ namespace SIPSorcery.SIP
         /// a good reason not to we can check if there is an existing client connection with the
         /// requested remote end point and use it.
         /// </summary>
-        /// <param name="destinationEndPoint">The remote destiation end point to send the data to.</param>
+        /// <param name="destinationEndPoint">The remote destination end point to send the data to.</param>
         /// <param name="buffer">The data to send.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
         public async override void Send(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
@@ -230,7 +233,7 @@ namespace SIPSorcery.SIP
         /// a good reason not to we can check if there is an existing client connection with the
         /// requested remote end point and use it.
         /// </summary>
-        /// <param name="destinationEndPoint">The remote destiation end point to send the data to.</param>
+        /// <param name="destinationEndPoint">The remote destination end point to send the data to.</param>
         /// <param name="buffer">The data to send.</param>
         /// <param name="connectionIDHint">The ID of the specific web socket connection to try and send the message on.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
@@ -247,21 +250,12 @@ namespace SIPSorcery.SIP
 
             try
             {
-                SIPMessagWebSocketBehavior client = null;
-
-                if (connectionIDHint != null)
+                var ingressClient = GetIngressConnection(destinationEndPoint, connectionIDHint);
+                
+                // And lastly if we now have a valid web socket then send.
+                if (ingressClient != null)
                 {
-                    m_clientConnections.TryGetValue(connectionIDHint, out client);
-                }
-
-                if (client == null)
-                {
-                    client = m_clientConnections.Where(x => x.Value.Context.UserEndPoint.Equals(destinationEndPoint)).Select(x => x.Value).FirstOrDefault();
-                }
-
-                if (client != null)
-                {
-                    await Task.Run(() => client.Send(buffer, 0, buffer.Length));
+                    await Task.Run(() => ingressClient.Send(buffer, 0, buffer.Length));
                     return SocketError.Success;
                 }
                 else
@@ -273,14 +267,6 @@ namespace SIPSorcery.SIP
             {
                 return sockExcp.SocketErrorCode;
             }
-        }
-
-        /// <summary>
-        /// Not implemented for the WebSocket channel.
-        /// </summary>
-        public override void SendSecure(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
-        {
-            throw new NotImplementedException("This Send method is not available in the SIP Web Socket channel, please use an alternative overload.");
         }
 
         /// <summary>
@@ -298,7 +284,7 @@ namespace SIPSorcery.SIP
         /// <returns>True if a match is found or false if not.</returns>
         public override bool HasConnection(string connectionID)
         {
-            return m_clientConnections.ContainsKey(connectionID);
+            return m_ingressConnections.ContainsKey(connectionID);
         }
 
         /// <summary>
@@ -308,7 +294,25 @@ namespace SIPSorcery.SIP
         /// <returns>True if there is a connection or false if not.</returns>
         public override bool HasConnection(IPEndPoint remoteEndPoint)
         {
-            return m_clientConnections.Any(x => x.Value.Context.UserEndPoint.Equals(remoteEndPoint));
+            return m_ingressConnections.Any(x => x.Value.Context.UserEndPoint.Equals(remoteEndPoint));
+        }
+
+        /// <summary>
+        /// Not implemented for the this channel.
+        /// </summary>
+        public override bool HasConnection(Uri serverUri)
+        {
+            throw new NotImplementedException("This HasConnection method is not available in the SIP Web Socket channel, please use an alternative overload.");
+        }
+
+        /// <summary>
+        /// Checks whether the specified address family is supported.
+        /// </summary>
+        /// <param name="addresFamily">The address family to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsAddressFamilySupported(AddressFamily addresFamily)
+        {
+            return addresFamily == ListeningIPAddress.AddressFamily;
         }
 
         /// <summary>
@@ -335,6 +339,32 @@ namespace SIPSorcery.SIP
         public override void Dispose()
         {
             this.Close();
+        }
+
+        /// <summary>
+        /// Attempts to get a web socket ingress connection (one where a client connected to us).
+        /// </summary>
+        /// <param name="destinationEndPoint">The remote end point of the connection.</param>
+        /// <param name="connectionIDHint">Optional. A connection ID hint for the ingress connection.</param>
+        /// <returns>Returns the client connection or null if not found.</returns>
+        private SIPMessagWebSocketBehavior GetIngressConnection(IPEndPoint destinationEndPoint, string connectionIDHint)
+        {
+            SIPMessagWebSocketBehavior client = null;
+
+            if (connectionIDHint != null)
+            {
+                // This send needs to use a specific web socket connection. If the connection has been closed
+                // then don't attempt to re-connect (often not possible any way).
+
+                m_ingressConnections.TryGetValue(connectionIDHint, out client);
+            }
+
+            if (client == null)
+            {
+                client = m_ingressConnections.Where(x => x.Value.Context.UserEndPoint.Equals(destinationEndPoint)).Select(x => x.Value).FirstOrDefault();
+            }
+
+            return client;
         }
     }
 }

--- a/src/core/SIP/Channels/SIPWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPWebSocketChannel.cs
@@ -218,7 +218,7 @@ namespace SIPSorcery.SIP
         /// <param name="destinationEndPoint">The remote destination end point to send the data to.</param>
         /// <param name="buffer">The data to send.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
-        public async override void Send(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
+        public async override void Send(SIPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
         {
             if (destinationEndPoint == null)
             {
@@ -241,7 +241,7 @@ namespace SIPSorcery.SIP
         /// <param name="buffer">The data to send.</param>
         /// <param name="connectionIDHint">The ID of the specific web socket connection to try and send the message on.</param>
         /// <returns>If no errors SocketError.Success otherwise an error value.</returns>
-        public override async Task<SocketError> SendAsync(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
+        public override async Task<SocketError> SendAsync(SIPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
         {
             if (destinationEndPoint == null)
             {
@@ -254,7 +254,7 @@ namespace SIPSorcery.SIP
 
             try
             {
-                var ingressClient = GetIngressConnection(destinationEndPoint, connectionIDHint);
+                var ingressClient = GetIngressConnection(destinationEndPoint.GetIPEndPoint(), connectionIDHint);
                 
                 // And lastly if we now have a valid web socket then send.
                 if (ingressClient != null)
@@ -276,7 +276,7 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// Not implemented for the WebSocket channel.
         /// </summary>
-        public override Task<SocketError> SendSecureAsync(IPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
+        public override Task<SocketError> SendSecureAsync(SIPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, string connectionIDHint)
         {
             throw new NotImplementedException("This Send method is not available in the SIP Web Socket channel, please use an alternative overload.");
         }
@@ -296,9 +296,9 @@ namespace SIPSorcery.SIP
         /// </summary>
         /// <param name="remoteEndPoint">The remote end point to check for an existing connection.</param>
         /// <returns>True if there is a connection or false if not.</returns>
-        public override bool HasConnection(IPEndPoint remoteEndPoint)
+        public override bool HasConnection(SIPEndPoint remoteEndPoint)
         {
-            return m_ingressConnections.Any(x => x.Value.Context.UserEndPoint.Equals(remoteEndPoint));
+            return m_ingressConnections.Any(x => x.Value.Context.UserEndPoint.Equals(remoteEndPoint.GetIPEndPoint()));
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPWebSocketChannel.cs
@@ -9,6 +9,10 @@
 // classes and a Web Socket Client. There was no Web Socket Server. For the latter it
 // is likely the decision was to rely on support in Kestrel and IIS.
 //
+// Note 2: ClientWebSocket.CreateFromStream would seem to allow server web socket 
+// connections to be created from an underlying HTTP connection. But it's only
+// available for netcoreapp3.0.
+//
 // Author(s):
 // Aaron Clauson (aaron@sipsorcery.com)
 //
@@ -313,6 +317,23 @@ namespace SIPSorcery.SIP
         public override bool IsAddressFamilySupported(AddressFamily addresFamily)
         {
             return addresFamily == ListeningIPAddress.AddressFamily;
+        }
+
+        /// <summary>
+        /// Checks whether the specified protocol is supported.
+        /// </summary>
+        /// <param name="protocol">The protocol to check.</param>
+        /// <returns>True if supported, false if not.</returns>
+        public override bool IsProtocolSupported(SIPProtocolsEnum protocol)
+        {
+            if(IsSecure)
+            {
+                return protocol == SIPProtocolsEnum.wss;
+            }
+            else
+            {
+                return protocol == SIPProtocolsEnum.ws;
+            }
         }
 
         /// <summary>

--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -54,6 +54,30 @@ namespace SIPSorcery.SIP
         public const string NAT_SENDKEEPALIVES_VALUE = "y";
 
         public const string ALLOWED_SIP_METHODS = "ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, PRACK, REFER, REGISTER, SUBSCRIBE";
+
+        /// <summary>
+        /// Gets the default SIP port for the protocol. 
+        /// </summary>
+        /// <param name="protocol">The transport layer protocol to get the port for.</param>
+        /// <returns>The default port to use.</returns>
+        public static int GetDefaultPort(SIPProtocolsEnum protocol)
+        {
+            switch (protocol)
+            {
+                case SIPProtocolsEnum.udp:
+                    return SIPConstants.DEFAULT_SIP_PORT;
+                case SIPProtocolsEnum.tcp:
+                    return SIPConstants.DEFAULT_SIP_PORT;
+                case SIPProtocolsEnum.tls:
+                    return SIPConstants.DEFAULT_SIP_TLS_PORT;
+                case SIPProtocolsEnum.ws:
+                    return SIPConstants.DEFAULT_SIP_WEBSOCKET_PORT;
+                case SIPProtocolsEnum.wss:
+                    return SIPConstants.DEFAULT_SIPS_WEBSOCKET_PORT;
+                default:
+                    throw new ApplicationException($"Protocol {protocol} was not recognised in GetDefaultPort.");
+            }
+        }
     }
 
     public enum SIPMessageTypesEnum
@@ -421,6 +445,7 @@ namespace SIPSorcery.SIP
         public const string MWI_TEXT_TYPE = "text/text";
         public const string PRESENCE_NOTIFY_CONTENT_TYPE = "application/pidf+xml";      // RFC3856 presence event package.
     }
+
     /// <summary>
     /// For SIP URI user portion the reserved characters below need to be escaped.
     /// 

--- a/src/core/SIP/SIPEndPoint.cs
+++ b/src/core/SIP/SIPEndPoint.cs
@@ -35,9 +35,6 @@ namespace SIPSorcery.SIP
         private const string CHANNELID_ATTRIBUTE_NAME = "cid";
         private const string CONNECTIONID_ATTRIBUTE_NAME = "xid";
 
-        private static int m_defaultSIPPort = SIPConstants.DEFAULT_SIP_PORT;
-        private static int m_defaultSIPTLSPort = SIPConstants.DEFAULT_SIP_TLS_PORT;
-
         /// <summary>
         /// The scheme the SIP end point is using. Note that some schemes and protocols are mutually exclusive.
         /// For example sips cannot be sent over UDP.
@@ -97,7 +94,7 @@ namespace SIPSorcery.SIP
         {
             Protocol = protocol;
             Address = address;
-            Port = (port == 0) ? (Protocol == SIPProtocolsEnum.tls) ? m_defaultSIPTLSPort : m_defaultSIPPort : port;
+            Port = (port == 0) ? SIPConstants.GetDefaultPort(Protocol) : port;
             ChannelID = channelID;
             ConnectionID = connectionID;
         }
@@ -112,21 +109,21 @@ namespace SIPSorcery.SIP
             }
 
             Address = endPoint.Address;
-            Port = (endPoint.Port == 0) ? (Protocol == SIPProtocolsEnum.tls) ? m_defaultSIPTLSPort : m_defaultSIPPort : endPoint.Port;
+            Port = (endPoint.Port == 0) ? SIPConstants.GetDefaultPort(Protocol) : endPoint.Port;
         }
 
         public SIPEndPoint(SIPProtocolsEnum protocol, IPEndPoint endPoint)
         {
             Protocol = protocol;
             Address = endPoint.Address;
-            Port = (endPoint.Port == 0) ? (Protocol == SIPProtocolsEnum.tls) ? m_defaultSIPTLSPort : m_defaultSIPPort : endPoint.Port;
+            Port = (endPoint.Port == 0) ? SIPConstants.GetDefaultPort(Protocol) : endPoint.Port;
         }
 
         public SIPEndPoint(SIPProtocolsEnum protocol, IPEndPoint endPoint, string channelID, string connectionID)
         {
             Protocol = protocol;
             Address = endPoint.Address;
-            Port = (endPoint.Port == 0) ? (Protocol == SIPProtocolsEnum.tls) ? m_defaultSIPTLSPort : m_defaultSIPPort : endPoint.Port;
+            Port = (endPoint.Port == 0) ? SIPConstants.GetDefaultPort(Protocol) : endPoint.Port;
             ChannelID = channelID;
             ConnectionID = connectionID;
         }

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -1169,11 +1169,11 @@ namespace SIPSorcery.SIP
             {
                 throw new ApplicationException("The transport layer does not have any SIP channels.");
             }
-            else if (!m_sipChannels.Any(x => x.Value.SIPProtocol == protocol && x.Value.IsAddressFamilySupported(dst.Address.AddressFamily)))
+            else if (!m_sipChannels.Any(x => x.Value.IsProtocolSupported(protocol) && x.Value.IsAddressFamilySupported(dst.Address.AddressFamily)))
             {
                 throw new ApplicationException($"The transport layer does not have any SIP channels matching {protocol} and {dst.AddressFamily}.");
             }
-            else if (!String.IsNullOrEmpty(channelIDHint) && m_sipChannels.Any(x => x.Value.SIPProtocol == protocol && x.Key == channelIDHint))
+            else if (!String.IsNullOrEmpty(channelIDHint) && m_sipChannels.Any(x => x.Value.IsProtocolSupported(protocol) && x.Key == channelIDHint))
             {
                 return m_sipChannels[channelIDHint];
             }
@@ -1223,7 +1223,7 @@ namespace SIPSorcery.SIP
                 }
 
                 // Hard to see how we could get to here. Maybe some weird IPv6 edge case or a network interface has gone down. Just return the first channel.
-                return m_sipChannels.Where(x => x.Value.SIPProtocol == protocol && x.Value.IsAddressFamilySupported(dst.Address.AddressFamily))
+                return m_sipChannels.Where(x => x.Value.IsProtocolSupported(protocol) && x.Value.IsAddressFamilySupported(dst.Address.AddressFamily))
                     .Select(x => x.Value).First();
             }
         }
@@ -1237,10 +1237,10 @@ namespace SIPSorcery.SIP
         /// <returns>A SIP channel if a match is found or null if not.</returns>
         private SIPChannel GetSIPChannel(SIPProtocolsEnum protocol, IPAddress listeningAddress)
         {
-            if (m_sipChannels.Any(x => x.Value.SIPProtocol == protocol && listeningAddress.Equals(x.Value.ListeningIPAddress)))
+            if (m_sipChannels.Any(x => x.Value.IsProtocolSupported(protocol) && listeningAddress.Equals(x.Value.ListeningIPAddress)))
             {
                 return m_sipChannels.Where(x =>
-                             x.Value.SIPProtocol == protocol && listeningAddress.Equals(x.Value.ListeningIPAddress))
+                             x.Value.IsProtocolSupported(protocol) && listeningAddress.Equals(x.Value.ListeningIPAddress))
                            .Select(x => x.Value)
                            .First();
             }

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -1169,7 +1169,7 @@ namespace SIPSorcery.SIP
             {
                 throw new ApplicationException("The transport layer does not have any SIP channels.");
             }
-            else if (!m_sipChannels.Any(x => x.Value.SIPProtocol == protocol && x.Value.ListeningIPAddress.AddressFamily == dst.Address.AddressFamily))
+            else if (!m_sipChannels.Any(x => x.Value.SIPProtocol == protocol && x.Value.IsAddressFamilySupported(dst.Address.AddressFamily)))
             {
                 throw new ApplicationException($"The transport layer does not have any SIP channels matching {protocol} and {dst.AddressFamily}.");
             }
@@ -1223,7 +1223,7 @@ namespace SIPSorcery.SIP
                 }
 
                 // Hard to see how we could get to here. Maybe some weird IPv6 edge case or a network interface has gone down. Just return the first channel.
-                return m_sipChannels.Where(x => x.Value.SIPProtocol == protocol && dst.Address.AddressFamily == x.Value.AddressFamily)
+                return m_sipChannels.Where(x => x.Value.SIPProtocol == protocol && x.Value.IsAddressFamilySupported(dst.Address.AddressFamily))
                     .Select(x => x.Value).First();
             }
         }

--- a/src/core/SIP/SIPURI.cs
+++ b/src/core/SIP/SIPURI.cs
@@ -43,8 +43,6 @@ namespace SIPSorcery.SIP
 
         private static SIPProtocolsEnum m_defaultSIPTransport = SIPProtocolsEnum.udp;
         private static SIPSchemesEnum m_defaultSIPScheme = SIPSchemesEnum.sip;
-        private static int m_defaultSIPPort = SIPConstants.DEFAULT_SIP_PORT;
-        private static int m_defaultSIPTLSPort = SIPConstants.DEFAULT_SIP_TLS_PORT;
         private static string m_sipRegisterRemoveAll = SIPConstants.SIP_REGISTER_REMOVEALL;
         private static string m_uriParamTransportKey = SIPHeaderAncillary.SIP_HEADERANC_TRANSPORT;
 
@@ -126,7 +124,7 @@ namespace SIPSorcery.SIP
                 }
                 else
                 {
-                    canonicalAddress += Host + ":" + m_defaultSIPPort;
+                    canonicalAddress += Host + ":" + SIPConstants.GetDefaultPort(Protocol);
                 }
 
                 return canonicalAddress;
@@ -505,16 +503,8 @@ namespace SIPSorcery.SIP
                 }
                 else
                 {
-                    if (Protocol == SIPProtocolsEnum.tls)
-                    {
-                        ipEndPoint.Port = m_defaultSIPTLSPort;
-                        return new SIPEndPoint(Protocol, ipEndPoint);
-                    }
-                    else
-                    {
-                        ipEndPoint.Port = m_defaultSIPPort;
-                        return new SIPEndPoint(Protocol, ipEndPoint);
-                    }
+                    ipEndPoint.Port = SIPConstants.GetDefaultPort(Protocol);
+                    return new SIPEndPoint(Protocol, ipEndPoint);
                 }
             }
             else

--- a/src/net/RTP/RTPChannel.cs
+++ b/src/net/RTP/RTPChannel.cs
@@ -109,11 +109,17 @@ namespace SIPSorcery.Net
             }
             catch (SocketException sockExcp)
             {
-                // Pretty sure the only cause of these exceptions is when an ICMP message comes back indicating there is no listening
-                // socket on the other end. Now there may be cases where this is valid, for example we start sending before the other end
-                // starts listening. Bubble it up and let the caller deal with it.
-                logger.LogWarning($"SocketException UdpReceiver.EndReceiveMessageFrom ({sockExcp.ErrorCode}). {sockExcp.Message}");
-                OnReceiveError?.Invoke(sockExcp);
+                if (sockExcp.SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    logger.LogWarning("RTP connection closed by remote host.");
+                    OnReceiveError?.Invoke(sockExcp);
+                    Close();
+                }
+                else
+                {
+                    logger.LogWarning($"SocketException UdpReceiver.EndReceiveMessageFrom ({sockExcp.ErrorCode}). {sockExcp.Message}");
+                    OnReceiveError?.Invoke(sockExcp);
+                }
             }
             catch (ObjectDisposedException) // Thrown when socket is closed. Can be safely ignored.
             { }
@@ -176,56 +182,22 @@ namespace SIPSorcery.Net
         /// <summary>
         /// The local port we are listening for RTP (and whatever else is multiplexed) packets on.
         /// </summary>
-        public int RTPPort
-        {
-            get
-            {
-                if (_rtpSocket != null)
-                {
-                    return (_rtpSocket.LocalEndPoint as IPEndPoint).Port;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-        }
+        public int RTPPort { get; private set; }
 
         /// <summary>
         /// The local end point the RTP socket is listening on.
         /// </summary>
-        public IPEndPoint RTPLocalEndPoint
-        {
-            get
-            {
-                if (_rtpSocket != null)
-                {
-                    return (_rtpSocket.LocalEndPoint as IPEndPoint);
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+        public IPEndPoint RTPLocalEndPoint { get; private set; }
 
         /// <summary>
         /// The local port we are listening for RTCP packets on.
         /// </summary>
-        public int ControlPort
-        {
-            get
-            {
-                if (_controlSocket != null)
-                {
-                    return (_controlSocket.LocalEndPoint as IPEndPoint).Port;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-        }
+        public int ControlPort { get; private set; }
+
+        /// <summary>
+        /// The local end point the control socket is listening on.
+        /// </summary>
+        public IPEndPoint ControlLocalEndPoint { get; private set; }
 
         public DateTime CreatedAt { get; private set; }
         public DateTime StartedAt { get; private set; }
@@ -274,6 +246,11 @@ namespace SIPSorcery.Net
         {
             CreatedAt = DateTime.Now;
             NetServices.CreateRtpSocket(localAddress, mediaStartPort, mediaEndPort, createControlSocket, out _rtpSocket, out _controlSocket);
+
+            RTPLocalEndPoint = _rtpSocket.LocalEndPoint as IPEndPoint;
+            RTPPort = RTPLocalEndPoint.Port;
+            ControlLocalEndPoint = _controlSocket.LocalEndPoint as IPEndPoint;
+            ControlPort = ControlLocalEndPoint.Port;
 
             RemoteRTPEndPoint = rtpRemoteEndPoint;
             RemoteControlEndPoint = controlEndPoint;

--- a/src/net/RTP/RTPChannel.cs
+++ b/src/net/RTP/RTPChannel.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
 
@@ -53,7 +52,9 @@ namespace SIPSorcery.Net
             m_recvBuffer = new byte[RECEIVE_BUFFER_SIZE];
         }
 
-        //public Task<int> ReceiveAsync(DivideByZeroException[] buffer, int offset, int count, SocketFlags flags)
+        // ToDo: Supposedly the Event Asynchronous Pattern (EAP) can be turned into the Task Asynchronous Pattern (TAP)
+        // with one line. Couldn't make it work as yet.
+        //public Task<int> ReceiveAsync(byte[] buffer, int offset, int count, SocketFlags flags)
         //{
         //    return Task<int>.Factory.FromAsync(m_udpSocket.BeginReceive, m_udpSocket.EndReceive,
         //        buffer, offset, count, flags, null, TaskCreationOptions.None);
@@ -78,18 +79,6 @@ namespace SIPSorcery.Net
                 // case the sopcket can be considered to be unusable and there's no point trying another receive.
                 logger.LogError($"Exception UdpReceiver.Receive. {excp.Message}");
                 OnReceiveError?.Invoke(excp);
-            }
-        }
-
-        /// <summary>
-        /// Closes the socket and stops any new receives from being initiated.
-        /// </summary>
-        public void Close()
-        {
-            if (!m_isClosed)
-            {
-                m_isClosed = true;
-                m_udpSocket?.Close();
             }
         }
 
@@ -139,6 +128,18 @@ namespace SIPSorcery.Net
                 {
                     BeginReceive();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Closes the socket and stops any new receives from being initiated.
+        /// </summary>
+        public void Close()
+        {
+            if (!m_isClosed)
+            {
+                m_isClosed = true;
+                m_udpSocket?.Close();
             }
         }
     }

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -612,7 +612,7 @@ namespace SIPSorcery.Net
 
             var rtpPacket = new RTPPacket(buffer);
 
-            if (rtpPacket.Header.PayloadType == m_remoteRtpEventPayloadID)
+            if (m_remoteRtpEventPayloadID != 0 && rtpPacket.Header.PayloadType == m_remoteRtpEventPayloadID)
             {
                 RTPEvent rtpEvent = new RTPEvent(rtpPacket.Payload);
                 OnRtpEvent?.Invoke(rtpEvent);

--- a/test/Initialise.cs
+++ b/test/Initialise.cs
@@ -94,6 +94,11 @@ namespace SIPSorcery.UnitTests
             return true;
         }
 
+        public override bool IsProtocolSupported(SIPProtocolsEnum protocol)
+        {
+            return true;
+        }
+
         /// <summary>
         /// Use to cause a mock message to be passed through to the SIP Transport class monitoring this mock channel.
         /// </summary>

--- a/test/Initialise.cs
+++ b/test/Initialise.cs
@@ -53,17 +53,17 @@ namespace SIPSorcery.UnitTests
             ID = Crypto.GetRandomInt(5).ToString();
         }
 
-        public override void Send(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
+        public override void Send(SIPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<SocketError> SendAsync(IPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
+        public override Task<SocketError> SendAsync(SIPEndPoint destinationEndPoint, byte[] buffer, string connectionIDHint)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<SocketError> SendSecureAsync(IPEndPoint destinationEndPoint, byte[] buffer, string serverCertificate, string connectionIDHint)
+        public override Task<SocketError> SendSecureAsync(SIPEndPoint destinationEndPoint, byte[] buffer, string serverCertificate, string connectionIDHint)
         {
             throw new NotImplementedException();
         }
@@ -79,7 +79,7 @@ namespace SIPSorcery.UnitTests
             throw new NotImplementedException();
         }
 
-        public override bool HasConnection(IPEndPoint remoteEndPoint)
+        public override bool HasConnection(SIPEndPoint remoteEndPoint)
         {
             throw new NotImplementedException();
         }

--- a/test/Initialise.cs
+++ b/test/Initialise.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 using Serilog;
 using SIPSorcery.SIP;
 using SIPSorcery.Sys;
-using Xunit.Abstractions;
 
 namespace SIPSorcery.UnitTests
 {
@@ -60,11 +59,6 @@ namespace SIPSorcery.UnitTests
             throw new NotImplementedException();
         }
 
-        public override void SendSecure(IPEndPoint destinationEndPoint, byte[] buffer, string serverCertificate, string connectionIDHint)
-        {
-            throw new NotImplementedException();
-        }
-
         public override Task<SocketError> SendSecureAsync(IPEndPoint destinationEndPoint, byte[] buffer, string serverCertificate, string connectionIDHint)
         {
             throw new NotImplementedException();
@@ -84,6 +78,16 @@ namespace SIPSorcery.UnitTests
         public override bool HasConnection(IPEndPoint remoteEndPoint)
         {
             throw new NotImplementedException();
+        }
+
+        public override bool HasConnection(Uri serverUri)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool IsAddressFamilySupported(AddressFamily addresFamily)
+        {
+            return true;
         }
 
         /// <summary>

--- a/test/core/SIP/SIPTransportUnitTest.cs
+++ b/test/core/SIP/SIPTransportUnitTest.cs
@@ -4,10 +4,10 @@
 // Description: Unit tests for the SIPTransport class.
 //
 // Author(s):
-// Aaron Clauson
+// Aaron Clauson (aaron@sipsorcery.com)
 // 
 // History:
-// 15 Oct 2019	Aaron Clauson	Created (aaron@sipsorcery.com), SIP Sorcery PTY LTD, Dublin, Ireland (www.sipsorcery.com).
+// 15 Oct 2019	Aaron Clauson	Created, Dublin, Ireland.
 //
 // License: 
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -23,7 +23,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SIPSorcery.SIP.UnitTests
 {
@@ -57,7 +56,12 @@ namespace SIPSorcery.SIP.UnitTests
             var clientChannel = new SIPUDPChannel(IPAddress.IPv6Loopback, 0);
 
             var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); });
-            var clientTask = Task.Run(async () => { await RunClient(clientChannel, serverChannel.GetContactURI(SIPSchemesEnum.sip, IPAddress.IPv6Loopback), testComplete, cancelServer, serverReadyEvent); });
+            var clientTask = Task.Run(async () => { await RunClient(
+                clientChannel, 
+                serverChannel.GetContactURI(SIPSchemesEnum.sip, new SIPEndPoint(SIPProtocolsEnum.udp, new IPEndPoint(IPAddress.IPv6Loopback, 0))), 
+                testComplete, 
+                cancelServer, 
+                serverReadyEvent); });
 
             serverReadyEvent.Wait(); 
             if (!Task.WhenAny(new Task[] { serverTask, clientTask}).Wait(TRANSPORT_TEST_TIMEOUT))
@@ -93,7 +97,12 @@ namespace SIPSorcery.SIP.UnitTests
             var clientChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
 
             var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); });
-            var clientTask = Task.Run(async () => { await RunClient(clientChannel, serverChannel.GetContactURI(SIPSchemesEnum.sip, IPAddress.Loopback), testComplete, cancelServer, serverReadyEvent); });
+            var clientTask = Task.Run(async () => { await RunClient(
+                clientChannel, 
+                serverChannel.GetContactURI(SIPSchemesEnum.sip, new SIPEndPoint(SIPProtocolsEnum.udp, new IPEndPoint(IPAddress.Loopback, 0))), 
+                testComplete, 
+                cancelServer, 
+                serverReadyEvent); });
 
             serverReadyEvent.Wait(); 
             if (!Task.WhenAny(new Task[] { serverTask, clientTask }).Wait(TRANSPORT_TEST_TIMEOUT))
@@ -133,7 +142,12 @@ namespace SIPSorcery.SIP.UnitTests
             clientChannel.DisableLocalTCPSocketsCheck = true;
 
             var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); });
-            var clientTask = Task.Run(async () => { await RunClient(clientChannel, serverChannel.GetContactURI(SIPSchemesEnum.sip, IPAddress.IPv6Loopback), testComplete, cancelServer, serverReadyEvent); });
+            var clientTask = Task.Run(async () => { await RunClient(
+                clientChannel, 
+                serverChannel.GetContactURI(SIPSchemesEnum.sip, new SIPEndPoint(SIPProtocolsEnum.tcp, new IPEndPoint(IPAddress.IPv6Loopback, 0))), 
+                testComplete, 
+                cancelServer, 
+                serverReadyEvent); });
 
             serverReadyEvent.Wait(); 
             if (!Task.WhenAny(new Task[] { serverTask, clientTask}).Wait(TRANSPORT_TEST_TIMEOUT))
@@ -171,7 +185,12 @@ namespace SIPSorcery.SIP.UnitTests
             clientChannel.DisableLocalTCPSocketsCheck = true;
 
             Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); });
-            var clientTask = Task.Run(async () => { await RunClient(clientChannel, serverChannel.GetContactURI(SIPSchemesEnum.sip, IPAddress.Loopback), testComplete, cancelServer, serverReadyEvent); });
+            var clientTask = Task.Run(async () => { await RunClient(
+                clientChannel, 
+                serverChannel.GetContactURI(SIPSchemesEnum.sip, new SIPEndPoint(SIPProtocolsEnum.tcp, new IPEndPoint(IPAddress.Loopback, 0))), 
+                testComplete, 
+                cancelServer, 
+                serverReadyEvent); });
 
             serverReadyEvent.Wait(); 
             if (!Task.WhenAny(new Task[] { clientTask }).Wait(TRANSPORT_TEST_TIMEOUT))
@@ -221,7 +240,7 @@ namespace SIPSorcery.SIP.UnitTests
 
                     var clientChannel = new SIPTCPChannel(IPAddress.Loopback, 0);
                     clientChannel.DisableLocalTCPSocketsCheck = true;
-                    SIPURI serverUri = serverChannel.GetContactURI(SIPSchemesEnum.sip, IPAddress.Loopback);
+                    SIPURI serverUri = serverChannel.GetContactURI(SIPSchemesEnum.sip, new SIPEndPoint(SIPProtocolsEnum.tcp, new IPEndPoint(IPAddress.Loopback, 0)));
 
                     logger.LogDebug($"Server URI {serverUri.ToString()}.");
 
@@ -276,7 +295,12 @@ namespace SIPSorcery.SIP.UnitTests
             clientChannel.DisableLocalTCPSocketsCheck = true;
 
             var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); });
-            var clientTask = Task.Run(async () => { await RunClient(clientChannel, serverChannel.GetContactURI(SIPSchemesEnum.sips, IPAddress.IPv6Loopback), testComplete, cancelServer, serverReadyEvent); });
+            var clientTask = Task.Run(async () => { await RunClient(
+                clientChannel, 
+                serverChannel.GetContactURI(SIPSchemesEnum.sips, new SIPEndPoint(SIPProtocolsEnum.tls, new IPEndPoint(IPAddress.IPv6Loopback, 0))), 
+                testComplete, 
+                cancelServer, 
+                serverReadyEvent); });
 
             serverReadyEvent.Wait(); 
             if (!Task.WhenAny(new Task[] { serverTask, clientTask }).Wait(TRANSPORT_TEST_TIMEOUT))
@@ -320,7 +344,12 @@ namespace SIPSorcery.SIP.UnitTests
             clientChannel.DisableLocalTCPSocketsCheck = true;
 
             var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); });
-            var clientTask = Task.Run(async () => { await RunClient(clientChannel, serverChannel.GetContactURI(SIPSchemesEnum.sips, IPAddress.Loopback), testComplete, cancelServer, serverReadyEvent); });
+            var clientTask = Task.Run(async () => { await RunClient(
+                clientChannel, 
+                serverChannel.GetContactURI(SIPSchemesEnum.sips, new SIPEndPoint(SIPProtocolsEnum.tls, new IPEndPoint(IPAddress.Loopback, 0))), 
+                testComplete, 
+                cancelServer, 
+                serverReadyEvent); });
 
             serverReadyEvent.Wait();
             if(!Task.WhenAny(new Task[] { serverTask, clientTask }).Wait(TRANSPORT_TEST_TIMEOUT))


### PR DESCRIPTION
As requested in #115.

Also adds a new option to the SIP transport class to create missing channels on demand. Saves potentially having to manually create a dozen different channels for client scenarios.