### PR TITLE
Async send and receive with performance improvements

### DIFF
--- a/src/app/Media/RtpVP8Header.cs
+++ b/src/app/Media/RtpVP8Header.cs
@@ -16,84 +16,128 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Text;
 
 namespace SIPSorcery.Media
 {
-    /// <summary>
-    /// Representation of the VP8 RTP header as specified in RFC7741
-    /// https://tools.ietf.org/html/rfc7741.
-    /// </summary>
-    public class RtpVP8Header
+  /// <summary>
+  /// Representation of the VP8 RTP header as specified in RFC7741
+  /// https://tools.ietf.org/html/rfc7741.
+  /// </summary>
+  public class RtpVP8Header
+  {
+
+    private bool IsMBitSet;
+
+    // Payload Descriptor Fields.
+    public bool ExtendedControlBitsPresent;     // Indicated whether extended control bits are present.
+    public bool NonReferenceFrame;              // When set indicates the frame can be discarded without affecting any other frames.
+    public bool StartOfVP8Partition;            // Should be set when the first payload octet is the start of a new VP8 partition.
+    public byte PartitionIndex;                 // Denotes the VP8 partition index that the first payload octet of the packet belongs to.
+    public bool IsPictureIDPresent;
+    public bool IsTL0PICIDXPresent;
+    public bool IsTIDPresent;
+    public bool IsKEYIDXPresent;
+    public ushort PictureID;
+    public byte TemporalLayerIndex;
+    public bool LayerSync;
+    public byte TL0PICIDX;
+    public byte KEYIDX;
+
+    public int PayloadDescriptorLength;
+
+    // Payload Header Fields.
+    public int FirstPartitionSize;              // The size of the first partition in bytes is calculated from the 19 bits in Size0, SIze1 & Size2 as: size = Size0 + (8 x Size1) + (2048 8 Size2).
+    public bool ShowFrame;
+    public int VersionNumber;
+    public bool IsKeyFrame;
+
+    // Complete length of header
+    public int Length;
+
+    byte[] b = null;
+    public RtpVP8Header(byte[] bytes)
     {
-        // Payload Descriptor Fields.
-        public bool ExtendedControlBitsPresent;     // Indicated whether extended control bits are present.
-        public bool NonReferenceFrame;              // When set indicates the frame can be discarded without affecting any other frames.
-        public bool StartOfVP8Partition;            // Should be set when the first payload octet is the start of a new VP8 partition.
-        public byte PartitionIndex;                 // Denotes the VP8 partition index that the first payload octet of the packet belongs to.
-        public bool IsPictureIDPresent;
-        public ushort PictureID;
 
-        // Payload Header Fields.
-        public int FirstPartitionSize;              // The size of the first partition in bytes is calculated from the 19 bits in Size0, SIze1 & Size2 as: size = Size0 + (8 x Size1) + (2048 8 Size2).
-        public bool ShowFrame;
-        public int VersionNumber;
-        public bool IsKeyFrame;
+      b = bytes;
+      // First byte of payload descriptor.
+      ExtendedControlBitsPresent = (bytes[0] & 0x80) != 0;
+      NonReferenceFrame = (bytes[0] & 0x20) != 0;
+      StartOfVP8Partition = (bytes[0] & 0x10) != 0;
 
-        private int _length = 0;
-        public int Length
+      PartitionIndex = (byte)(bytes[0] & 0x0f);
+
+      // Is second byte being used.
+      if (ExtendedControlBitsPresent)
+      {
+        IsPictureIDPresent = (bytes[0] & 0x80) != 0;
+        IsTL0PICIDXPresent = (bytes[0] & 0x40) != 0;
+        IsTIDPresent = (bytes[0] & 0x20) != 0;
+        IsKEYIDXPresent = (bytes[0] & 0x410) != 0;
+        PayloadDescriptorLength = 2;
+        // Is the picture ID being used.
+        if (IsPictureIDPresent)
         {
-            get { return _length; }
+          IsMBitSet = (bytes[PayloadDescriptorLength] & 0x80) != 0;
+          if (IsMBitSet)
+          {
+
+            // The Picure ID is using two bytes.
+            PictureID = (ushort)(((byte)(bytes[PayloadDescriptorLength] & 0x7f) << 8) + bytes[PayloadDescriptorLength + 1]);
+            PayloadDescriptorLength = 4;
+          }
+          else
+          {
+
+            // The picture ID is using one byte.
+            PictureID = bytes[PayloadDescriptorLength];
+            PayloadDescriptorLength = 3;
+          }
         }
 
-        private int _payloadDescriptorLength;
-        public int PayloadDescriptorLength
+        if (IsTL0PICIDXPresent)
         {
-            get { return _payloadDescriptorLength; }
+          TL0PICIDX = bytes[PayloadDescriptorLength - 1];
+          PayloadDescriptorLength += 1;
         }
 
-        public RtpVP8Header()
-        { }
-
-        public static RtpVP8Header GetVP8Header(byte[] rtpPayload)
+        if (IsTIDPresent || IsKEYIDXPresent)
         {
-            RtpVP8Header vp8Header = new RtpVP8Header();
-            int payloadHeaderStartIndex = 1;
-
-            // First byte of payload descriptor.
-            vp8Header.ExtendedControlBitsPresent = ((rtpPayload[0] >> 7) & 0x01) == 1;
-            vp8Header.StartOfVP8Partition = ((rtpPayload[0] >> 4) & 0x01) == 1;
-            vp8Header._length = 1;
-
-            // Is second byte being used.
-            if (vp8Header.ExtendedControlBitsPresent)
-            {
-                vp8Header.IsPictureIDPresent = ((rtpPayload[1] >> 7) & 0x01) == 1;
-                vp8Header._length = 2;
-                payloadHeaderStartIndex = 2;
-            }
-
-            // Is the picture ID being used.
-            if (vp8Header.IsPictureIDPresent)
-            {
-                if (((rtpPayload[2] >> 7) & 0x01) == 1)
-                {
-                    // The Picure ID is using two bytes.
-                    vp8Header._length = 4;
-                    payloadHeaderStartIndex = 4;
-                    vp8Header.PictureID = BitConverter.ToUInt16(rtpPayload, 2);
-                }
-                else
-                {
-                    // The picture ID is using one byte.
-                    vp8Header.PictureID = rtpPayload[2];
-                    vp8Header._length = 3;
-                    payloadHeaderStartIndex = 3;
-                }
-            }
-
-            vp8Header._payloadDescriptorLength = payloadHeaderStartIndex;
-
-            return vp8Header;
+          TemporalLayerIndex = (byte)((bytes[PayloadDescriptorLength] & 0xC0) >> 6);
+          LayerSync = ((byte)bytes[PayloadDescriptorLength] & 0x20) != 0;
+          KEYIDX = (byte)(bytes[PayloadDescriptorLength] & 0x1f);
         }
+      }
+      else
+      {
+        PayloadDescriptorLength = 1;
+      }
+      Length = PayloadDescriptorLength;
+
+      if (StartOfVP8Partition && PartitionIndex == 0)
+      {
+        byte payloadHeaderByte = bytes[PayloadDescriptorLength];
+        ShowFrame = (payloadHeaderByte & 0x10) != 0;
+
+        VersionNumber = (payloadHeaderByte & 0x0e) >> 1;
+        IsKeyFrame = (payloadHeaderByte & 0x01) == 0; // inverse Key Frame
+        FirstPartitionSize = (payloadHeaderByte & 0xe0) >> 5 + 8 * bytes[PayloadDescriptorLength + 1] + 2048 * bytes[PayloadDescriptorLength + 2];
+      }
     }
+
+
+    public override string ToString()
+    {
+      if (b != null)
+      {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(Convert.ToString(b[0], 2).PadLeft(8, '0'));
+        sb.AppendLine(Convert.ToString(b[1], 2).PadLeft(8, '0'));
+        sb.AppendLine(Convert.ToString(b[2], 2).PadLeft(8, '0'));
+        sb.AppendLine(Convert.ToString(b[3], 2).PadLeft(8, '0'));
+        return sb.ToString();
+      }
+      return base.ToString();
+    }
+  }
 }

