### PR TITLE
Extend SIPCallFailedDelegate

### DIFF
--- a/examples/SIPCallServer/Program.cs
+++ b/examples/SIPCallServer/Program.cs
@@ -148,7 +148,7 @@ namespace SIPSorcery
                         var ua = new SIPUserAgent(_sipTransport, null);
                         ua.ClientCallTrying += (uac, resp) => Log.LogInformation($"{uac.CallDescriptor.To} Trying: {resp.StatusCode} {resp.ReasonPhrase}.");
                         ua.ClientCallRinging += (uac, resp) => Log.LogInformation($"{uac.CallDescriptor.To} Ringing: {resp.StatusCode} {resp.ReasonPhrase}.");
-                        ua.ClientCallFailed += (uac, err) => Log.LogWarning($"{uac.CallDescriptor.To} Failed: {err}");
+                        ua.ClientCallFailed += (uac, err, resp) => Log.LogWarning($"{uac.CallDescriptor.To} Failed: {err}, Status code: {resp?.StatusCode}");
                         ua.ClientCallAnswered += (uac, resp) => Log.LogInformation($"{uac.CallDescriptor.To} Answered: {resp.StatusCode} {resp.ReasonPhrase}.");
                         ua.OnDtmfTone += (key, duration) => OnDtmfTone(ua, key, duration);
                         ua.OnRtpEvent += (evt, hdr) => Log.LogDebug($"rtp event {evt.EventID}, duration {evt.Duration}, end of event {evt.EndOfEvent}, timestamp {hdr.Timestamp}, marker {hdr.MarkerBit}.");

--- a/src/app/SIPAppFunctionDelegates.cs
+++ b/src/app/SIPAppFunctionDelegates.cs
@@ -29,7 +29,7 @@ namespace SIPSorcery.SIP.App
 
     // SIP User Agent Delegates.
     public delegate void SIPCallResponseDelegate(ISIPClientUserAgent uac, SIPResponse sipResponse);
-    public delegate void SIPCallFailedDelegate(ISIPClientUserAgent uac, string errorMessage);
+    public delegate void SIPCallFailedDelegate(ISIPClientUserAgent uac, string errorMessage, SIPResponse sipResponse);
     public delegate void SIPUASStateChangedDelegate(ISIPServerUserAgent uas, SIPResponseStatusCodesEnum statusCode, string reasonPhrase);
 
     // Get SIP account(s) from external sources delegate.

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -229,7 +229,7 @@ namespace SIPSorcery.SIP.App
                     if (m_callCancelled)
                     {
                         Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Call was cancelled during DNS resolution of " + callURI.Host, Owner));
-                        CallFailed?.Invoke(this, "Cancelled by caller");
+                        CallFailed?.Invoke(this, "Cancelled by caller", null);
                     }
                     else if (m_serverEndPoint != null)
                     {
@@ -370,7 +370,7 @@ namespace SIPSorcery.SIP.App
                         else
                         {
                             m_serverTransaction.CancelCall(rtccError);
-                            CallFailed?.Invoke(this, rtccError);
+                            CallFailed?.Invoke(this, rtccError, null);
                         }
 
                         return switchServerInvite;
@@ -381,13 +381,13 @@ namespace SIPSorcery.SIP.App
                         {
                             Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Forward leg failed, could not resolve URI host " + callURI.Host, Owner));
                             m_serverTransaction?.CancelCall("Unresolvable destination " + callURI.Host);
-                            CallFailed?.Invoke(this, "unresolvable destination " + callURI.Host);
+                            CallFailed?.Invoke(this, "unresolvable destination " + callURI.Host, null);
                         }
                         else
                         {
                             Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Forward leg failed, could not resolve top Route host " + routeSet.TopRoute.Host, Owner));
                             m_serverTransaction?.CancelCall("Unresolvable destination " + routeSet.TopRoute.Host);
-                            CallFailed?.Invoke(this, "unresolvable destination " + routeSet.TopRoute.Host);
+                            CallFailed?.Invoke(this, "unresolvable destination " + routeSet.TopRoute.Host, null);
                         }
                     }
                 }
@@ -395,7 +395,7 @@ namespace SIPSorcery.SIP.App
             catch (ApplicationException appExcp)
             {
                 m_serverTransaction?.CancelCall(appExcp.Message);
-                CallFailed?.Invoke(this, appExcp.Message);
+                CallFailed?.Invoke(this, appExcp.Message, null);
             }
             catch (AggregateException aggExcp)
             {
@@ -404,13 +404,13 @@ namespace SIPSorcery.SIP.App
                     Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Exception UserAgentClient Call. " + innerExcp.Message, Owner));
                 }
                 m_serverTransaction?.CancelCall($"Aggregate exception, inner exception count {aggExcp.InnerExceptions.Count}.");
