### PR TITLE
Extends the TAP (async/await) approach to the SIP Transaction classes

### DIFF
--- a/examples/UserAgentClient/Program.cs
+++ b/examples/UserAgentClient/Program.cs
@@ -174,6 +174,7 @@ namespace SIPSorcery
                 null);
 
             uac.Call(callDescriptor);
+            uac.ServerTransaction.TransactionTraceMessage += (tx, msg) => Log.LogInformation($"UAC tx trace message. {msg}");
 
             // Ctrl-c will gracefully exit the call at any point.
             Console.CancelKeyPress += delegate (object sender, ConsoleCancelEventArgs e)

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -549,7 +549,7 @@ namespace SIPSorcery.SIP.App
             }
         }
 
-        private void ServerFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> ServerFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
             try
             {
@@ -745,14 +745,17 @@ namespace SIPSorcery.SIP.App
 
                     CallAnswered?.Invoke(this, sipResponse);
                 }
+
+                return Task.FromResult(SocketError.Success);
             }
             catch (Exception excp)
             {
                 Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.Error, "Exception ServerFinalResponseReceived. " + excp.Message, Owner));
+                return Task.FromResult(SocketError.Fault);
             }
         }
 
-        private void ServerInformationResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> ServerInformationResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
             Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Information response " + sipResponse.StatusCode + " " + sipResponse.ReasonPhrase + " for " + m_serverTransaction.TransactionRequest.URI.ToString() + ".", Owner));
 
@@ -772,6 +775,8 @@ namespace SIPSorcery.SIP.App
                     CallTrying?.Invoke(this, sipResponse);
                 }
             }
+
+            return Task.FromResult(SocketError.Success);
         }
 
         private void ServerTimedOut(SIPTransaction sipTransaction)
@@ -782,7 +787,7 @@ namespace SIPSorcery.SIP.App
             }
         }
 
-        private void ByeServerFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> ByeServerFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
             try
             {
@@ -807,11 +812,13 @@ namespace SIPSorcery.SIP.App
                     authByeTransaction.NonInviteTransactionTimedOut += (tx) => logger.LogDebug($"Authenticated Bye request for {m_sipCallDescriptor.Uri} timed out.");
                     authByeTransaction.SendRequest();
                 }
+
+                return Task.FromResult(SocketError.Success);
             }
-            catch (Exception exception)
+            catch (Exception excp)
             {
-                Exception excp = exception;
                 Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.Error, string.Concat("Exception ByServerFinalResponseReceived. ", excp.Message), this.Owner));
+                return Task.FromResult(SocketError.Fault);
             }
         }
 

--- a/src/app/SIPUserAgents/SIPNotifierClient.cs
+++ b/src/app/SIPUserAgents/SIPNotifierClient.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -291,7 +292,7 @@ namespace SIPSorcery.SIP.App
             m_waitForSubscribeResponse.Set();
         }
 
-        private void SubscribeTransactionFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> SubscribeTransactionFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
             try
             {
@@ -391,12 +392,16 @@ namespace SIPSorcery.SIP.App
                     SubscriptionFailed(m_resourceURI, sipResponse.Status, "Subscribe failed with response " + sipResponse.StatusCode + " " + sipResponse.ReasonPhrase + ".");
                     m_waitForSubscribeResponse.Set();
                 }
+
+                return Task.FromResult(SocketError.Success);
             }
             catch (Exception excp)
             {
                 logger.LogError("Exception SubscribeTransactionFinalResponseReceived. " + excp.Message);
                 SubscriptionFailed(m_resourceURI, SIPResponseStatusCodesEnum.InternalServerError, "Exception processing subscribe response. " + excp.Message);
                 m_waitForSubscribeResponse.Set();
+
+                return Task.FromResult(SocketError.Fault);
             }
         }
     }

--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -18,7 +18,9 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
 
@@ -279,7 +281,7 @@ namespace SIPSorcery.SIP.App
 
                         SIPNonInviteTransaction regTransaction = new SIPNonInviteTransaction(m_sipTransport, regRequest, m_outboundProxy);
                         // These handlers need to be on their own threads to take the processing off the SIP transport layer.
-                        regTransaction.NonInviteTransactionFinalResponseReceived += (lep, rep, tn, rsp) => { ThreadPool.QueueUserWorkItem(delegate { ServerResponseReceived(lep, rep, tn, rsp); }); };
+                        regTransaction.NonInviteTransactionFinalResponseReceived += (lep, rep, tn, rsp) => { ThreadPool.QueueUserWorkItem(delegate { ServerResponseReceived(lep, rep, tn, rsp); }); return Task.FromResult(SocketError.Success); };
                         regTransaction.NonInviteTransactionTimedOut += (tn) => { ThreadPool.QueueUserWorkItem(delegate { RegistrationTimedOut(tn); }); };
 
                         m_sipTransport.SendTransaction(regTransaction);
