### PR TITLE
Issue 182 - Fix performance hot spots on sip-txengine thread

### DIFF
--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -305,7 +305,7 @@ namespace SIPSorcery.SIP
             {
                 while (!m_isClosed)
                 {
-                    if (m_pendingTransactions.Count == 0)
+                    if (m_pendingTransactions.IsEmpty)
                     {
                         Task.Delay(MAX_TXCHECK_WAIT_MILLISECONDS).Wait();
                     }

--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -307,7 +307,7 @@ namespace SIPSorcery.SIP
                 {
                     if (m_pendingTransactions.IsEmpty)
                     {
-                        Task.Delay(MAX_TXCHECK_WAIT_MILLISECONDS).Wait();
+                        Thread.Sleep(MAX_TXCHECK_WAIT_MILLISECONDS);
                     }
                     else
                     {
@@ -474,7 +474,7 @@ namespace SIPSorcery.SIP
 
                         RemoveExpiredTransactions();
 
-                       Task.Delay(TXCHECK_WAIT_MILLISECONDS).Wait();
+                       Thread.Sleep(TXCHECK_WAIT_MILLISECONDS);
                     }
                 }
             }

--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -493,13 +493,13 @@ namespace SIPSorcery.SIP
         /// <returns>The result of the send attempt.</returns>
         private Task<SocketError> SendTransactionProvisionalResponse(SIPTransaction transaction)
         {
-            if (transaction.InitialTransmit == DateTime.MinValue)
-            {
-                transaction.InitialTransmit = DateTime.Now;
-            }
-
             transaction.Retransmits = transaction.Retransmits + 1;
             transaction.LastTransmit = DateTime.Now;
+
+            if (transaction.InitialTransmit == DateTime.MinValue)
+            {
+                transaction.InitialTransmit = transaction.LastTransmit;
+            }
 
             // Provisional response reliable for INVITE-UAS.
             if (transaction.Retransmits > 1)
@@ -518,13 +518,13 @@ namespace SIPSorcery.SIP
         /// <returns>The result of the send attempt.</returns>
         private Task<SocketError> SendTransactionFinalResponse(SIPTransaction transaction)
         {
-            if (transaction.InitialTransmit == DateTime.MinValue)
-            {
-                transaction.InitialTransmit = DateTime.Now;
-            }
-
             transaction.Retransmits = transaction.Retransmits + 1;
             transaction.LastTransmit = DateTime.Now;
+
+            if (transaction.InitialTransmit == DateTime.MinValue)
+            {
+                transaction.InitialTransmit = transaction.LastTransmit;
+            }
 
             if (transaction.Retransmits > 1)
             {
@@ -543,13 +543,13 @@ namespace SIPSorcery.SIP
         {
             Task<SocketError> result = null;
 
-            if (transaction.InitialTransmit == DateTime.MinValue)
-            {
-                transaction.InitialTransmit = DateTime.Now;
-            }
-
             transaction.Retransmits = transaction.Retransmits + 1;
             transaction.LastTransmit = DateTime.Now;
+
+            if (transaction.InitialTransmit == DateTime.MinValue)
+            {
+                transaction.InitialTransmit = transaction.LastTransmit;
+            }
 
             // INVITE-UAC and no-INVITE transaction types, send request reliably.
             if (transaction.Retransmits > 1)

--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -140,7 +140,7 @@ namespace SIPSorcery.SIP
                     {
                         //logger.LogDebug("Looking for ACK transaction, branchid=" + sipRequest.Header.Via.TopViaHeader.Branch + ".");
 
-                        foreach (SIPTransaction transaction in m_pendingTransactions.Values)
+                        foreach (var (_, transaction) in m_pendingTransactions)
                         {
                             // According to the standard an ACK should only not get matched by the branchid on the original INVITE for a non-2xx response. However
                             // my Cisco phone created a new branchid on ACKs to 487 responses and since the Cisco also used the same Call-ID and From tag on the initial
@@ -184,7 +184,7 @@ namespace SIPSorcery.SIP
                     }
                     else if (sipRequest.Method == SIPMethodsEnum.PRACK)
                     {
-                        foreach (SIPTransaction transaction in m_pendingTransactions.Values)
+                        foreach (var (_, transaction) in m_pendingTransactions)
                         {
                             if (transaction.TransactionType == SIPTransactionTypesEnum.InviteServer)
                             {
@@ -232,7 +232,7 @@ namespace SIPSorcery.SIP
         {
             logger.LogDebug("=== Pending Transactions ===");
 
-            foreach (SIPTransaction transaction in m_pendingTransactions.Values)
+            foreach (var (_, transaction) in m_pendingTransactions)
             {
                 logger.LogDebug("Pending transaction " + transaction.TransactionRequest.Method + " " + transaction.TransactionState + " " + DateTime.Now.Subtract(transaction.Created).TotalSeconds.ToString("0.##") + "s " + transaction.TransactionRequestURI.ToString() + " (" + transaction.TransactionId + ").");
             }
@@ -271,7 +271,7 @@ namespace SIPSorcery.SIP
 
             lock (m_pendingTransactions)
             {
-                foreach (SIPTransaction transaction in m_pendingTransactions.Values)
+                foreach (var (_, transaction) in m_pendingTransactions)
                 {
                     if ((transaction.TransactionType == SIPTransactionTypesEnum.InviteClient || transaction.TransactionType == SIPTransactionTypesEnum.InviteServer) &&
                         transaction.TransactionFinalResponse != null &&
@@ -311,7 +311,7 @@ namespace SIPSorcery.SIP
                     }
                     else
                     {
-                        foreach (SIPTransaction transaction in m_pendingTransactions.Values.Where(x => x.DeliveryPending))
+                        foreach (var (_, transaction) in m_pendingTransactions.Where(x => x.Value.DeliveryPending))
                         {
                             try
                             {
@@ -578,7 +578,7 @@ namespace SIPSorcery.SIP
             {
                 List<string> expiredTransactionIds = new List<string>();
 
-                foreach (SIPTransaction transaction in m_pendingTransactions.Values)
+                foreach (var (_, transaction) in m_pendingTransactions)
                 {
                     if (transaction.TransactionType == SIPTransactionTypesEnum.InviteClient || transaction.TransactionType == SIPTransactionTypesEnum.InviteServer)
                     {

--- a/src/sys/TypeExtensions.cs
+++ b/src/sys/TypeExtensions.cs
@@ -159,5 +159,13 @@ namespace SIPSorcery.Sys
             }
             return buffer.ToArray();
         }
+
+#if NET46 || NETSTANDARD2_0
+        public static void Deconstruct<T1, T2>(this KeyValuePair<T1, T2> tuple, out T1 key, out T2 value)
+        {
+            key = tuple.Key;
+            value = tuple.Value;
+        }
+#endif
     }
 }


### PR DESCRIPTION
This PR attempts to reduce the amount of CPU used by `SIPTransactionEngine.ProcessPendingTransactions()`.  In my local test runs, these changes improved the performance noticeably.  See Issue #182 for a more thorough description of the intent.