### PR TITLE
Add description for media streams

### DIFF
--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -237,6 +237,18 @@ namespace SIPSorcery.Net
                                 sdp.SessionName = sdpLineTrimmed.Substring(2);
                                 break;
 
+                            case var l when l.StartsWith("i="):
+                                if (activeAnnouncement != null)
+                                {
+                                    activeAnnouncement.MediaDescription = sdpLineTrimmed.Substring(2);
+                                }
+                                else
+                                {
+                                    sdp.SessionDescription = sdpLineTrimmed.Substring(2);
+                                }
+
+                                break;
+
                             case var l when l.StartsWith("c="):
 
                                 if (activeAnnouncement != null)

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -120,6 +120,11 @@ namespace SIPSorcery.Net
         public List<string> BandwidthAttributes = new List<string>();
 
         /// <summary>
+        /// In media definitions, "i=" fields are primarily intended for labelling media streams https://tools.ietf.org/html/rfc4566#page-12
+        /// </summary>
+        public string MediaDescription;
+
+        /// <summary>
         ///  For AVP these will normally be a media payload type as defined in the RTP Audio/Video Profile.
         /// </summary>
         public Dictionary<int, SDPAudioVideoMediaFormat> MediaFormats = new Dictionary<int, SDPAudioVideoMediaFormat>();
@@ -219,6 +224,9 @@ namespace SIPSorcery.Net
         public override string ToString()
         {
             string announcement = "m=" + Media + " " + Port + " " + Transport + " " + GetFormatListToString() + m_CRLF;
+
+            announcement += !string.IsNullOrWhiteSpace(MediaDescription) ? "i=" + MediaDescription + m_CRLF : null;
+
             announcement += (Connection == null) ? null : Connection.ToString();
 
             foreach (string bandwidthAttribute in BandwidthAttributes)

--- a/test/unit/net/SDP/SDPUnitTests.cs
+++ b/test/unit/net/SDP/SDPUnitTests.cs
@@ -1061,6 +1061,7 @@ a=ssrc:2404235415 cname:{7c06c5db-d3db-4891-b729-df4919014c3f}";
                 @"v=0
 o=root 5936658357711814578 0 IN IP4 0.0.0.0
 s=-
+i=mySession
 t=0 0
 m=audio 55316 RTP/AVP 0 101
 a=rtpmap:0 PCMU/8000
@@ -1081,6 +1082,8 @@ a=fmtp:MCPTT mc_queueing;mc_priority=4";
 
             Assert.Equal("MCPTT", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.application).Single().ApplicationMediaFormats.Single().Key);
             Assert.Equal("mc_queueing;mc_priority=4", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.application).Single().ApplicationMediaFormats.Single().Value.Fmtp);
+            Assert.Equal("mySession", rndTripSdp.SessionDescription);
+            Assert.Equal("speech", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.audio).Single().MediaDescription);
         }
     }
 }


### PR DESCRIPTION
I have a requirement to specify the "i" field for media sessions and documented in [RFC4566](https://tools.ietf.org/html/rfc4566#page-12)

I couldn't find a good place to put a unit test for the SDPMediaAnnouncement.ToString() change. So please point me in the right direction if you have an idea for that.