@@ -325,7 +327,7 @@ namespace SIPSorcery.SIP.App
                             m_attempts++;
                             SIPRequest authenticatedRequest = GetAuthenticatedRegistrationRequest(sipTransaction.TransactionRequest, sipResponse);
                             SIPNonInviteTransaction regAuthTransaction = new SIPNonInviteTransaction(m_sipTransport, authenticatedRequest, m_outboundProxy);
-                            regAuthTransaction.NonInviteTransactionFinalResponseReceived += (lep, rep, tn, rsp) => { ThreadPool.QueueUserWorkItem(delegate { AuthResponseReceived(lep, rep, tn, rsp); }); };
+                            regAuthTransaction.NonInviteTransactionFinalResponseReceived += (lep, rep, tn, rsp) => { ThreadPool.QueueUserWorkItem(delegate { AuthResponseReceived(lep, rep, tn, rsp); }); return Task.FromResult(SocketError.Success); };
                             regAuthTransaction.NonInviteTransactionTimedOut += (tn) => { ThreadPool.QueueUserWorkItem(delegate { RegistrationTimedOut(tn); }); };
                             m_sipTransport.SendTransaction(regAuthTransaction);
                         }

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -453,6 +453,8 @@ namespace SIPSorcery.SIP.App
                             transferAccepted.SetResult(false);
                         }
                     });
+
+                    return Task.FromResult(SocketError.Success);
                 };
 
                 referTx.NonInviteTransactionFinalResponseReceived += referTxStatusHandler;
@@ -564,7 +566,7 @@ namespace SIPSorcery.SIP.App
                     {
                         // The application is going to handle the re-INVITE request. We'll send a Trying response as a precursor.
                         SIPResponse tryingResponse = SIPResponse.GetResponse(sipRequest, SIPResponseStatusCodesEnum.Trying, null);
-                        reInviteTransaction.SendProvisionalResponse(tryingResponse);
+                        await reInviteTransaction.SendProvisionalResponse(tryingResponse);
                         OnReinviteRequest(reInviteTransaction);
                     }
                 }
@@ -687,7 +689,7 @@ namespace SIPSorcery.SIP.App
         /// <param name="remoteEndPoint">The remote end point the response came from.</param>
         /// <param name="sipTransaction">The UAS transaction the response is part of.</param>
         /// <param name="sipResponse">The SIP response.</param>
