### PR TITLE
Updated to handle receiving of larger UDP packets

### DIFF
--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -77,7 +77,7 @@ namespace SIPSorcery.SIP
                 Port = (m_udpSocket.LocalEndPoint as IPEndPoint).Port;
             }
 
-            m_recvBuffer = new byte[SIPConstants.SIP_MAXIMUM_UDP_SEND_LENGTH * 2];
+            m_recvBuffer = new byte[SIPConstants.SIP_MAXIMUM_RECEIVE_LENGTH];
 
             logger.LogInformation($"SIP UDP Channel created for {ListeningEndPoint}.");
 
@@ -119,6 +119,11 @@ namespace SIPSorcery.SIP
                     SocketFlags flags = SocketFlags.None;
 
                     int bytesRead = m_udpSocket.EndReceiveMessageFrom(ar, ref flags, ref remoteEP, out var packetInfo);
+
+                    if (flags == SocketFlags.Truncated)
+                    {
+                        logger.LogWarning($"The message was too large to fit into the specified buffer and was truncated.");
+                    }
 
                     if (bytesRead > 0)
                     {

--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -32,6 +32,8 @@ namespace SIPSorcery.SIP
         public const int NONCE_TIMEOUT_MINUTES = 5;                         // Length of time an issued nonce is valid for.
         public const int SIP_MAXIMUM_RECEIVE_LENGTH = 65535;                // Any SIP messages over this size will generate an error.
         public const int SIP_MAXIMUM_UDP_SEND_LENGTH = 1300;                // Any SIP messages over this size should be prevented from using a UDP transport.
+        public const int SIP_MAXIMUM_UDP_RECEIVE_LENGTH = 65535;            // RFC 3251 implementations MUST be able to handle messages up to the maximum datagram packet size. For UDP, this size is 65,535 bytes, ...
+
         public const string SIP_REQUEST_REGEX = @"^\w+ .* SIP/.*";          // bnf:	Request-Line = Method SP Request-URI SP SIP-Version CRLF
         public const string SIP_RESPONSE_REGEX = @"^SIP/.* \d{3}";          // bnf: Status-Line = SIP-Version SP Status-Code SP Reason-Phrase CRLF
         public const string SIP_BRANCH_MAGICCOOKIE = "z9hG4bK";

--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -32,7 +32,6 @@ namespace SIPSorcery.SIP
         public const int NONCE_TIMEOUT_MINUTES = 5;                         // Length of time an issued nonce is valid for.
         public const int SIP_MAXIMUM_RECEIVE_LENGTH = 65535;                // Any SIP messages over this size will generate an error.
         public const int SIP_MAXIMUM_UDP_SEND_LENGTH = 1300;                // Any SIP messages over this size should be prevented from using a UDP transport.
-        public const int SIP_MAXIMUM_UDP_RECEIVE_LENGTH = 65535;            // RFC 3251 implementations MUST be able to handle messages up to the maximum datagram packet size. For UDP, this size is 65,535 bytes, ...
 
         public const string SIP_REQUEST_REGEX = @"^\w+ .* SIP/.*";          // bnf:	Request-Line = Method SP Request-URI SP SIP-Version CRLF
         public const string SIP_RESPONSE_REGEX = @"^SIP/.* \d{3}";          // bnf: Status-Line = SIP-Version SP Status-Code SP Reason-Phrase CRLF


### PR DESCRIPTION
I noticed large UDP packets were being truncated. Hope this is of use.
