### PR TITLE
Minor efficiency improvements to RTP/RTCP handling

### DIFF
--- a/examples/WebRTCExamples/WebRTCExamples.sln
+++ b/examples/WebRTCExamples/WebRTCExamples.sln
@@ -35,6 +35,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPToWebRtcBridgeVideo", "S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorcery", "..\..\src\SIPSorcery.csproj", "{7C43A82E-2988-4BE3-B047-932ADC28AEE3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorceryMedia.Abstractions", "..\..\..\SIPSorceryMedia.Abstractions\src\SIPSorceryMedia.Abstractions.csproj", "{27E17637-6E6C-4F82-A23F-25A48E42DD93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorceryMedia.Encoders", "..\..\..\SIPSorceryMedia.Encoders\src\SIPSorceryMedia.Encoders.csproj", "{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -237,6 +241,30 @@ Global
 		{7C43A82E-2988-4BE3-B047-932ADC28AEE3}.Release|x64.Build.0 = Release|Any CPU
 		{7C43A82E-2988-4BE3-B047-932ADC28AEE3}.Release|x86.ActiveCfg = Release|Any CPU
 		{7C43A82E-2988-4BE3-B047-932ADC28AEE3}.Release|x86.Build.0 = Release|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Debug|x64.Build.0 = Debug|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Debug|x86.Build.0 = Debug|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Release|x64.ActiveCfg = Release|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Release|x64.Build.0 = Release|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Release|x86.ActiveCfg = Release|Any CPU
+		{27E17637-6E6C-4F82-A23F-25A48E42DD93}.Release|x86.Build.0 = Release|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Debug|x64.Build.0 = Debug|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Debug|x86.Build.0 = Debug|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Release|x64.ActiveCfg = Release|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Release|x64.Build.0 = Release|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Release|x86.ActiveCfg = Release|Any CPU
+		{252A9785-1D6C-4B8E-95B8-30D94E34C7B5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/WebRTCExamples/WebRTCReceiver/WebRTCReceiver.csproj
+++ b/examples/WebRTCExamples/WebRTCReceiver/WebRTCReceiver.csproj
@@ -18,11 +18,12 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <!--<PackageReference Include="SIPSorcery" Version="5.0.3" />-->
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
-    <PackageReference Include="SIPSorceryMedia.Encoders" Version="0.0.7-pre" />
+    <!--<PackageReference Include="SIPSorceryMedia.Encoders" Version="0.0.7-pre" />-->
     <PackageReference Include="SIPSorceryMedia.Windows" Version="0.0.28-pre" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\SIPSorceryMedia.Encoders\src\SIPSorceryMedia.Encoders.csproj" />
     <ProjectReference Include="..\..\..\src\SIPSorcery.csproj" />
   </ItemGroup>
 

--- a/examples/WebRTCExamples/WebRTCReceiver/captureopts.html
+++ b/examples/WebRTCExamples/WebRTCReceiver/captureopts.html
@@ -123,7 +123,7 @@
     <div>
         <fieldset style="width: 400px">
             <legend>Capture Options:</legend>
-            <input type="checkbox" checked="checked" name="captureAudio" /> Audio <br />
+            <input type="checkbox" name="captureAudio" /> Audio <br />
             <input type="checkbox" checked="checked" name="captureVideo" onchange="document.querySelector('#videoResOptions').disabled=!this.checked" /> Video <br />
             <fieldset style="width: 200px" id="videoResOptions">
                 <legend>Video Resolution:</legend>

--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -20,8 +20,12 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.8" />
     <PackageReference Include="DnsClient" Version="1.4.0-beta-20200801.7" />
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
-    <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.0.1" />
+    <!--<PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.0.1" />-->
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SIPSorceryMedia.Abstractions\src\SIPSorceryMedia.Abstractions.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/net/ICE/IceChecklistEntry.cs
+++ b/src/net/ICE/IceChecklistEntry.cs
@@ -183,12 +183,17 @@ namespace SIPSorcery.Net
         public DateTime TurnPermissionsResponseAt { get; set; } = DateTime.MinValue;
 
         /// <summary>
-        /// If a candidate has been nominated then this field records the time the last
+        /// If a candidate has been nominated this field records the time the last
         /// STUN binding response was received from the remote peer.
         /// </summary>
         public DateTime LastConnectedResponseAt { get; set; }
 
         public bool IsLocalController { get; private set; }
+
+        /// <summary>
+        /// Timestamp for the most recent binding request received from the remote peer.
+        /// </summary>
+        public DateTime LastBindingRequestReceivedAt { get; set;}
 
         /// <summary>
         /// Creates a new entry for the ICE session checklist.
@@ -231,6 +236,7 @@ namespace SIPSorcery.Net
                     // If the candidate has been nominated then this is a response to a periodic
                     // check to whether the connection is still available.
                     LastConnectedResponseAt = DateTime.Now;
+                    RequestTransactionID = Crypto.GetRandomString(STUNHeader.TRANSACTION_ID_LENGTH);
                 }
                 else
                 {

--- a/src/net/RTCP/ReceptionReport.cs
+++ b/src/net/RTCP/ReceptionReport.cs
@@ -173,10 +173,14 @@ namespace SIPSorcery.Net
     /// </summary>
     public class ReceptionReport
     {
-        private const int MAX_DROPOUT = 3000;
-        private const int MAX_MISORDER = 100;
-        private const int MIN_SEQUENTIAL = 2;
+        //private const int MAX_DROPOUT = 3000;
+        //private const int MAX_MISORDER = 100;
+        //private const int MIN_SEQUENTIAL = 2;
         private const int RTP_SEQ_MOD = 1 << 16;
+        //private const int MAX_POSITIVE_LOSS = 0x7fffff;
+        //private const int MAX_NEGATIVE_LOSS = 0x800000;
+        private const int SEQ_NUM_WRAP_LOW = 256;
+        private const int SEQ_NUM_WRAP_HIGH = 65280;
 
         /// <summary>
         /// Data source being reported.
@@ -189,12 +193,12 @@ namespace SIPSorcery.Net
         private ushort m_max_seq;
 
         /// <summary>
-        /// shifted count of seq. number cycles.
+        /// Increments by UInt16.MaxValue each time the sequence number wraps around.
         /// </summary>
-        private uint m_cycles;
+        private ulong m_cycles;
 
         /// <summary>
-        /// base seq number
+        /// The first sequence number received.
         /// </summary>
         private uint m_base_seq;
 
@@ -206,7 +210,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// sequ. packets till source is valid.
         /// </summary>
-        private uint m_probation;
+        //private uint m_probation;
 
         /// <summary>
         /// packets received.
@@ -216,7 +220,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// packet expected at last interval.
         /// </summary>
-        private uint m_expected_prior;
+        private ulong m_expected_prior;
 
         /// <summary>
         /// packet received at last interval.
@@ -273,16 +277,58 @@ namespace SIPSorcery.Net
         /// <param name="rtpTimestamp">The timestamp in the RTP header.</param>
         /// <param name="arrivalTimestamp">The current timestamp in the SAME units as the RTP timestamp.
         /// For example for 8Khz audio the arrival timestamp needs 8000 ticks per second.</param>
-        internal bool RtpPacketReceived(ushort seq, uint rtpTimestamp, uint arrivalTimestamp)
+        internal void RtpPacketReceived(ushort seq, uint rtpTimestamp, uint arrivalTimestamp)
         {
             // Sequence number calculations and cycles as per RFC3550 Appendix A.1.
-            if (m_received == 0)
+            //if (m_received == 0)
+            //{
+            //    init_seq(seq);
+            //    m_max_seq = (ushort)(seq - 1);
+            //    m_probation = MIN_SEQUENTIAL;
+            //}
+            //bool ready = update_seq(seq);
+
+            if(m_received == 0)
             {
-                init_seq(seq);
-                m_max_seq = (ushort)(seq - 1);
-                m_probation = MIN_SEQUENTIAL;
+                m_base_seq = seq;
             }
-            bool ready = update_seq(seq);
+
+            m_received++;
+
+            if (seq == m_max_seq + 1)
+            {
+                // Packet is in sequence.
+                m_max_seq = seq; 
+            }
+            else if(seq == 0 && m_max_seq == ushort.MaxValue)
+            {
+                // Packet is in sequence and a wrap around has occurred.
+                m_max_seq = seq;
+                m_cycles += RTP_SEQ_MOD;
+            }
+            else
+            {
+                // Out of order, duplicate or skipped sequence number.
+                if(seq > m_max_seq)
+                {
+                    // Seqnum is greater than expected. RTP packet is dropped or out of order.
+                    m_max_seq = seq;
+                }
+                else if(seq < SEQ_NUM_WRAP_LOW && m_max_seq > SEQ_NUM_WRAP_HIGH)
+                {
+                    // Seqnum is out of order and has wrapped.
+                    m_max_seq = seq;
+                    m_cycles += RTP_SEQ_MOD;
+                }
+                else
+                {
+                    // Remaining conditions are:
+                    // - seqnum == m_max_seq indicating a duplicate RTP packet, or
+                    // - is seqnum is more than 1 less than m_max_seqnum. Which most 
+                    //   likely indicates an RTP packet was delivered out of order.
+                    m_bad_seq++;
+                }
+             }
 
             // Estimating the Interarrival Jitter as defined in RFC3550 Appendix A.8.
             uint transit = arrivalTimestamp - rtpTimestamp;
@@ -294,7 +340,7 @@ namespace SIPSorcery.Net
             }
             m_jitter += (uint)(d - ((m_jitter + 8) >> 4));
 
-            return ready;
+            //return ready;
         }
 
         /// <summary>
@@ -304,15 +350,15 @@ namespace SIPSorcery.Net
         public ReceptionReportSample GetSample(uint ntpTimestampNow)
         {
             // Determining the number of packets expected and lost in RFC3550 Appendix A.3.
-            uint extended_max = m_cycles + m_max_seq;
-            uint expected = extended_max - m_base_seq + 1;
-            int lost = (int)(expected - m_received);
+            ulong extended_max = m_cycles + m_max_seq;
+            ulong expected = extended_max - m_base_seq + 1;
+            int lost = (m_received == 0) ? 0 : (int)(expected - m_received);
 
-            uint expected_interval = expected - m_expected_prior;
+            ulong expected_interval = expected - m_expected_prior;
             m_expected_prior = expected;
             uint received_interval = m_received - m_received_prior;
             m_received_prior = m_received;
-            uint lost_interval = expected_interval - received_interval;
+            ulong lost_interval = expected_interval - received_interval;
             byte fraction = (byte)((expected_interval == 0 || lost_interval <= 0) ? 0 : (lost_interval << 8) / expected_interval);
 
             // In this case, the estimate is sampled for the reception report as:
@@ -324,97 +370,105 @@ namespace SIPSorcery.Net
                 delay = ntpTimestampNow - m_lastSenderReportTimestamp;
             }
 
-            return new ReceptionReportSample(SSRC, fraction, lost, m_max_seq, jitter, m_lastSenderReportTimestamp, delay);
+            return new ReceptionReportSample(SSRC, fraction, (int)lost_interval, m_max_seq, jitter, m_lastSenderReportTimestamp, delay);
         }
 
         /// <summary>
+        /// NOTE 20 Dec 2020: This algorigthm. from RFC3550 Appendix A.1 is intended as part of determining when a new
+        /// RTP source should be accepted as valid. The intention is not necessarily to be used to determine when 
+        /// a reception report can be generated, which was wat it was being used for here.
+        /// 
         /// Initialises the sequence number state for the reception RTP stream.
         /// This method is from RFC3550 Appendix A.1 "RTP Data Header Validity Checks".
         /// </summary>
         /// <param name="seq">The sequence number from the received RTP packet that triggered this update.</param>
-        void init_seq(ushort seq)
-        {
-            m_base_seq = seq;
-            m_max_seq = seq;
-            m_bad_seq = RTP_SEQ_MOD + 1;   /* so seq == bad_seq is false */
-            m_cycles = 0;
-            m_received = 0;
-            m_received_prior = 0;
-            m_expected_prior = 0;
-        }
+        //void init_seq(ushort seq)
+        //{
+        //    m_base_seq = seq;
+        //    m_max_seq = seq;
+        //    m_bad_seq = RTP_SEQ_MOD + 1;   /* so seq == bad_seq is false */
+        //    m_cycles = 0;
+        //    m_received = 0;
+        //    m_received_prior = 0;
+        //    m_expected_prior = 0;
+        //}
 
         /// <summary>
+        /// NOTE 20 Dec 2020: This algorigthm. from RFC3550 Appendix A.1 is intended to decide when a new RTP
+        /// source should be accepted as valid. The intention is not necessarily to be used to determine when 
+        /// a reception report can be generated, which was wat it was being used for here.
+        /// 
         /// Update the sequence number state for the reception RTP stream.
         /// This method is from RFC3550 Appendix A.1 "RTP Data Header Validity Checks".
         /// </summary>
         /// <param name="seq">The sequence number from the received RTP packet that triggered this update.</param>
         /// <returns>True when the required number of packets have been received and a report can be generated. False
         /// indicates not yet enough data.</returns>
-        bool update_seq(ushort seq)
-        {
-            ushort udelta = (ushort)(seq - m_max_seq);
+        //bool update_seq(ushort seq)
+        //{
+        //    ushort udelta = (ushort)(seq - m_max_seq);
 
-            /*
-             * Source is not valid until MIN_SEQUENTIAL packets with
-             * sequential sequence numbers have been received.
-             */
-            if (m_probation > 0)
-            {
-                /* packet is in sequence */
-                if (seq == m_max_seq + 1)
-                {
-                    m_probation--;
-                    m_max_seq = seq;
-                    if (m_probation == 0)
-                    {
-                        init_seq(seq);
-                        m_received++;
-                        return false;
-                    }
-                }
-                else
-                {
-                    m_probation = MIN_SEQUENTIAL - 1;
-                    m_max_seq = seq;
-                }
-                return true;
-            }
-            else if (udelta < MAX_DROPOUT)
-            {
-                /* in order, with permissible gap */
-                if (seq < m_max_seq)
-                {
-                    /*
-                     * Sequence number wrapped - count another 64K cycle.
-                     */
-                    m_cycles += RTP_SEQ_MOD;
-                }
-                m_max_seq = seq;
-            }
-            else if (udelta <= RTP_SEQ_MOD - MAX_MISORDER)
-            {
-                /* the sequence number made a very large jump */
-                if (seq == m_bad_seq)
-                {
-                    /*
-                     * Two sequential packets -- assume that the other side
-                     * restarted without telling us so just re-sync
-                     * (i.e., pretend this was the first packet).
-                     */
-                    init_seq(seq);
-                }
-                else
-                {
-                    m_bad_seq = (uint)((seq + 1) & (RTP_SEQ_MOD - 1));
-                    return true;
-                }
-            }
-            else
-            {
-                /* duplicate or reordered packet */
-            }
-            m_received++;
-            return false;
-        }
+        //    /*
+        //     * Source is not valid until MIN_SEQUENTIAL packets with
+        //     * sequential sequence numbers have been received.
+        //     */
+        //    if (m_probation > 0)
+        //    {
+        //        /* packet is in sequence */
+        //        if (seq == m_max_seq + 1)
+        //        {
+        //            m_probation--;
+        //            m_max_seq = seq;
+        //            if (m_probation == 0)
+        //            {
+        //                init_seq(seq);
+        //                m_received++;
+        //                return false;
+        //            }
+        //        }
+        //        else
+        //        {
+        //            m_probation = MIN_SEQUENTIAL - 1;
+        //            m_max_seq = seq;
+        //        }
+        //        return true;
+        //    }
+        //    else if (udelta < MAX_DROPOUT)
+        //    {
+        //        /* in order, with permissible gap */
+        //        if (seq < m_max_seq)
+        //        {
+        //            /*
+        //             * Sequence number wrapped - count another 64K cycle.
+        //             */
+        //            m_cycles += RTP_SEQ_MOD;
+        //        }
+        //        m_max_seq = seq;
+        //    }
+        //    else if (udelta <= RTP_SEQ_MOD - MAX_MISORDER)
+        //    {
+        //        /* the sequence number made a very large jump */
+        //        if (seq == m_bad_seq)
+        //        {
+        //            /*
+        //             * Two sequential packets -- assume that the other side
+        //             * restarted without telling us so just re-sync
+        //             * (i.e., pretend this was the first packet).
+        //             */
+        //            init_seq(seq);
+        //        }
+        //        else
+        //        {
+        //            m_bad_seq = (uint)((seq + 1) & (RTP_SEQ_MOD - 1));
+        //            return true;
+        //        }
+        //    }
+        //    else
+        //    {
+        //        /* duplicate or reordered packet */
+        //    }
+        //    m_received++;
+        //    return false;
+        //}
     }
 }

--- a/src/net/RTP/MediaStreamTrack.cs
+++ b/src/net/RTP/MediaStreamTrack.cs
@@ -43,6 +43,11 @@ namespace SIPSorcery.Net
         public ushort SeqNum { get; internal set; }
 
         /// <summary>
+        /// The last seqnum received from the remote peer for this stream.
+        /// </summary>
+        public ushort LastRemoteSeqNum { get; internal set; }
+
+        /// <summary>
         /// The value used in the RTP Timestamp header field for media packets
         /// sent using this media stream.
         /// </summary>

--- a/src/net/RTP/RTPChannel.cs
+++ b/src/net/RTP/RTPChannel.cs
@@ -88,9 +88,9 @@ namespace SIPSorcery.Net
             // This exception can be thrown in response to an ICMP packet. The problem is the ICMP packet can be a false positive.
             // For example if the remote RTP socket has not yet been opened the remote host could generate an ICMP packet for the 
             // initial RTP packets. Experience has shown that it's not safe to close an RTP connection based solely on ICMP packets.
-            catch (SocketException)
+            catch (SocketException sockExcp)
             {
-                //logger.LogWarning($"Socket error {sockExcp.SocketErrorCode} in UdpReceiver.BeginReceive. {sockExcp.Message}");
+                logger.LogWarning($"Socket error {sockExcp.SocketErrorCode} in UdpReceiver.BeginReceiveFrom. {sockExcp.Message}");
                 //Close(sockExcp.Message);
             }
             catch (Exception excp)
@@ -98,7 +98,7 @@ namespace SIPSorcery.Net
                 // From https://github.com/dotnet/corefx/blob/e99ec129cfd594d53f4390bf97d1d736cff6f860/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs#L3262
                 // the BeginReceiveFrom will only throw if there is an problem with the arguments or the socket has been disposed of. In that
                 // case the socket can be considered to be unusable and there's no point trying another receive.
-                logger.LogError($"Exception UdpReceiver.BeginReceive. {excp.Message}");
+                logger.LogError($"Exception UdpReceiver.BeginReceiveFrom. {excp.Message}");
                 Close(excp.Message);
             }
         }
