### PR TITLE
SipMessage rawbuffer reference added.

### DIFF
--- a/src/core/SIP/SIPMessageBase.cs
+++ b/src/core/SIP/SIPMessageBase.cs
@@ -65,5 +65,11 @@ namespace SIPSorcery.SIP
         /// when sending this request/response.
         /// </summary>
         public string SendFromHintConnectionID;
+
+        /// <summary>
+        /// Used for binary data payloads where body string might be corrupt due to it's utf-8 encoding.
+        /// </summary>
+        public byte[] RawBuffer;
+
     }
 }

--- a/src/core/SIP/SIPRequest.cs
+++ b/src/core/SIP/SIPRequest.cs
@@ -97,6 +97,7 @@ namespace SIPSorcery.SIP
                     sipRequest.SIPVersion = statusLine.Substring(secondSpacePosn, statusLine.Length - secondSpacePosn).Trim();
                     sipRequest.Header = SIPHeader.ParseSIPHeaders(sipMessage.SIPHeaders);
                     sipRequest.Body = sipMessage.Body;
+                    sipRequest.RawBuffer = sipMessage.RawBuffer;
 
                     return sipRequest;
                 }

--- a/src/core/SIP/SIPResponse.cs
+++ b/src/core/SIP/SIPResponse.cs
@@ -102,7 +102,7 @@ namespace SIPSorcery.SIP
 
                 sipResponse.Header = SIPHeader.ParseSIPHeaders(sipMessageBuffer.SIPHeaders);
                 sipResponse.Body = sipMessageBuffer.Body;
-
+                sipResponse.RawBuffer = sipMessageBuffer.RawBuffer;
                 return sipResponse;
             }
             catch (SIPValidationException)

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -872,7 +872,7 @@ namespace SIPSorcery.SIP
                                 return Task.FromResult(SocketError.InvalidArgument);
                             }
 
-                            SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(rawSIPMessage, localEndPoint, remoteEndPoint);
+                            SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(buffer, localEndPoint, remoteEndPoint);
 
                             if (sipMessageBuffer != null)
                             {


### PR DESCRIPTION
This is for messages with binary data in the body. A multipart/mixed body might contain binary payloads such as images, icons and other small files. Accessing the RawBuffer exposed by this commit is nessesary to obain the correct data as the utf8 encoded Body data could be lossy.