### PR TITLE
Two stage DNS lookups using local cache.

### DIFF
--- a/examples/sipcmdline/sipcmdline.csproj
+++ b/examples/sipcmdline/sipcmdline.csproj
@@ -10,7 +10,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="SIPSorcery" Version="4.0.60-pre" />
+    <!--<PackageReference Include="SIPSorcery" Version="4.0.60-pre" />-->
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SIPSorcery.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/sipcmdline/sipcmdline.sln
+++ b/examples/sipcmdline/sipcmdline.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 16.0.29911.98
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sipcmdline", "sipcmdline.csproj", "{14118008-BF73-4534-9B62-1B64F847AB33}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery", "..\..\src\SIPSorcery.csproj", "{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DnsClient", "..\..\..\..\github\sipsorcery_dnsclient\src\DnsClient\DnsClient.csproj", "{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DnsSipLookups", "..\..\..\Prototypes\DnsSipLookups\DnsSipLookups.csproj", "{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +21,18 @@ Global
 		{14118008-BF73-4534-9B62-1B64F847AB33}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{14118008-BF73-4534-9B62-1B64F847AB33}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{14118008-BF73-4534-9B62-1B64F847AB33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/sipcmdline/sipcmdline.sln
+++ b/examples/sipcmdline/sipcmdline.sln
@@ -7,10 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sipcmdline", "sipcmdline.cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery", "..\..\src\SIPSorcery.csproj", "{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DnsClient", "..\..\..\..\github\sipsorcery_dnsclient\src\DnsClient\DnsClient.csproj", "{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DnsSipLookups", "..\..\..\Prototypes\DnsSipLookups\DnsSipLookups.csproj", "{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,14 +21,6 @@ Global
 		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4FD7F60-0B1A-4FBD-A24A-28A5EF053D60}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C3C7E7DA-2440-41B8-ADF1-C8195E20017A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FF3ED6DE-80EC-461F-9CD7-CBE056AC7354}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-    <!--<PackageReference Include="DnsClient" Version="1.3.2" />-->
+    <PackageReference Include="DnsClient" Version="1.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>1.0.0</Version>
@@ -30,10 +30,6 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\github\sipsorcery_dnsclient\src\DnsClient\DnsClient.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-    <PackageReference Include="DnsClient" Version="1.3.2" />
+    <!--<PackageReference Include="DnsClient" Version="1.3.2" />-->
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>1.0.0</Version>
@@ -30,6 +30,10 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\github\sipsorcery_dnsclient\src\DnsClient\DnsClient.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -159,14 +159,14 @@ namespace SIPSorcery.SIP.App
                     routeSet.PushRoute(new SIPRoute(sipCallDescriptor.RouteSet, true));
                     Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "Route set for call " + routeSet.ToString() + ".", Owner));
                     //lookupResult = m_sipTransport.GetURIEndPoint(routeSet.TopRoute.URI, false);
-                    lookupResult = await m_sipTransport.ResolveSIPUri(routeSet.TopRoute.URI).ConfigureAwait(false);
+                    lookupResult = await m_sipTransport.ResolveSIPUriAsync(routeSet.TopRoute.URI).ConfigureAwait(false);
                 }
                 else
                 {
                     Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.DialPlan, "SIPClientUserAgent attempting to resolve " + callURI.Host + ".", Owner));
                     //lookupResult = m_sipTransport.GetURIEndPoint(callURI, false);
                     DateTime lookupStartedAt = DateTime.Now;
-                    lookupResult = await m_sipTransport.ResolveSIPUri(callURI).ConfigureAwait(false);
+                    lookupResult = await m_sipTransport.ResolveSIPUriAsync(callURI).ConfigureAwait(false);
                     lookupDurationMilliseconds = DateTime.Now.Subtract(lookupStartedAt).TotalMilliseconds;
                 }
 
@@ -237,7 +237,6 @@ namespace SIPSorcery.SIP.App
                 }
 
                 SIPRequest inviteRequest = GetInviteRequest(m_sipCallDescriptor, m_sipCallDescriptor.BranchId, m_sipCallDescriptor.CallId, routeSet, content, sipCallDescriptor.ContentType);
-                inviteRequest.DnsResult = serverEndPoint;
 
                 // Now that we have a destination socket create a new UAC transaction for forwarded leg of the call.
                 m_serverTransaction = new UACInviteTransaction(m_sipTransport, inviteRequest, m_outboundProxy);