-        private void ReinviteRequestFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> ReinviteRequestFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
             if (sipResponse.Status == SIPResponseStatusCodesEnum.Ok)
             {
@@ -698,6 +700,8 @@ namespace SIPSorcery.SIP.App
             {
                 logger.LogWarning($"Re-INVITE request failed with response {sipResponse.ShortDescription}.");
             }
+
+            return Task.FromResult(SocketError.Success);
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPTCPChannel.cs
+++ b/src/core/SIP/Channels/SIPTCPChannel.cs
@@ -84,12 +84,6 @@ namespace SIPSorcery.SIP
         public bool DisableLocalTCPSocketsCheck;
 
         /// <summary>
-        /// If set to true this channel accepts new client connections, i.e. it is listening and acting as a server.
-        /// If false the channel is being used to house outgoing connections only, no incoming clients accepted.
-        /// </summary>
-        public bool IsOutboundOnly { get; private set; } = false;
-
-        /// <summary>
         /// Keeps a list of TCP sockets this process is listening on to prevent it establishing TCP connections to itself.
         /// </summary>
         private static List<string> m_localTCPSockets = new List<string>();
@@ -126,23 +120,6 @@ namespace SIPSorcery.SIP
         public SIPTCPChannel(IPAddress listenAddress, int listenPort)
             : this(new IPEndPoint(listenAddress, listenPort), SIPProtocolsEnum.tcp)
         { }
-
-        /// <summary>
-        /// Creates a client only channel, no incoming connections accepted. This is useful for certain SIP client scenarios
-        /// where all communications are expected to be initiated from our end.
-        /// </summary>
-        /// <param name="addressFamily">Whether to connect to IPv4 or IPv6 servers.</param>
-        /// <param name="protocol">The channel protocol, can be TCP or TLS.</param>
-        public SIPTCPChannel(AddressFamily addressFamily, SIPProtocolsEnum protocol)
-        {
-            ListeningIPAddress = (addressFamily == AddressFamily.InterNetworkV6) ? IPAddress.IPv6Any : IPAddress.Any;
-            Port = 0;
-            SIPProtocol = protocol;
-            IsReliable = true;
-
-            // Set the flag so the application knows we are a client only channel.
-            IsOutboundOnly = false;
-        }
 
         /// <summary>
         /// Initialises the SIP channel's socket listener.

--- a/src/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/core/SIP/Channels/SIPTLSChannel.cs
@@ -62,16 +62,6 @@ namespace SIPSorcery.SIP
         { }
 
         /// <summary>
-        /// Creates a client only channel, no incoming connections accepted. This is useful for certain SIP client scenarios
-        /// where all communications are expected to be initiated from our end.
-        /// </summary>
-        /// <param name="addressFamily">Whether to connect to IPv4 or IPv6 servers.</param>
-        public SIPTLSChannel(AddressFamily addressFamily) : base(addressFamily, SIPProtocolsEnum.tls)
-        {
-            IsSecure = true;
-        }
-
-        /// <summary>
         /// For the TLS channel the SSL stream must be created and any authentication actions undertaken.
         /// </summary>
         /// <param name="streamConnection">The stream connection holding the newly accepted client socket.</param>

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -781,6 +781,7 @@ namespace SIPSorcery.SIP
                                         }
                                         else
                                         {
+                                            // TODO: Where does this exception end up?
                                             SIPTransportResponseReceived?.Invoke(localEndPoint, remoteEndPoint, sipResponse);
                                         }
                                     }

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -1070,11 +1070,12 @@ namespace SIPSorcery.SIP
             switch (protocol)
             {
                 case SIPProtocolsEnum.tcp:
-                    sipChannel = new SIPTCPChannel(addressFamily, SIPProtocolsEnum.tcp);
+                    sipChannel = new SIPTCPChannel(new IPEndPoint(localAddress, 0));
                     break;
-                case SIPProtocolsEnum.tls:
-                    sipChannel = new SIPTLSChannel(addressFamily);
-                    break;
+                //case SIPProtocolsEnum.tls:
+                    // TODO: Workout how to generate a random certificate.
+                    //sipChannel = new SIPTLSChannel(randomCertificate, new IPEndPoint(localAddress, 0));
+                //    break;
                 case SIPProtocolsEnum.udp:
                     sipChannel = new SIPUDPChannel(new IPEndPoint(localAddress, 0));
                     break;

--- a/src/core/SIPFunctionDelegates.cs
+++ b/src/core/SIPFunctionDelegates.cs
@@ -15,6 +15,7 @@
 // ============================================================================
 
 using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace SIPSorcery.SIP
@@ -36,8 +37,8 @@ namespace SIPSorcery.SIP
 
     // SIP Transaction delegates.
     public delegate void SIPTransactionStateChangeDelegate(SIPTransaction sipTransaction);
-    public delegate void SIPTransactionResponseReceivedDelegate(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse);
-    public delegate void SIPTransactionRequestReceivedDelegate(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPRequest sipRequest);
+    public delegate Task<SocketError> SIPTransactionResponseReceivedDelegate(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse);
+    public delegate Task<SocketError> SIPTransactionRequestReceivedDelegate(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPRequest sipRequest);
     public delegate void SIPTransactionCancelledDelegate(SIPTransaction sipTransaction);
     public delegate void SIPTransactionTimedOutDelegate(SIPTransaction sipTransaction);
     public delegate void SIPTransactionRequestRetransmitDelegate(SIPTransaction sipTransaction, SIPRequest sipRequest, int retransmitNumber);

--- a/src/core/SIPTransactions/SIPNonInviteTransaction.cs
+++ b/src/core/SIPTransactions/SIPNonInviteTransaction.cs
@@ -13,6 +13,9 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
 namespace SIPSorcery.SIP
 {
     public class SIPNonInviteTransaction : SIPTransaction
@@ -49,19 +52,19 @@ namespace SIPSorcery.SIP
             NonInviteTransactionTimedOut?.Invoke(this);
         }
 
-        private void SIPNonInviteTransaction_TransactionRequestReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPRequest sipRequest)
+        private Task<SocketError> SIPNonInviteTransaction_TransactionRequestReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPRequest sipRequest)
         {
-            NonInviteRequestReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipRequest);
+            return NonInviteRequestReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipRequest);
         }
 
-        private void SIPNonInviteTransaction_TransactionInformationResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> SIPNonInviteTransaction_TransactionInformationResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
-            NonInviteTransactionInfoResponseReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipResponse);
+            return NonInviteTransactionInfoResponseReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipResponse);
         }
 
-        private void SIPNonInviteTransaction_TransactionFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
+        private Task<SocketError> SIPNonInviteTransaction_TransactionFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
-            NonInviteTransactionFinalResponseReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipResponse);
+            return NonInviteTransactionFinalResponseReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipResponse);
         }
 
         private void SIPNonInviteTransaction_TransactionRequestRetransmit(SIPTransaction sipTransaction, SIPRequest sipRequest, int retransmitNumber)

