### PR TITLE
Fix data loss when body contains non-UTF8 data

### DIFF
--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -872,7 +872,7 @@ namespace SIPSorcery.SIP
                                 return Task.FromResult(SocketError.InvalidArgument);
                             }
 
-                            SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(rawSIPMessage, localEndPoint, remoteEndPoint);
+                            SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(buffer, localEndPoint, remoteEndPoint);
 
                             if (sipMessageBuffer != null)
                             {


### PR DESCRIPTION
When parsing a sip message the SipTransport was passing in the UTF8 decoded messsge, instead of the raw buffer. This caused data loss when the buffer contained non-UTF8 encoded data (as used in mcdata messages).