@@ -128,12 +128,44 @@ namespace SIPSorcery.Net
                         //}
 
                         byte[] packetBuffer = new byte[bytesRead];
+                        // TODO: When .NET Frmework support is dropped switch to using a slice instead of a copy.
                         Buffer.BlockCopy(m_recvBuffer, 0, packetBuffer, 0, bytesRead);
                         OnPacketReceived?.Invoke(this, m_localEndPoint.Port, remoteEP as IPEndPoint, packetBuffer);
                     }
                 }
+
+                // If there is still data available it should be read now. This is more efficient than calling
+                // BeginReceiveFrom which will incur the overheaed of creating the callback and then immediately firing it.
+                // It also avoids the situation where if the application cannot keep up with the network then BeginReceiveFrom
+                // will be called synchronously (if data is available it calls the callback method immediately) which can
+                // create a very nasty stack.
+                if (!m_isClosed && m_udpSocket.Available > 0)
+                {
+                    EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
+
+                    while (!m_isClosed && m_udpSocket.Available > 0)
+                    {
+                        int bytesReadSync = m_udpSocket.ReceiveFrom(m_recvBuffer, 0, m_recvBuffer.Length, SocketFlags.None, ref remoteEP);
+
+                        if (bytesReadSync > 0)
+                        {
+                            byte[] packetBufferSync = new byte[bytesReadSync];
+                            // TODO: When .NET Frmework support is dropped switch to using a slice instead of a copy.
+                            Buffer.BlockCopy(m_recvBuffer, 0, packetBufferSync, 0, bytesReadSync);
+                            OnPacketReceived?.Invoke(this, m_localEndPoint.Port, remoteEP as IPEndPoint, packetBufferSync);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
             }
-            catch (SocketException)
+            catch(SocketException resetSockExcp) when (resetSockExcp.SocketErrorCode == SocketError.ConnectionReset)
+            {
+                // Thrown when close is called on a socket from this end. Safe to ignore.
+            }
+            catch (SocketException sockExcp)
             {
                 // Socket errors do not trigger a close. The reason being that there are genuine situations that can cause them during
                 // normal RTP operation. For example:
@@ -144,13 +176,13 @@ namespace SIPSorcery.Net
                 // in the BeginReceive method (very handy). Follow-up, this doesn't seem to be the case, the socket exception can occur in 
                 // BeginReceive before any packets have been exchanged. This means it's not safe to close if BeginReceive gets an ICMP 
                 // error since the remote party may not have initialised their socket yet.
-                //logger.LogWarning($"SocketException UdpReceiver.EndReceiveMessage. {sockExcp}");
+                logger.LogWarning($"SocketException UdpReceiver.EndReceiveFrom ({sockExcp.SocketErrorCode}). {sockExcp}");
             }
             catch (ObjectDisposedException) // Thrown when socket is closed. Can be safely ignored.
             { }
             catch (Exception excp)
             {
-                logger.LogError($"Exception UdpReceiver.EndReceiveMessage. {excp}");
+                logger.LogError($"Exception UdpReceiver.EndReceiveFrom. {excp}");
                 Close(excp.Message);
             }
             finally

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1955,8 +1955,7 @@ namespace SIPSorcery.Net
                     {
                         if (m_srtpUnprotect != null)
                         {
-                            int outBufLen = 0;
-                            int res = m_srtpUnprotect(buffer, buffer.Length, out outBufLen);
+                            int res = m_srtpUnprotect(buffer, buffer.Length, out int outBufLen);
 
                             if (res != 0)
                             {
@@ -2032,6 +2031,14 @@ namespace SIPSorcery.Net
                                 // whether it wants to subscribe to frames of RTP packets.
                                 if (mediaType == SDPMediaTypesEnum.video)
                                 {
+                                    if(rtpPacket.Header.SequenceNumber != (VideoRemoteTrack.LastRemoteSeqNum + 1) &&
+                                       !(rtpPacket.Header.SequenceNumber == 0 && VideoRemoteTrack.LastRemoteSeqNum == UInt16.MaxValue))
+                                    {
+                                        logger.LogWarning($"Video stream sequence number jumped from {VideoRemoteTrack.LastRemoteSeqNum} to {rtpPacket.Header.SequenceNumber}.");
+                                    }
+
+                                    VideoRemoteTrack.LastRemoteSeqNum = rtpPacket.Header.SequenceNumber;
+
                                     var videoFormat = GetSendingFormat(SDPMediaTypesEnum.video);
                                     if (videoFormat.Name() == VideoCodecsEnum.VP8.ToString())
                                     {
@@ -2050,6 +2057,16 @@ namespace SIPSorcery.Net
                                     {
                                         logger.LogWarning($"The depacketisation logic for video codec {videoFormat.Name()} has not been implemented, PR's welcome!");
                                     }
+                                }
+                                else if(mediaType == SDPMediaTypesEnum.audio)
+                                {
+                                    if (rtpPacket.Header.SequenceNumber != (AudioRemoteTrack.LastRemoteSeqNum + 1) &&
+                                       !(rtpPacket.Header.SequenceNumber == 0 && AudioRemoteTrack.LastRemoteSeqNum == UInt16.MaxValue))
+                                    {
+                                        logger.LogWarning($"Video stream sequence number jumped from {VideoRemoteTrack.LastRemoteSeqNum} to {rtpPacket.Header.SequenceNumber}.");
+                                    }
+
+                                    AudioRemoteTrack.LastRemoteSeqNum = rtpPacket.Header.SequenceNumber;
                                 }
 
                                 OnRtpPacketReceived?.Invoke(remoteEndPoint, mediaType, rtpPacket);

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -2031,7 +2031,8 @@ namespace SIPSorcery.Net
                                 // whether it wants to subscribe to frames of RTP packets.
                                 if (mediaType == SDPMediaTypesEnum.video)
                                 {
-                                    if(rtpPacket.Header.SequenceNumber != (VideoRemoteTrack.LastRemoteSeqNum + 1) &&
+                                    if(VideoRemoteTrack.LastRemoteSeqNum != 0 &&
+                                        rtpPacket.Header.SequenceNumber != (VideoRemoteTrack.LastRemoteSeqNum + 1) &&
                                        !(rtpPacket.Header.SequenceNumber == 0 && VideoRemoteTrack.LastRemoteSeqNum == UInt16.MaxValue))
                                     {
                                         logger.LogWarning($"Video stream sequence number jumped from {VideoRemoteTrack.LastRemoteSeqNum} to {rtpPacket.Header.SequenceNumber}.");
@@ -2058,12 +2059,13 @@ namespace SIPSorcery.Net
                                         logger.LogWarning($"The depacketisation logic for video codec {videoFormat.Name()} has not been implemented, PR's welcome!");
                                     }
                                 }
-                                else if(mediaType == SDPMediaTypesEnum.audio)
+                                else if(mediaType == SDPMediaTypesEnum.audio && AudioRemoteTrack != null)
                                 {
-                                    if (rtpPacket.Header.SequenceNumber != (AudioRemoteTrack.LastRemoteSeqNum + 1) &&
+                                    if (AudioRemoteTrack.LastRemoteSeqNum != 0 &&
+                                        rtpPacket.Header.SequenceNumber != (AudioRemoteTrack.LastRemoteSeqNum + 1) &&
                                        !(rtpPacket.Header.SequenceNumber == 0 && AudioRemoteTrack.LastRemoteSeqNum == UInt16.MaxValue))
                                     {
-                                        logger.LogWarning($"Video stream sequence number jumped from {VideoRemoteTrack.LastRemoteSeqNum} to {rtpPacket.Header.SequenceNumber}.");
+                                        logger.LogWarning($"Audio stream sequence number jumped from {AudioRemoteTrack.LastRemoteSeqNum} to {rtpPacket.Header.SequenceNumber}.");
                                     }
 
                                     AudioRemoteTrack.LastRemoteSeqNum = rtpPacket.Header.SequenceNumber;

--- a/src/net/RTP/RtpVideoFramer.cs
+++ b/src/net/RTP/RtpVideoFramer.cs
@@ -25,10 +25,12 @@ namespace SIPSorcery.Net
 {
     public class RtpVideoFramer
     {
+        private const int MAX_FRAME_SIZE = 65536;
+
         private static ILogger logger = Log.Logger;
 
         private VideoCodecsEnum _codec;
-        private byte[] _currVideoFrame = new byte[65536];
+        private byte[] _currVideoFrame = new byte[MAX_FRAME_SIZE];
         private int _currVideoFramePosn = 0;
 
         public RtpVideoFramer(VideoCodecsEnum codec)
@@ -45,8 +47,10 @@ namespace SIPSorcery.Net
         {
             var payload = rtpPacket.Payload;
 
-            //logger.LogDebug($"rtp video, seqnum {seqnum}, ts {timestamp}, marker {marker}, payload {payload.Length}.");
-            if (_currVideoFramePosn + payload.Length >= _currVideoFrame.Length)
+            //var hdr = rtpPacket.Header;
+            //logger.LogDebug($"rtp video, seqnum {hdr.SequenceNumber}, ts {hdr.Timestamp}, marker {hdr.MarkerBit}, payload {payload.Length}.");
+
+            if (_currVideoFramePosn + payload.Length >= MAX_FRAME_SIZE)
             {
                 // Something has gone very wrong. Clear the buffer.
                 _currVideoFramePosn = 0;
@@ -73,9 +77,8 @@ namespace SIPSorcery.Net
             }
             else
             {
-                var hdr = rtpPacket.Header;
                 logger.LogWarning("Discarding RTP packet, VP8 header Start bit not set.");
-                logger.LogWarning($"rtp video, seqnum {hdr.SequenceNumber}, ts {hdr.Timestamp}, marker {hdr.MarkerBit}, payload {payload.Length}.");
+                //logger.LogWarning($"rtp video, seqnum {hdr.SequenceNumber}, ts {hdr.Timestamp}, marker {hdr.MarkerBit}, payload {payload.Length}.");
             }
 
             return null;

--- a/test/unit/net/RTCP/ReceptionReportUnitTest.cs
+++ b/test/unit/net/RTCP/ReceptionReportUnitTest.cs
@@ -1,0 +1,75 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: ReceptionReportUnitTest.cs
+//
+// Description: Unit tests for the ReceptionReport class.
+
+// Author(s):
+// Aaron Clauson (aaron@sipsorcery.com)
+// 
+// History:
+// 20 Dec 2020  Aaron Clauson   Created, Dublin, Ireland.
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using Xunit;
+
+namespace SIPSorcery.UnitTests.Net
+{
+    [Trait("Category", "unit")]
+    public class ReceptionReportUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public ReceptionReportUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Checks that the lost packet count and sequence number are correctly sampled for
+        /// a single RTP packet received.
+        /// </summary>
+        [Fact]
+        public void CheckSinglePacketReportUnitTest()
+        {
+            uint ssrc = 1234;
+
+            ReceptionReport rep = new ReceptionReport(ssrc);
+
+            var sample0 = rep.GetSample(0);
+
+            Assert.NotNull(sample0);
+            Assert.Equal(0, sample0.PacketsLost);
+            Assert.Equal(0U, sample0.ExtendedHighestSequenceNumber);
+        }
+
+        /// <summary>
+        /// Checks that the lost packet count and sequence number are correctly sampled for
+        /// three in order RTP packets being received.
+        /// </summary>
+        [Fact]
+        public void CheckThreePacketsReportUnitTest()
+        {
+            uint ssrc = 1234;
+            ushort seq = 0;
+
+            ReceptionReport rep = new ReceptionReport(ssrc);
+
+            rep.RtpPacketReceived(seq++, 0, 0);
+            rep.RtpPacketReceived(seq++, 0, 0);
+            rep.RtpPacketReceived(seq++, 0, 0);
+
+            var sample3 = rep.GetSample(0);
+
+            Assert.NotNull(sample3);
+            Assert.Equal(0, sample3.PacketsLost);
+            Assert.Equal(2U, sample3.ExtendedHighestSequenceNumber);
+        }
+    }
+}


### PR DESCRIPTION
As part of an investigation into supporting 1080p WebRTC video streams two areas of improvement were identified:

 - The RTCP reception reports were reporting the wrong loss statistics. This statistic can be used by the remote peer, Chrome makes use of it, to adjust the sending bit rate.
 
 - The `UdpReceiver` class was observed to create a very large call stack when unable to keep up with the UDP packets arriving from the network. The reason for this is the begin/end callback mechanism used. An improvement is after each end receive call check if there is more network data available and if so process it immediately and avoid teh callback.