--- a/src/net/RTCP/RTCPReportPacket.cs
+++ b/src/net/RTCP/RTCPReportPacket.cs
@@ -1,6 +1,8 @@
 //-----------------------------------------------------------------------------
 // Filename: RTCPReportPacket.cs
 //
+// Description:
+//
 //      Custom RTCP Report Packet
 //        0                   1                   2                   3
 //        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -11,10 +13,10 @@
 //       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
 //
 // Author(s):
-// Aaron Clauson
+// Aaron Clauson (aaron@sipsorcery.com)
 //  
 // History:
-// 23 Feb 2007	Aaron Clauson	Created  (aaron@sipsorcery.com), Montreux, Switzerland (www.sipsorcery.com)
+// 23 Feb 2007	Aaron Clauson	Created, Hobart, Australia.
 // 11 Aug 2019  Aaron Clauson   Added full license header.
 //
 // License: 

--- a/src/net/RTCP/RTCPSenderReport.cs
+++ b/src/net/RTCP/RTCPSenderReport.cs
@@ -1,6 +1,8 @@
 //-----------------------------------------------------------------------------
 // Filename: RTCPSenderReport.cs
 //
+// Description:
+//
 //        RTCP Snder Report Payload
 //        0                   1                   2                   3
 //        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -19,10 +21,10 @@
 //        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
 //
 // Author(s):
-// Aaron Clauson
+// Aaron Clauson (aaron@sipsorcery.com)
 // 
 // History:
-// 12 Aug 2019  Aaron Clauson   Created (aaron@sipsorcery.com), Montreux, Switzerland (www.sipsorcery.com).
+// 12 Aug 2019  Aaron Clauson   Created, Montreux, Switzerland.
 //
 // License: 
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -710,29 +710,5 @@ namespace SIPSorcery.Net
 
             return rtpJpegHeader;
         }
-
-        #region Obsolete methods.
-
-        /// <summary>
-        /// Processes received RTP packets.
-        /// </summary>
-        /// <param name="buffer">The raw data received on the RTP socket.</param>
-        /// <param name="offset">Offset in the buffer that the received data starts from.</param>
-        /// <param name="count">The number of bytes received.</param>
-        /// <param name="remoteEndPoint">The remote end point the receive was from.</param>
-        /// <returns>An RTP packet.</returns>
-        [Obsolete("Use alternative receive method", true)]
-        public RTPPacket RtpReceive(byte[] buffer, int offset, int count, IPEndPoint remoteEndPoint)
-        {
-            if (m_lastReceiveFromEndPoint == null || !m_lastReceiveFromEndPoint.Equals(remoteEndPoint))
-            {
-                OnReceiveFromEndPointChanged?.Invoke(m_lastReceiveFromEndPoint, remoteEndPoint);
-                m_lastReceiveFromEndPoint = remoteEndPoint;
-            }
-
-            return new RTPPacket(buffer.Skip(offset).Take(count).ToArray());
-        }
-
-        #endregion
     }
 }

--- a/src/sys/Net/NetServices.cs
+++ b/src/sys/Net/NetServices.cs
@@ -81,7 +81,6 @@ namespace SIPSorcery.Sys
                 {
                     controlPort = rtpPort + 1;
                 }
-                //}
 
                 if (rtpPort != 0)
                 {

--- a/test/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
+++ b/test/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
@@ -9,15 +9,13 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using SIPSorcery.Sys;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SIPSorcery.SIP.UnitTests
 {
@@ -129,6 +127,7 @@ namespace SIPSorcery.SIP.UnitTests
                         logger.LogDebug("Server new call received.");
                         var busyResponse = SIPResponse.GetResponse(newCallRequest, SIPResponseStatusCodesEnum.BusyHere, null);
                         (sipTransaction as UASInviteTransaction).SendFinalResponse(busyResponse);
+                        return Task.FromResult(SocketError.Success);
                     };
                     serverTransaction.TransactionStateChanged += (tx) =>
                     {


### PR DESCRIPTION
Prior to this all send/receives from transaction classes were directed to the `SendReliable` method which are then picked up and actioned by the dedicated thread in the transaction engine.

While this approach works it is not responsive enough in certain cases, specifically sending `100 Trying` responses to `INVITE` requests and sending `ACK` requests for `INVITE` responses. The consequence of the slower is retransmits of the request or response from the remote party. Again while this is not an issue it is not ideal and pollutes diagnostic SIP traces and such.

This PR allows specific actions from the SIP transaction classes to go straight to the transport layer without needing to be handled by the separate transaction engine thread.