--- a/src/net/DtlsSrtp/DtlsUtils.cs
+++ b/src/net/DtlsSrtp/DtlsUtils.cs
@@ -381,14 +381,20 @@ namespace SIPSorcery.Net
 
             return x509;
         }
+        const int keyStrength = 2048;
+        static CryptoApiRandomGenerator randomGenerator = new CryptoApiRandomGenerator();
+        static SecureRandom random = new SecureRandom(randomGenerator);
+
+        static KeyGenerationParameters keyGenerationParameters = new KeyGenerationParameters(random, keyStrength);
+        static RsaKeyPairGenerator keyPairGenerator = null;
 
         public static AsymmetricKeyParameter CreatePrivateKeyResource(string subjectName = "CN=root")
         {
-            const int keyStrength = 2048;
+
 
             // Generating Random Numbers
-            var randomGenerator = new CryptoApiRandomGenerator();
-            var random = new SecureRandom(randomGenerator);
+            //  var randomGenerator = new CryptoApiRandomGenerator();
+            //  var random = new SecureRandom(randomGenerator);
 
             // The Certificate Generator
             var certificateGenerator = new X509V3CertificateGenerator();
@@ -411,9 +417,14 @@ namespace SIPSorcery.Net
             certificateGenerator.SetNotAfter(notAfter);
 
             // Subject Public Key
-            var keyGenerationParameters = new KeyGenerationParameters(random, keyStrength);
-            var keyPairGenerator = new RsaKeyPairGenerator();
-            keyPairGenerator.Init(keyGenerationParameters);
+            //   var keyGenerationParameters = new KeyGenerationParameters(random, keyStrength);
+            //   var keyPairGenerator = new RsaKeyPairGenerator();
+            //    keyPairGenerator.Init(keyGenerationParameters);
+            if (keyPairGenerator == null)
+            {
+                keyPairGenerator = new RsaKeyPairGenerator();
+                keyPairGenerator.Init(keyGenerationParameters);
+            }
             var subjectKeyPair = keyPairGenerator.GenerateKeyPair();
 
             return subjectKeyPair.Private;

--- a/src/net/DtlsSrtp/Transform/RawPacket.cs
+++ b/src/net/DtlsSrtp/Transform/RawPacket.cs
@@ -148,8 +148,7 @@ namespace SIPSorcery.Net
          */
         public bool GetExtensionBit()
         {
-            buffer.Position = 0;
-            return (buffer.ReadByte() & 0x10) == 0x10;
+            return (this.buffer.GetBuffer()[0] & 0x10) == 0x10;
         }
 
         /**
@@ -181,8 +180,7 @@ namespace SIPSorcery.Net
          */
         public int GetCsrcCount()
         {
-            this.buffer.Position = 0;
-            return (this.buffer.ReadByte() & 0x0f);
+            return (this.buffer.GetBuffer()[0] & 0x0f);
         }
 
         /**

--- a/src/net/RTP/RTPHeader.cs
+++ b/src/net/RTP/RTPHeader.cs
@@ -31,24 +31,17 @@ namespace SIPSorcery.Net
         public int CSRCCount = 0;                               // 4 bits
         public int MarkerBit = 0;                               // 1 bit.
         public int PayloadType = (int)SDPMediaFormatsEnum.PCMU; // 7 bits.
-        public UInt16 SequenceNumber;                           // 16 bits.
+        public ushort SequenceNumber;                           // 16 bits.
         public uint Timestamp;                                  // 32 bits.
         public uint SyncSource;                                 // 32 bits.
         public int[] CSRCList;                                  // 32 bits.
-        public UInt16 ExtensionProfile;                         // 16 bits.
-        public UInt16 ExtensionLength;                          // 16 bits, length of the header extensions in 32 bit words.
+        public ushort ExtensionProfile;                         // 16 bits.
+        public ushort ExtensionLength;                          // 16 bits, length of the header extensions in 32 bit words.
         public byte[] ExtensionPayload;
 
         public int Length
         {
             get { return MIN_HEADER_LEN + (CSRCCount * 4) + ((HeaderExtensionFlag == 0) ? 0 : 4 + (ExtensionLength * 4)); }
-        }
-
-        public RTPHeader()
-        {
-            SequenceNumber = Crypto.GetRandomUInt16();
-            SyncSource = Crypto.GetRandomUInt();
-            Timestamp = Crypto.GetRandomUInt();
         }
 
         /// <summary>
@@ -57,6 +50,7 @@ namespace SIPSorcery.Net
         /// <param name="packet"></param>
         public RTPHeader(byte[] packet)
         {
+            if (packet == null) { return; }
             if (packet.Length < MIN_HEADER_LEN)
             {
                 throw new ApplicationException("The packet did not contain the minimum number of bytes for an RTP header packet.");
@@ -108,7 +102,7 @@ namespace SIPSorcery.Net
             }
         }
 
-        public byte[] GetHeader(UInt16 sequenceNumber, uint timestamp, uint syncSource)
+        public byte[] GetHeader(ushort sequenceNumber, uint timestamp, uint syncSource)
         {
             SequenceNumber = sequenceNumber;
             Timestamp = timestamp;
@@ -121,7 +115,7 @@ namespace SIPSorcery.Net
         {
             byte[] header = new byte[Length];
 
-            UInt16 firstWord = Convert.ToUInt16(Version * 16384 + PaddingFlag * 8192 + HeaderExtensionFlag * 4096 + CSRCCount * 256 + MarkerBit * 128 + PayloadType);
+            ushort firstWord = Convert.ToUInt16(Version * 16384 + PaddingFlag * 8192 + HeaderExtensionFlag * 4096 + CSRCCount * 256 + MarkerBit * 128 + PayloadType);
 
             if (BitConverter.IsLittleEndian)
             {

--- a/src/net/RTP/RTPPacket.cs
+++ b/src/net/RTP/RTPPacket.cs
@@ -18,19 +18,19 @@ using System;
 
 namespace SIPSorcery.Net
 {
-    public class RTPPacket
+    public sealed class RTPPacket
     {
         public RTPHeader Header;
         public byte[] Payload;
 
         public RTPPacket()
         {
-            Header = new RTPHeader();
+            Header = new RTPHeader(null);
         }
 
         public RTPPacket(int payloadSize)
         {
-            Header = new RTPHeader();
+            Header = new RTPHeader(null);
             Payload = new byte[payloadSize];
         }
 

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -289,6 +289,7 @@ namespace SIPSorcery.Net
     /// </remarks>
     public class RTPSession : IMediaSession, IDisposable
     {
+        private bool isDisposed;
         private const int RTP_MAX_PAYLOAD = 1400;
 
         /// <summary>
@@ -1469,6 +1470,12 @@ namespace SIPSorcery.Net
             }
         }
 
+
+        private ushort NextSeqNum(ushort seqNum)
+        {
+            return (ushort)(++seqNum & 0xffff);
+        }
+
         /// <summary>
         /// Sends an audio packet to the remote party.
         /// </summary>
@@ -1476,7 +1483,7 @@ namespace SIPSorcery.Net
         /// gets added onto the timestamp being set in the RTP header.</param>
         /// <param name="payloadTypeID">The payload ID to set in the RTP header.</param>
         /// <param name="buffer">The audio payload to send.</param>
-        public void SendAudioFrame(uint duration, int payloadTypeID, byte[] buffer)
+        public async Task SendAudioFrame(uint duration, int payloadTypeID, byte[] buffer)
         {
             if (IsClosed || m_rtpEventInProgress || AudioDestinationEndPoint == null)
             {
@@ -1511,11 +1518,8 @@ namespace SIPSorcery.Net
                         int markerBit = 0;
 
                         var audioRtpChannel = GetRtpChannel(SDPMediaTypesEnum.audio);
-                        SendRtpPacket(audioRtpChannel, AudioDestinationEndPoint, payload, audioTrack.Timestamp, markerBit, payloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession);
-
-                        //logger.LogDebug($"send audio { audioRtpChannel.RTPLocalEndPoint}->{AudioDestinationEndPoint}.");
-
-                        audioTrack.SeqNum = (audioTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(audioTrack.SeqNum + 1);
+                        await SendRtpPacket(audioRtpChannel, AudioDestinationEndPoint, payload, audioTrack.Timestamp, markerBit, payloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession).ConfigureAwait(false);
+                        audioTrack.SeqNum = NextSeqNum(audioTrack.SeqNum);
                     }
 
                     audioTrack.Timestamp += duration;
@@ -1534,7 +1538,7 @@ namespace SIPSorcery.Net
         /// to be based on a 90Khz clock.</param>
         /// <param name="payloadTypeID">The payload ID to place in the RTP header.</param>
         /// <param name="buffer">The VP8 encoded payload.</param>
-        public void SendVp8Frame(uint duration, int payloadTypeID, byte[] buffer)
+        public async Task SendVp8Frame(uint duration, int payloadTypeID, byte[] buffer)
         {
             var dstEndPoint = m_isMediaMultiplexed ? AudioDestinationEndPoint : VideoDestinationEndPoint;
 
@@ -1557,27 +1561,23 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
+
+                    var videoChannel = GetRtpChannel(SDPMediaTypesEnum.video);
                     for (int index = 0; index * RTP_MAX_PAYLOAD < buffer.Length; index++)
                     {
                         int offset = index * RTP_MAX_PAYLOAD;
                         int payloadLength = (offset + RTP_MAX_PAYLOAD < buffer.Length) ? RTP_MAX_PAYLOAD : buffer.Length - offset;
 
-                        byte[] vp8HeaderBytes = (index == 0) ? new byte[] { 0x10 } : new byte[] { 0x00 };
-                        byte[] payload = new byte[payloadLength + vp8HeaderBytes.Length];
-                        Buffer.BlockCopy(vp8HeaderBytes, 0, payload, 0, vp8HeaderBytes.Length);
-                        Buffer.BlockCopy(buffer, offset, payload, vp8HeaderBytes.Length, payloadLength);
-
+                        byte[] payload = new byte[payloadLength + 1];//vp8HeaderBytes.Length];
+                        payload[0] = (index == 0) ? (byte)0x10 : (byte)0x00;
+                        // Buffer.BlockCopy(vp8HeaderBytes, 0, payload, 0, vp8HeaderBytes.Length);
+                        Buffer.BlockCopy(buffer, offset, payload, 1, payloadLength);
                         int markerBit = ((offset + payloadLength) >= buffer.Length) ? 1 : 0; // Set marker bit for the last packet in the frame.
-
-                        var videoChannel = GetRtpChannel(SDPMediaTypesEnum.video);
-
-                        SendRtpPacket(videoChannel, dstEndPoint, payload, videoTrack.Timestamp, markerBit, payloadTypeID, videoTrack.Ssrc, videoTrack.SeqNum, VideoRtcpSession);
-                        //logger.LogDebug($"send VP8 {videoChannel.RTPLocalEndPoint}->{dstEndPoint} timestamp {videoTrack.Timestamp}, sample length {buffer.Length}.");
-
-                        videoTrack.SeqNum = (videoTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(videoTrack.SeqNum + 1);
+                        await SendRtpPacket(videoChannel, dstEndPoint, payload, videoTrack.Timestamp, markerBit, payloadTypeID, videoTrack.Ssrc, videoTrack.SeqNum, VideoRtcpSession).ConfigureAwait(false);
+                        videoTrack.SeqNum = NextSeqNum(videoTrack.SeqNum);
                     }
-
                     videoTrack.Timestamp += duration;
+
                 }
             }
             catch (SocketException sockExcp)
@@ -1596,7 +1596,7 @@ namespace SIPSorcery.Net
         /// <param name="jpegWidth">The width of the JPEG image.</param>
         /// <param name="jpegHeight">The height of the JPEG image.</param>
         /// <param name="framesPerSecond">The rate at which the JPEG frames are being transmitted at. used to calculate the timestamp.</param>
-        public void SendJpegFrame(uint duration, int payloadTypeID, byte[] jpegBytes, int jpegQuality, int jpegWidth, int jpegHeight)
+        public async Task SendJpegFrame(uint duration, int payloadTypeID, byte[] jpegBytes, int jpegQuality, int jpegWidth, int jpegHeight)
         {
             var dstEndPoint = m_isMediaMultiplexed ? AudioDestinationEndPoint : VideoDestinationEndPoint;
 
@@ -1621,6 +1621,7 @@ namespace SIPSorcery.Net
                 {
                     for (int index = 0; index * RTP_MAX_PAYLOAD < jpegBytes.Length; index++)
                     {
+
                         uint offset = Convert.ToUInt32(index * RTP_MAX_PAYLOAD);
                         int payloadLength = ((index + 1) * RTP_MAX_PAYLOAD < jpegBytes.Length) ? RTP_MAX_PAYLOAD : jpegBytes.Length - index * RTP_MAX_PAYLOAD;
                         byte[] jpegHeader = CreateLowQualityRtpJpegHeader(offset, jpegQuality, jpegWidth, jpegHeight);
@@ -1630,9 +1631,8 @@ namespace SIPSorcery.Net
                         packetPayload.AddRange(jpegBytes.Skip(index * RTP_MAX_PAYLOAD).Take(payloadLength));
 
                         int markerBit = ((index + 1) * RTP_MAX_PAYLOAD < jpegBytes.Length) ? 0 : 1;
-                        SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.video), dstEndPoint, packetPayload.ToArray(), videoTrack.Timestamp, markerBit, payloadTypeID, videoTrack.Ssrc, videoTrack.SeqNum, VideoRtcpSession);
-
-                        videoTrack.SeqNum = (videoTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(videoTrack.SeqNum + 1);
+                        await SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.video), dstEndPoint, packetPayload.ToArray(), videoTrack.Timestamp, markerBit, payloadTypeID, videoTrack.Ssrc, videoTrack.SeqNum, VideoRtcpSession).ConfigureAwait(false);
+                        videoTrack.SeqNum = NextSeqNum(videoTrack.SeqNum);
                     }
 
                     videoTrack.Timestamp += duration;
@@ -1650,7 +1650,7 @@ namespace SIPSorcery.Net
         /// <param name="frame">The H264 encoded frame to transmit.</param>
         /// <param name="frameSpacing">The increment to add to the RTP timestamp for each new frame.</param>
         /// <param name="payloadType">The payload type to set on the RTP packet.</param>
-        public void SendH264Frame(uint duration, int payloadTypeID, byte[] frame)
+        public async Task SendH264Frame(uint duration, int payloadTypeID, byte[] frame)
         {
             var dstEndPoint = m_isMediaMultiplexed ? AudioDestinationEndPoint : VideoDestinationEndPoint;
 
@@ -1708,9 +1708,8 @@ namespace SIPSorcery.Net
                         Buffer.BlockCopy(h264Header, 0, payload, 0, H264_RTP_HEADER_LENGTH);
                         Buffer.BlockCopy(frame, offset, payload, H264_RTP_HEADER_LENGTH, payloadLength);
 
-                        SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.video), dstEndPoint, payload, videoTrack.Timestamp, markerBit, payloadTypeID, videoTrack.Ssrc, videoTrack.SeqNum, VideoRtcpSession);
-
-                        videoTrack.SeqNum = (videoTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(videoTrack.SeqNum + 1);
+                        await SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.video), dstEndPoint, payload, videoTrack.Timestamp, markerBit, payloadTypeID, videoTrack.Ssrc, videoTrack.SeqNum, VideoRtcpSession).ConfigureAwait(false);
+                        videoTrack.SeqNum = NextSeqNum(videoTrack.SeqNum);
                     }
 
                     videoTrack.Timestamp += duration;
@@ -1794,9 +1793,9 @@ namespace SIPSorcery.Net
                         byte[] buffer = rtpEvent.GetEventPayload();
 
                         int markerBit = (i == 0) ? 1 : 0;  // Set marker bit for the first packet in the event.
-                        SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.audio), dstEndPoint, buffer, startTimestamp, markerBit, rtpEvent.PayloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession);
+                        await SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.audio), dstEndPoint, buffer, startTimestamp, markerBit, rtpEvent.PayloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession).ConfigureAwait(false);
 
-                        audioTrack.SeqNum = (audioTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(audioTrack.SeqNum + 1);
+                        audioTrack.SeqNum = NextSeqNum(audioTrack.SeqNum);
                     }
 
                     await Task.Delay(samplePeriod, cancellationToken).ConfigureAwait(false);
@@ -1809,9 +1808,9 @@ namespace SIPSorcery.Net
                             rtpEvent.Duration += rtpTimestampStep;
                             byte[] buffer = rtpEvent.GetEventPayload();
 
-                            SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.audio), dstEndPoint, buffer, startTimestamp, 0, rtpEvent.PayloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession);
+                            await SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.audio), dstEndPoint, buffer, startTimestamp, 0, rtpEvent.PayloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession).ConfigureAwait(false);
 
-                            audioTrack.SeqNum = (audioTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(audioTrack.SeqNum + 1);
+                            audioTrack.SeqNum = NextSeqNum(audioTrack.SeqNum);
 
                             await Task.Delay(samplePeriod, cancellationToken).ConfigureAwait(false);
                         }
@@ -1819,13 +1818,13 @@ namespace SIPSorcery.Net
                         // Send the end of event packets.
                         for (int j = 0; j < RTPEvent.DUPLICATE_COUNT && !cancellationToken.IsCancellationRequested; j++)
                         {
+
                             rtpEvent.EndOfEvent = true;
                             rtpEvent.Duration = rtpEvent.TotalDuration;
                             byte[] buffer = rtpEvent.GetEventPayload();
 
-                            SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.audio), dstEndPoint, buffer, startTimestamp, 0, rtpEvent.PayloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession);
-
-                            audioTrack.SeqNum = (audioTrack.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(audioTrack.SeqNum + 1);
+                            await SendRtpPacket(GetRtpChannel(SDPMediaTypesEnum.audio), dstEndPoint, buffer, startTimestamp, 0, rtpEvent.PayloadTypeID, audioTrack.Ssrc, audioTrack.SeqNum, AudioRtcpSession).ConfigureAwait(false);
+                            audioTrack.SeqNum = NextSeqNum(audioTrack.SeqNum);
                         }
                     }
                 }
@@ -1852,7 +1851,7 @@ namespace SIPSorcery.Net
         /// <param name="timestamp">The timestamp to set on the RTP header.</param>
         /// <param name="markerBit">The value to set on the RTP header marker bit, should be 0 or 1.</param>
         /// <param name="payloadTypeID">The payload ID to set in the RTP header.</param>
-        public void SendRtpRaw(SDPMediaTypesEnum mediaType, byte[] payload, uint timestamp, int markerBit, int payloadTypeID)
+        public async Task SendRtpRaw(SDPMediaTypesEnum mediaType, byte[] payload, uint timestamp, int markerBit, int payloadTypeID)
         {
             if (mediaType == SDPMediaTypesEnum.audio && AudioLocalTrack == null)
             {
@@ -1864,16 +1863,14 @@ namespace SIPSorcery.Net
             }
             else
             {
-                var rtpChannel = GetRtpChannel(mediaType);
-                RTCPSession rtcpSession = (mediaType == SDPMediaTypesEnum.video) ? VideoRtcpSession : AudioRtcpSession;
-                IPEndPoint dstEndPoint = (mediaType == SDPMediaTypesEnum.audio || m_isMediaMultiplexed) ? AudioDestinationEndPoint : VideoDestinationEndPoint;
-                MediaStreamTrack track = (mediaType == SDPMediaTypesEnum.video) ? VideoLocalTrack : AudioLocalTrack;
-
+                IPEndPoint dstEndPoint = (mediaType == SDPMediaTypesEnum.audio || m_isMediaMultiplexed) ? AudioDestinationEndPoint : VideoDestinationEndPoint;               
                 if (dstEndPoint != null)
                 {
-                    SendRtpPacket(rtpChannel, dstEndPoint, payload, timestamp, markerBit, payloadTypeID, track.Ssrc, track.SeqNum, rtcpSession);
-
-                    track.SeqNum = (track.SeqNum == UInt16.MaxValue) ? (ushort)0 : (ushort)(track.SeqNum + 1);
+                    var rtpChannel = GetRtpChannel(mediaType);
+                    RTCPSession rtcpSession = (mediaType == SDPMediaTypesEnum.video) ? VideoRtcpSession : AudioRtcpSession;
+                    MediaStreamTrack track = (mediaType == SDPMediaTypesEnum.video) ? VideoLocalTrack : AudioLocalTrack;
+                    await SendRtpPacket(rtpChannel, dstEndPoint, payload, timestamp, markerBit, payloadTypeID, track.Ssrc, track.SeqNum, rtcpSession).ConfigureAwait(false);
+                    track.SeqNum = NextSeqNum(track.SeqNum);
                 }
             }
         }
@@ -1883,10 +1880,10 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="mediaType">The media type of the RTCP report  being sent. Must be audio or video.</param>
         /// <param name="feedback">The feedback report to send.</param>
-        public void SendRtcpFeedback(SDPMediaTypesEnum mediaType, RTCPFeedback feedback)
+        public async Task SendRtcpFeedback(SDPMediaTypesEnum mediaType, RTCPFeedback feedback)
         {
             var reportBytes = feedback.GetBytes();
-            SendRtcpReport(mediaType, reportBytes);
+            await SendRtcpReport(mediaType, reportBytes).ConfigureAwait(false); ;
         }
 
         /// <summary>
@@ -2312,7 +2309,7 @@ namespace SIPSorcery.Net
         /// <param name="timestamp">The RTP header timestamp.</param>
         /// <param name="markerBit">The RTP header marker bit.</param>
         /// <param name="payloadType">The RTP header payload type.</param>
-        private void SendRtpPacket(RTPChannel rtpChannel, IPEndPoint dstRtpSocket, byte[] data, uint timestamp, int markerBit, int payloadType, uint ssrc, ushort seqNum, RTCPSession rtcpSession)
+        private async Task SendRtpPacket(RTPChannel rtpChannel, IPEndPoint dstRtpSocket, byte[] data, uint timestamp, int markerBit, int payloadType, uint ssrc, ushort seqNum, RTCPSession rtcpSession)
         {
             if (IsSecure && !IsSecureContextReady)
             {
@@ -2335,7 +2332,7 @@ namespace SIPSorcery.Net
 
                 if (m_srtpProtect == null)
                 {
-                    rtpChannel.Send(RTPChannelSocketsEnum.RTP, dstRtpSocket, rtpBuffer);
+                    await rtpChannel.SendAsync(RTPChannelSocketsEnum.RTP, dstRtpSocket, rtpBuffer).ConfigureAwait(false);
                 }
                 else
                 {
@@ -2347,7 +2344,7 @@ namespace SIPSorcery.Net
                     }
                     else
                     {
-                        rtpChannel.Send(RTPChannelSocketsEnum.RTP, dstRtpSocket, rtpBuffer.Take(outBufLen).ToArray());
+                        await rtpChannel.SendAsync(RTPChannelSocketsEnum.RTP, dstRtpSocket, rtpBuffer.Take(outBufLen).ToArray()).ConfigureAwait(false);
                     }
                 }
                 m_lastRtpTimestamp = timestamp;
@@ -2371,7 +2368,7 @@ namespace SIPSorcery.Net
             else
             {
                 var reportBytes = report.GetBytes();
-                SendRtcpReport(mediaType, reportBytes);
+                SendRtcpReport(mediaType, reportBytes).ConfigureAwait(false);
                 OnSendReport?.Invoke(mediaType, report);
             }
         }
@@ -2380,7 +2377,7 @@ namespace SIPSorcery.Net
         /// Sends the RTCP report to the remote call party.
         /// </summary>
         /// <param name="report">The serialised RTCP report to send.</param>
-        private void SendRtcpReport(SDPMediaTypesEnum mediaType, byte[] reportBuffer)
+        private async Task SendRtcpReport(SDPMediaTypesEnum mediaType, byte[] reportBuffer)
         {
             IPEndPoint controlDstEndPoint = null;
             if (m_isMediaMultiplexed || mediaType == SDPMediaTypesEnum.audio)
@@ -2406,7 +2403,7 @@ namespace SIPSorcery.Net
 
                 if (m_srtcpControlProtect == null)
                 {
-                    rtpChannel.Send(sendOnSocket, controlDstEndPoint, reportBuffer);
+                    await rtpChannel.SendAsync(sendOnSocket, controlDstEndPoint, reportBuffer).ConfigureAwait(false);
                 }
                 else
                 {
@@ -2421,7 +2418,7 @@ namespace SIPSorcery.Net
                     }
                     else
                     {
-                        rtpChannel.Send(sendOnSocket, controlDstEndPoint, sendBuffer.Take(outBufLen).ToArray());
+                        await rtpChannel.SendAsync(sendOnSocket, controlDstEndPoint, sendBuffer.Take(outBufLen).ToArray()).ConfigureAwait(false);
                     }
                 }
             }
@@ -2493,15 +2490,24 @@ namespace SIPSorcery.Net
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
+            if (isDisposed) { return; }
             Close("disposed");
+            isDisposed = true;
         }
 
         /// <summary>
         /// Close the session if the instance is out of scope.
         /// </summary>
-        public virtual void Dispose()
+        public void Dispose()
         {
-            Close("disposed");
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~RTPSession()
+        {
+            // Finalizer calls Dispose(false)
+            Dispose(false);
         }
     }
 }

--- a/src/net/SDP/SDPMediaFormat.cs
+++ b/src/net/SDP/SDPMediaFormat.cs
@@ -97,6 +97,27 @@ namespace SIPSorcery.Net
                     return GetClockRate(payloadType);
             }
         }
+
+        public static bool EncodingParameterMandatory(SDPMediaFormatsEnum payloadType)
+        {
+            switch (payloadType)
+            {
+                case SDPMediaFormatsEnum.OPUS:
+                    return true;
+            }
+            return false;
+        }
+
+        public static string EncodingParameterDefault(SDPMediaFormatsEnum formatCodec)
+        {
+            switch (formatCodec)
+            {
+                case SDPMediaFormatsEnum.OPUS:
+                    return "2"; // assume 2 channels
+
+            }
+            throw new ArgumentOutOfRangeException(nameof(formatCodec));
+        }
     }
 
     /// <summary>
@@ -141,7 +162,29 @@ namespace SIPSorcery.Net
         /// a=fmtp:101 0-16
         /// </code>
         /// </summary>
-        public string FormatAttribute { get; set; }
+        public string FormatAttribute
+        {
+            get
+            {
+                var result = Name;
+                if (ClockRate != 0)
+                {
+                    result += "/" + ClockRate;
+                    if (!string.IsNullOrEmpty(EncodingParameter))
+                    {
+                        result += "/" + EncodingParameter;
+                    }
+                    else
+                    {
+                        if (SDPMediaFormatInfo.EncodingParameterMandatory(FormatCodec))
+                        {
+                            result += "/" + SDPMediaFormatInfo.EncodingParameterDefault(FormatCodec);
+                        }
+                    }
+                }
+                return result;
+            }
+        }
 
         /// <summary>
         /// The optional format parameter attribute for the media format. For standard media types this is not necessary.
@@ -182,6 +225,8 @@ namespace SIPSorcery.Net
         /// </summary>
         public bool IsStandardAttribute { get; set; }
 
+        public string EncodingParameter { get; set; }
+
         public SDPMediaFormat(int formatID)
         {
             FormatID = formatID.ToString();
@@ -192,7 +237,6 @@ namespace SIPSorcery.Net
                 ClockRate = SDPMediaFormatInfo.GetRtpClockRate(FormatCodec);
                 //IsStandardAttribute = (formatID < DYNAMIC_ATTRIBUTES_START);
             }
-            FormatAttribute = (ClockRate == 0) ? Name : Name + "/" + ClockRate;
         }
 
         public SDPMediaFormat(string formatID)
@@ -205,15 +249,14 @@ namespace SIPSorcery.Net
         {
             Name = name;
             FormatCodec = GetFormatCodec(Name);
-            FormatAttribute = (ClockRate == 0) ? Name : Name + "/" + ClockRate;
         }
 
-        public SDPMediaFormat(int formatID, string name, int clockRate) : this(formatID)
+        public SDPMediaFormat(int formatID, string name, int clockRate, string encodingParameter) : this(formatID)
         {
             Name = name;
             FormatCodec = GetFormatCodec(Name);
             ClockRate = clockRate;
-            FormatAttribute = (ClockRate == 0) ? Name : Name + "/" + ClockRate;
+            EncodingParameter = encodingParameter;
         }
 
         public SDPMediaFormat(SDPMediaFormatsEnum format) : this((int)format)
@@ -223,9 +266,7 @@ namespace SIPSorcery.Net
 
         public void SetFormatAttribute(string attribute)
         {
-            FormatAttribute = attribute;
-
-            Match attributeMatch = Regex.Match(attribute, @"(?<name>\w+)/(?<clockrate>\d+)\s*");
+            Match attributeMatch = Regex.Match(attribute, @"(?<name>\w+)/(?<clockrate>\d+)/(?<EncodingParameter>\d+)\s*");
             if (attributeMatch.Success)
             {
                 Name = attributeMatch.Result("${name}");
@@ -235,6 +276,9 @@ namespace SIPSorcery.Net
                 {
                     ClockRate = clockRate;
                 }
+
+                EncodingParameter = attributeMatch.Result("${EncodingParameter}");
+
             }
         }
 
@@ -270,7 +314,7 @@ namespace SIPSorcery.Net
         {
             foreach (SDPMediaFormatsEnum format in Enum.GetValues(typeof(SDPMediaFormatsEnum)))
             {
-                if (name.ToLower() == format.ToString().ToLower())
+                if (name.Equals(format.ToString(), StringComparison.OrdinalIgnoreCase))
                 {
                     return format;
                 }
@@ -309,7 +353,7 @@ namespace SIPSorcery.Net
                 // TODO: Need to compare all aspects of the format not just the codec.
                 if (format.FormatAttribute?.StartsWith(SDP.TELEPHONE_EVENT_ATTRIBUTE) != true
                     && b.Any(x => (x.FormatCodec != SDPMediaFormatsEnum.Unknown && x.FormatCodec == format.FormatCodec)
-                    || (x.Name != null && format.Name != null && x.Name.ToLower() == format.Name.ToLower())))
+                    || (x.Name != null && format.Name != null && x.Name.Equals(format.Name, StringComparison.OrdinalIgnoreCase))))
                 {
                     compatible.Add(format);
                 }

--- a/test/integration/net/RTP/RTPChannelIntegrationTest.cs
+++ b/test/integration/net/RTP/RTPChannelIntegrationTest.cs
@@ -79,7 +79,7 @@ namespace SIPSorcery.Net.UnitTests
 
                     logger.LogDebug($"Attempting to send packet from {channel1.RTPLocalEndPoint} to {channel2Dst}.");
 
-                    var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[PACKET_LENGTH]);
+                    var sendResult = await channel1.SendAsync(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[PACKET_LENGTH]).ConfigureAwait(false);
 
                     logger.LogDebug($"Send result {sendResult}.");
 

--- a/test/unit/net/ICE/MockTurnServer.cs
+++ b/test/unit/net/ICE/MockTurnServer.cs
@@ -56,7 +56,7 @@ namespace SIPSorcery.Net.UnitTests
             _listener = new UdpReceiver(_clientSocket);
             _listener.OnPacketReceived += OnPacketReceived;
             _listener.OnClosed += (reason) => logger.LogDebug($"MockTurnServer on {ListeningEndPoint} closed.");
-            _listener.BeginReceiveFrom();
+            _listener.ReceiveAsync();
         }
 
         private void OnPacketReceived(UdpReceiver receiver, int localPort, IPEndPoint remoteEndPoint, byte[] packet)
@@ -83,7 +83,7 @@ namespace SIPSorcery.Net.UnitTests
                         _relayListener = new UdpReceiver(_relaySocket);
                         _relayListener.OnPacketReceived += OnRelayPacketReceived;
                         _relayListener.OnClosed += (reason) => logger.LogDebug($"MockTurnServer relay on {_relayEndPoint} closed.");
-                        _relayListener.BeginReceiveFrom();
+                        _relayListener.ReceiveAsync();
                     }
 
                     STUNMessage allocateResponse = new STUNMessage(STUNMessageTypesEnum.AllocateSuccessResponse);

--- a/test/unit/net/RTP/RTPChannelUnitTest.cs
+++ b/test/unit/net/RTP/RTPChannelUnitTest.cs
@@ -94,7 +94,7 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug($"Attempting to send packet from {channel1.RTPLocalEndPoint} to {channel2Dst}.");
 
-            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x00 });
+            var sendResult = await channel1.SendAsync(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x00 }).ConfigureAwait(false);
 
             logger.LogDebug($"Send result {sendResult}.");
 
@@ -141,7 +141,7 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug($"Attempting to send packet from {channel1.RTPLocalEndPoint} to {channel2Dst}.");
 
-            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x00 });
+            var sendResult = await channel1.SendAsync(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x00 }).ConfigureAwait(false);
 
             logger.LogDebug($"Send result {sendResult}.");
 
@@ -188,7 +188,7 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug($"Attempting to send packet from {channel1.RTPLocalEndPoint} to {channel2Dst}.");
 
-            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x00 });
+            var sendResult = await channel1.SendAsync(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x00 }).ConfigureAwait(false);
 
             logger.LogDebug($"Send result {sendResult}.");
 

--- a/test/unit/net/RTP/RTPHeaderUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderUnitTest.cs
@@ -31,7 +31,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            RTPHeader rtpHeader = new RTPHeader();
+            RTPHeader rtpHeader = new RTPHeader(null);
             byte[] headerBuffer = rtpHeader.GetHeader(1, 0, 1);
 
             int byteNum = 1;
@@ -48,7 +48,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            RTPHeader src = new RTPHeader();
+            RTPHeader src = new RTPHeader(null);
             byte[] headerBuffer = src.GetHeader(1, 0, 1);
             RTPHeader dst = new RTPHeader(headerBuffer);
 
@@ -81,7 +81,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            RTPHeader src = new RTPHeader();
+            RTPHeader src = new RTPHeader(null);
             src.Version = 3;
             src.PaddingFlag = 1;
             src.HeaderExtensionFlag = 1;


### PR DESCRIPTION
This PR is quite big. Unfortunately it is not so easy to split this all up, since a lot of things are dependant on one another.

**Major changes**
- RTCPeerConnection async
- Fix in Dispose logic

**Major performance changes**
- DtlsUtils - reuse key generators saves time on every connection attempt
- NetServices: Gather network interfaces once - Saves 200 milliseconds on each call

**Minor performance changes**
- RawPacket -  Unnecessary seeking in RTP header removed - minor performance improvement
- RTPHeader removed default constructor saves 3 calls that are unnecessary
- RTPPacket changed to work with the changes for RTPHeader

**Changes required for WebRTCBridge**
- VP8 header - required change for getting correct bits from the header in WebRTCBridge
- Fix Dispose for RTPSession
- RTPSession refactored NextSeqNum and used native ushort instead of UInt16 and fixed the Dispose method