--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -310,7 +310,7 @@ namespace SIPSorcery.SIP.App
                     {
                         //SIPDNSLookupResult lookupResult = m_sipTransport.GetHostEndPoint(m_registrarHost, false);
                         SIPURI uri = SIPURI.ParseSIPURIRelaxed(m_registrarHost);
-                        var lookupResult = m_sipTransport.ResolveSIPUri(uri).Result;
+                        var lookupResult = m_sipTransport.ResolveSIPUriAsync(uri).ConfigureAwait(false).GetAwaiter().GetResult();
                         if (lookupResult == null)
                         {
                             Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.ContactRegisterFailed, "Could not resolve " + m_registrarHost + ".", null));
@@ -384,7 +384,7 @@ namespace SIPSorcery.SIP.App
                             {
                                 //SIPDNSLookupResult lookupResult = m_sipTransport.GetHostEndPoint(m_registrarHost, false);
                                 SIPURI uri = SIPURI.ParseSIPURIRelaxed(m_registrarHost);
-                                var lookupResult = m_sipTransport.ResolveSIPUri(uri).Result;
+                                var lookupResult = m_sipTransport.ResolveSIPUriAsync(uri).ConfigureAwait(false).GetAwaiter().GetResult();
                                 if (lookupResult == null)
                                 {
                                     Log_External(new SIPMonitorConsoleEvent(SIPMonitorServerTypesEnum.UserAgentClient, SIPMonitorEventTypesEnum.ContactRegisterFailed, "Could not resolve " + m_registrarHost + ".", null));

--- a/src/core/SIP/SIPEndPoint.cs
+++ b/src/core/SIP/SIPEndPoint.cs
@@ -22,7 +22,7 @@ using SIPSorcery.Sys;
 namespace SIPSorcery.SIP
 {
     /// <summary>
-    /// This class is a more specific versions of the SIPURI class BUT is only concerned with the network and
+    /// This class is a more specific version of the SIPURI class BUT is only concerned with the network and
     /// transport properties. It contains all the information needed to determine the remote end point to
     /// deliver a SIP request or response to.
     /// 
@@ -36,11 +36,7 @@ namespace SIPSorcery.SIP
         private const string CHANNELID_ATTRIBUTE_NAME = "cid";
         private const string CONNECTIONID_ATTRIBUTE_NAME = "xid";
 
-        /// <summary>
-        /// The scheme the SIP end point is using. Note that some schemes and protocols are mutually exclusive.
-        /// For example sips cannot be sent over UDP.
-        /// </summary>
-        //public SIPSchemesEnum Scheme { get; private set; } = SIPSchemesEnum.sip;
+        public static SIPEndPoint Empty { get; } = new SIPEndPoint(SIPProtocolsEnum.udp, null, 0);
 
         /// <summary>
         /// The transport/application layer protocol the SIP end point is using.
@@ -234,11 +230,16 @@ namespace SIPSorcery.SIP
 
         public override string ToString()
         {
-            IPEndPoint ep = new IPEndPoint(Address, Port);
-            string result = Protocol + ":" + ep.ToString();
-            //result += (!String.IsNullOrEmpty(ChannelID) ? ";" + CHANNELID_ATTRIBUTE_NAME + "=" + ChannelID : null);
-            //result += (!String.IsNullOrEmpty(ConnectionID) ? ";" + CONNECTIONID_ATTRIBUTE_NAME + "=" + ConnectionID : null);
-            return result;
+            if (Address == null)
+            {
+                return Protocol + ":empty";
+            }
+            else
+            {
+                IPEndPoint ep = new IPEndPoint(Address, Port);
+                string result = Protocol + ":" + ep.ToString();
+                return result;
+            }
         }
 
         public static bool AreEqual(SIPEndPoint endPoint1, SIPEndPoint endPoint2)

--- a/src/core/SIP/SIPMessageBase.cs
+++ b/src/core/SIP/SIPMessageBase.cs
@@ -65,9 +65,5 @@ namespace SIPSorcery.SIP
         /// when sending this request/response.
         /// </summary>
         public string SendFromHintConnectionID;
-
-        internal DateTime DnsLookupStartedAt = DateTime.MinValue;
-        internal DateTime DnsLookupFailedAt = DateTime.MinValue;
-        internal SIPEndPoint DnsResult;
     }
 }


### PR DESCRIPTION
Adds ability to use a two stage process for SIP DNS lookups. First stage attempts to use the local cache and only if there is a miss will a DNS query be submitted to the network.

Depends on https://github.com/MichaCo/DnsClient.NET/pull/82.