### PR TITLE
send/async use semaphoreslim instead of lock

### DIFF
--- a/src/net/SCTP/Association.cs
+++ b/src/net/SCTP/Association.cs
@@ -360,10 +360,7 @@ namespace SIPSorcery.Net.Sctp
             {
                 ByteBuffer obb = mkPkt(c);
                 //logger.LogDebug($"SCTP packet send: {Packet.getHex(obb)}");
-                lock (this)
-                {
-                    _transp.Send(obb.Data, obb.offset, obb.Limit);
-                }
+                _transp.Send(obb.Data, obb.offset, obb.Limit);
             }
             //else
             //{

--- a/src/net/SCTP/SCTPStream.cs
+++ b/src/net/SCTP/SCTPStream.cs
@@ -172,10 +172,8 @@ namespace SIPSorcery.Net.Sctp
         }
 
         abstract public void send(string message);
-        abstract public Task sendasync(string message);
 
         abstract public void send(byte[] message);
-        abstract public Task sendasync(byte[] message);
 
         public Association getAssociation()
         {

--- a/src/net/SCTP/SCTPStream.cs
+++ b/src/net/SCTP/SCTPStream.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SCTP4CS.Utils;
 using SIPSorcery.Sys;
@@ -171,8 +172,10 @@ namespace SIPSorcery.Net.Sctp
         }
 
         abstract public void send(string message);
+        abstract public Task sendasync(string message);
 
         abstract public void send(byte[] message);
+        abstract public Task sendasync(byte[] message);
 
         public Association getAssociation()
         {

--- a/src/net/SCTP/small/BlockingSCTPStream.cs
+++ b/src/net/SCTP/small/BlockingSCTPStream.cs
@@ -33,7 +33,6 @@ namespace SIPSorcery.Net.Sctp
     {
         private ConcurrentDictionary<int, SCTPMessage> undeliveredOutboundMessages = new ConcurrentDictionary<int, SCTPMessage>();
         private static ILogger logger = Log.Logger;
-        private SemaphoreSlim semaphore = new SemaphoreSlim(1);
 
         public BlockingSCTPStream(Association a, int id) : base(a, id) { }
 

--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Net.Sctp;
 using SIPSorcery.Sys;
@@ -103,6 +104,32 @@ namespace SIPSorcery.Net
             else
             {
                 _sctpStream.send(data);
+            }
+        }
+
+        public Task sendasync(string data)
+        {
+            if (!IsOpened)
+            {
+                logger.LogWarning("An attempt was made to send on a closed data channel.");
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return _sctpStream.sendasync(data);
+            }
+        }
+
+        public Task sendasync(byte[] data)
+        {
+            if (!IsOpened)
+            {
+                logger.LogWarning("An attempt was made to send on a closed data channel.");
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return _sctpStream.sendasync(data);
             }
         }
 

--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -107,32 +107,6 @@ namespace SIPSorcery.Net
             }
         }
 
-        public Task sendasync(string data)
-        {
-            if (!IsOpened)
-            {
-                logger.LogWarning("An attempt was made to send on a closed data channel.");
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _sctpStream.sendasync(data);
-            }
-        }
-
-        public Task sendasync(byte[] data)
-        {
-            if (!IsOpened)
-            {
-                logger.LogWarning("An attempt was made to send on a closed data channel.");
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _sctpStream.sendasync(data);
-            }
-        }
-
         public void send(byte[] data)
         {
             if (!IsOpened)


### PR DESCRIPTION
When I was profiling my app I saw a lot of cpu being used in this lock statement, I switched it over to using semaphoreslim instead when waiting to send. I also added async methods on send as well. Then made the send method use the async methods but using the best practice of GetAwaiter.GetResult() to unwrap any exceptions correctly.