-                CallFailed?.Invoke(this, aggExcp.InnerExceptions.First().Message);
+                CallFailed?.Invoke(this, aggExcp.InnerExceptions.First().Message, null);
             }
             catch (Exception excp)
             {
                 Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Exception UserAgentClient Call. " + excp.Message, Owner));
                 m_serverTransaction?.CancelCall("Unknown exception");
-                CallFailed?.Invoke(this, excp.Message);
+                CallFailed?.Invoke(this, excp.Message, null);
             }
             return null;
         }
@@ -467,7 +467,7 @@ namespace SIPSorcery.SIP.App
                     m_cancelTransaction.SendRequest();
                 }
 
-                CallFailed?.Invoke(this, "Call cancelled by user.");
+                CallFailed?.Invoke(this, "Call cancelled by user.", null);
             }
             catch (Exception excp)
             {
@@ -567,7 +567,7 @@ namespace SIPSorcery.SIP.App
                         {
                             // No point trying to authenticate if there is no password to use.
                             Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Forward leg failed, authentication was requested but no credentials were available.", Owner));
-                            CallFailed?.Invoke(this, "Authentication requested when no credentials available");
+                            CallFailed?.Invoke(this, "Authentication requested when no credentials available", sipResponse);
                         }
                         else if (m_serverAuthAttempts == 0)
                         {
@@ -611,7 +611,7 @@ namespace SIPSorcery.SIP.App
                         }
                         else
                         {
-                            CallFailed?.Invoke(this, "Authentication with provided credentials failed");
+                            CallFailed?.Invoke(this, "Authentication with provided credentials failed", sipResponse);
                         }
                     }
 
@@ -674,7 +674,7 @@ namespace SIPSorcery.SIP.App
         {
             if (!m_callCancelled)
             {
-                CallFailed?.Invoke(this, "Timeout, no response from server");
+                CallFailed?.Invoke(this, "Timeout, no response from server", null);
             }
         }
 

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -253,7 +253,7 @@ namespace SIPSorcery.SIP.App
             {
                 callResult.TrySetResult(true);
             };
-            ClientCallFailed += (uac, errorMessage) =>
+            ClientCallFailed += (uac, errorMessage, result) =>
             {
                 callResult.TrySetResult(false);
             };
@@ -298,7 +298,7 @@ namespace SIPSorcery.SIP.App
                 var sdp = mediaSession.CreateOffer(sdpAnnounceAddress);
                 if (sdp == null)
                 {
-                    ClientCallFailed?.Invoke(m_uac, $"Could not generate an offer.");
+                    ClientCallFailed?.Invoke(m_uac, $"Could not generate an offer.", null);
                     CallEnded();
                 }
                 else
@@ -310,7 +310,7 @@ namespace SIPSorcery.SIP.App
             }
             else
             {
-                ClientCallFailed?.Invoke(m_uac, $"Could not resolve destination when placing call to {sipCallDescriptor.Uri}.");
+                ClientCallFailed?.Invoke(m_uac, $"Could not resolve destination when placing call to {sipCallDescriptor.Uri}.", null);
                 CallEnded();
             }
         }
@@ -934,11 +934,11 @@ namespace SIPSorcery.SIP.App
         /// </summary>
         /// <param name="uac">The client user agent used to initiate the call.</param>
         /// <param name="errorMessage">An error message indicating the reason for the failure.</param>
-        private void ClientCallFailedHandler(ISIPClientUserAgent uac, string errorMessage)
+        private void ClientCallFailedHandler(ISIPClientUserAgent uac, string errorMessage, SIPResponse sipResponse)
         {
             logger.LogWarning($"Call attempt to {m_uac.CallDescriptor.Uri} failed with {errorMessage}.");
 
-            ClientCallFailed?.Invoke(uac, errorMessage);
+            ClientCallFailed?.Invoke(uac, errorMessage, sipResponse);
         }
 
         /// <summary>
@@ -963,7 +963,7 @@ namespace SIPSorcery.SIP.App
             else
             {
                 logger.LogDebug($"Call attempt was answered with failure response {sipResponse.ShortDescription}.");
-                ClientCallFailed?.Invoke(uac, sipResponse.ReasonPhrase);
+                ClientCallFailed?.Invoke(uac, sipResponse.ReasonPhrase, sipResponse);
                 CallEnded();
             }
         }


### PR DESCRIPTION
Extend SIPCallFailedDelegate to support sipResponde object where it is possible to get it.  Important to get SIP status codes.

Hello, i would aks you accept this commit. It will be very helpfull in some cases where i need do something bysed on SIP status code.
Thank you