### PR TITLE
Incorrect DNS TTL caching behavior of OPT EDNS0 RR

### DIFF
--- a/src/net/DNS/Resolver.cs
+++ b/src/net/DNS/Resolver.cs
@@ -394,6 +394,11 @@ namespace Heijden.DNS
             //logger.LogDebug("Seconds lived=" + secondsLived + ".");
             foreach (RR rr in response.RecordsRR)
             {
+                if (rr.Type == DnsType.OPT)
+                {
+                    continue;
+                }
+
                 rr.TimeLived = TimeLived;
                 // The TTL property calculates its actual time to live
                 if (secondsLived > MIN_CACHE_SECONDS && secondsLived >= rr.TTL)


### PR DESCRIPTION
This is not directly a bug but in my setup, it is causing issues.

The issue is that my DNS queries come back with an additional OPT pseudo-RR even thought from what it looks like we aren't asking it to. Which causes all DNS queries to never be cached and also it returns null when asked for a lookup.

As per https://en.wikipedia.org/wiki/Extension_mechanisms_for_DNS

> EDNS introduces a single pseudo-RR type: OPT.
>
> As pseudo-RRs, OPT type RRs never appear in any zone file; they exist only in messages, fabricated by the DNS participants.
>
> The mechanism is backward compatible, because older DNS responders ignore any RR of the unknown OPT type in a request and a newer DNS responder never includes an OPT in a response unless there was one in the request. The presence of the OPT in the request signifies a newer requester that knows what to do with an OPT in the response.



Also, see https://github.com/DNSCrypt/dnscrypt-proxy/issues/527