### PR TITLE
Revert "Enhancing the flexibility of protocol encoding processing "

### DIFF
--- a/src/core/SIP/Channels/SIPChannel.cs
+++ b/src/core/SIP/Channels/SIPChannel.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -163,22 +162,11 @@ namespace SIPSorcery.SIP
             InternetDefaultAddress = NetServices.InternetDefaultAddress;
         }
 
-        protected SIPChannel() : this(SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING)
+        public SIPChannel()
         {
             int id = Interlocked.Increment(ref _lastUsedChannelID);
             ID = id.ToString();
         }
-
-        protected SIPChannel(Encoding sipEncoding, Encoding sipBodyEncoding)
-        {
-            int id = Interlocked.Increment(ref _lastUsedChannelID);
-            ID = id.ToString();
-            SIPEncoding = sipEncoding;
-            SIPBodyEncoding = sipBodyEncoding;
-        }
-
-        public Encoding SIPEncoding { get; private set; }
-        public Encoding SIPBodyEncoding { get; private set; }
 
         /// <summary>
         /// Checks whether the host string corresponds to a socket address that this SIP channel is listening on.

--- a/src/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -23,7 +23,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -93,16 +92,11 @@ namespace SIPSorcery.SIP
         /// </summary>
         private bool m_isReceiveTaskRunning = false;
 
-        public SIPClientWebSocketChannel() 
-        {
-
-        }
-
         /// <summary>
         /// Creates a SIP channel to establish outbound connections and send SIP messages 
         /// over a web socket communications layer.
         /// </summary>
-        public SIPClientWebSocketChannel(Encoding sipEncoding, Encoding sipBodyEncoding) : base(sipEncoding, sipBodyEncoding)
+        public SIPClientWebSocketChannel() : base()
         {
             IsReliable = true;
             SIPProtocol = SIPProtocolsEnum.ws;
@@ -425,7 +419,7 @@ namespace SIPSorcery.SIP
             clientConn.RecvEndPosn += bytesRead;
 
             int bytesSkipped = 0;
-            byte[] sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(clientConn.PendingReceiveBuffer, clientConn.RecvStartPosn, clientConn.RecvEndPosn, SIPEncoding, out bytesSkipped);
+            byte[] sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(clientConn.PendingReceiveBuffer, clientConn.RecvStartPosn, clientConn.RecvEndPosn, out bytesSkipped);
 
             while (sipMsgBuffer != null)
             {
@@ -447,7 +441,7 @@ namespace SIPSorcery.SIP
                 else
                 {
                     // Try and extract another SIP message from the receive buffer.
-                    sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(clientConn.PendingReceiveBuffer, clientConn.RecvStartPosn, clientConn.RecvEndPosn, SIPEncoding, out bytesSkipped);
+                    sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(clientConn.PendingReceiveBuffer, clientConn.RecvStartPosn, clientConn.RecvEndPosn, out bytesSkipped);
                 }
             }
         }

--- a/src/core/SIP/Channels/SIPStreamConnection.cs
+++ b/src/core/SIP/Channels/SIPStreamConnection.cs
@@ -21,7 +21,6 @@ using System;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Text;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP
@@ -41,9 +40,6 @@ namespace SIPSorcery.SIP
         /// RecvSocketArgs is used for TCP channel receives. 
         /// </summary>
         public Socket StreamSocket;
-
-        private readonly Encoding m_sipEncoding;
-        private readonly Encoding m_sipBodyEncoding;
         public SocketAsyncEventArgs RecvSocketArgs;
 
         /// <summary>
@@ -93,33 +89,14 @@ namespace SIPSorcery.SIP
         /// </summary>
         public event SIPMessageReceivedAsyncDelegate SIPMessageReceived;
 
-        public SIPStreamConnection(
-            Socket streamSocket,
-            SIPEndPoint remoteSIPEndPoint,
-            SIPProtocolsEnum connectionProtocol) : this(streamSocket, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING, remoteSIPEndPoint,
-            connectionProtocol)
-        {
-
-        }
-
         /// <summary>
         /// Records the crucial stream connection properties and initialises the required buffers.
         /// </summary>
         /// <param name="streamSocket">The local socket the stream is using.</param>
-        /// <param name="remoteSIPEndPoint">The remote network end point of this connection.</param>
+        /// <param name="remoteEndPoint">The remote network end point of this connection.</param>
         /// <param name="connectionProtocol">Whether the stream is TCP or TLS.</param>
-        /// <param name="sipEncoding"></param>
-        /// <param name="sipBodyEncoding"></param>
-        public SIPStreamConnection(
-            Socket streamSocket,
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding,
-            SIPEndPoint remoteSIPEndPoint,
-            SIPProtocolsEnum connectionProtocol)
+        public SIPStreamConnection(Socket streamSocket, SIPEndPoint remoteSIPEndPoint, SIPProtocolsEnum connectionProtocol)
         {
-            m_sipEncoding = sipEncoding;
-            m_sipBodyEncoding = sipBodyEncoding;
-
             StreamSocket = streamSocket;
             LastTransmission = DateTime.Now;
             RemoteSIPEndPoint = remoteSIPEndPoint;
@@ -145,7 +122,7 @@ namespace SIPSorcery.SIP
             RecvEndPosn += bytesRead;
 
             int bytesSkipped = 0;
-            byte[] sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(buffer, RecvStartPosn, RecvEndPosn, m_sipEncoding, out bytesSkipped);
+            byte[] sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(buffer, RecvStartPosn, RecvEndPosn, out bytesSkipped);
 
             while (sipMsgBuffer != null)
             {
@@ -169,7 +146,7 @@ namespace SIPSorcery.SIP
                 else
                 {
                     // Try and extract another SIP message from the receive buffer.
-                    sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(buffer, RecvStartPosn, RecvEndPosn, m_sipEncoding, out bytesSkipped);
+                    sipMsgBuffer = SIPMessageBuffer.ParseSIPMessageFromStream(buffer, RecvStartPosn, RecvEndPosn, out bytesSkipped);
                 }
             }
         }

--- a/src/core/SIP/Channels/SIPTCPChannel.cs
+++ b/src/core/SIP/Channels/SIPTCPChannel.cs
@@ -83,7 +83,7 @@ namespace SIPSorcery.SIP
         /// This string is used in debug messages. It makes it possible to differentiate
         /// whether an instance in acting solely as a TCP channel or as the base class of a TLS channel.
         /// </summary>
-        protected virtual string ProtDescr { get; } = "TCP";
+        virtual protected string ProtDescr { get; } = "TCP";
 
         /// <summary>
         /// Can be set to allow TCP channels hosted in the same process to send to each other. Useful for testing.
@@ -100,31 +100,14 @@ namespace SIPSorcery.SIP
         private CancellationTokenSource m_cts = new CancellationTokenSource();
         private bool m_isDualMode;
 
-        public SIPTCPChannel(
-            IPEndPoint endPoint,
-            SIPProtocolsEnum protocol,
-            bool canListen=true,
-            bool useDualMode=false) : this(endPoint, protocol,SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING, canListen, useDualMode)
-        {
-
-        }
-
         /// <summary>
         /// Creates a SIP channel to listen for and send SIP messages over TCP.
         /// </summary>
         /// <param name="endPoint">The IP end point to send from and optionally listen on.</param>
         /// <param name="protocol">Whether the channel is being used with TCP or TLS (TLS channels get upgraded once connected).</param>
-        /// <param name="sipBodyEncoding"></param>
         /// <param name="canListen">Indicates whether the channel is capable of listening for new client connections.
         /// A TLS channel without a certificate cannot listen.</param>
-        /// <param name="sipEncoding"></param>
-        public SIPTCPChannel(
-            IPEndPoint endPoint, 
-            SIPProtocolsEnum protocol, 
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding,
-            bool canListen, 
-            bool useDualMode) : base(sipEncoding,sipBodyEncoding)
+        public SIPTCPChannel(IPEndPoint endPoint, SIPProtocolsEnum protocol, bool canListen = true, bool useDualMode = false) : base()
         {
             if (endPoint == null)
             {
@@ -164,10 +147,6 @@ namespace SIPSorcery.SIP
             : this(endPoint, SIPProtocolsEnum.tcp, true, useDualMode)
         { }
 
-        public SIPTCPChannel(IPEndPoint endPoint,Encoding sipEncoding,Encoding sipBodyEncoding, bool useDualMode = false)
-            : this(endPoint, SIPProtocolsEnum.tcp, sipEncoding,sipBodyEncoding,true, useDualMode)
-        { }
-
         public SIPTCPChannel(IPAddress listenAddress, int listenPort, bool useDualMode = false)
             : this(new IPEndPoint(listenAddress, listenPort), SIPProtocolsEnum.tcp, true, useDualMode)
         { }
@@ -194,7 +173,7 @@ namespace SIPSorcery.SIP
                         clientSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                         clientSocket.LingerState = new LingerOption(true, 0);
 
-                        SIPStreamConnection sipStmConn = new SIPStreamConnection(clientSocket,  SIPEncoding,SIPBodyEncoding,remoteEndPoint, SIPProtocol);
+                        SIPStreamConnection sipStmConn = new SIPStreamConnection(clientSocket, remoteEndPoint, SIPProtocol);
                         sipStmConn.SIPMessageReceived += SIPTCPMessageReceived;
 
                         m_connections.TryAdd(sipStmConn.ConnectionID, sipStmConn);
@@ -400,7 +379,7 @@ namespace SIPSorcery.SIP
                     logger.LogDebug($"ConnectAsync SIP {ProtDescr} Channel connect completed result for {ListeningSIPEndPoint}->{dstEndPoint} {connectTcs.Task.Result}.");
 
                     var remoteSIPEndPoint = new SIPEndPoint(SIPProtocol, clientSocket.RemoteEndPoint as IPEndPoint);
-                    SIPStreamConnection sipStmConn = new SIPStreamConnection(clientSocket,SIPEncoding,SIPBodyEncoding,  remoteSIPEndPoint, SIPProtocol);
+                    SIPStreamConnection sipStmConn = new SIPStreamConnection(clientSocket, remoteSIPEndPoint, SIPProtocol);
                     sipStmConn.SIPMessageReceived += SIPTCPMessageReceived;
 
                     var postConnectResult = await OnClientConnect(sipStmConn, serverCertificateName).ConfigureAwait(false);
@@ -483,7 +462,7 @@ namespace SIPSorcery.SIP
                 }
                 else if (!DisableLocalTCPSocketsCheck && NetServices.LocalIPAddresses.Contains(dstSIPEndPoint.Address) && Port == dstSIPEndPoint.Port)
                 {
-                    logger.LogWarning($"SIP {ProtDescr} Channel blocked Send to {dstSIPEndPoint} as it was identified as a locally hosted {ProtDescr} socket.\r\n" + SIPConstants.DEFAULT_ENCODING.GetString(buffer));
+                    logger.LogWarning($"SIP {ProtDescr} Channel blocked Send to {dstSIPEndPoint} as it was identified as a locally hosted {ProtDescr} socket.\r\n" + Encoding.UTF8.GetString(buffer));
                     throw new ApplicationException($"A Send call was blocked in SIP {ProtDescr} Channel due to the destination being another local TCP socket.");
                 }
                 else

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -27,7 +27,6 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -52,24 +51,12 @@ namespace SIPSorcery.SIP
         /// </summary>
         private static ConcurrentDictionary<IPEndPoint, DateTime> m_sendFailures = new ConcurrentDictionary<IPEndPoint, DateTime>();
 
-        public SIPUDPChannel(
-            IPEndPoint endPoint,
-            bool useDualMode = false) : this(endPoint, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING, useDualMode)
-        {
-
-        }
         /// <summary>
         /// Creates a SIP channel to listen for and send SIP messages over UDP.
         /// </summary>
         /// <param name="endPoint">The IP end point to listen on and send from.</param>
-        /// <param name="sipBodyEncoding"></param>
         /// <param name="useDualMode">If true then IPv6 sockets will be created as dual mode IPv4/IPv6 on supporting systems.</param>
-        /// <param name="sipEncoding"></param>
-        public SIPUDPChannel(
-            IPEndPoint endPoint,
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding,
-            bool useDualMode=false) : base(sipEncoding, sipBodyEncoding)
+        public SIPUDPChannel(IPEndPoint endPoint, bool useDualMode = false) : base()
         {
             if (endPoint == null)
             {
@@ -87,8 +74,8 @@ namespace SIPSorcery.SIP
             {
                 Port = (m_udpSocket.LocalEndPoint as IPEndPoint).Port;
             }
-
-            if (ListeningIPAddress.AddressFamily == AddressFamily.InterNetworkV6)
+            
+            if(ListeningIPAddress.AddressFamily == AddressFamily.InterNetworkV6)
             {
                 m_isDualMode = m_udpSocket.DualMode;
             }
@@ -260,9 +247,9 @@ namespace SIPSorcery.SIP
         /// This method is not implemented for the SIP UDP channel.
         /// </summary>
         public override Task<SocketError> SendSecureAsync(SIPEndPoint dstEndPoint,
-            byte[] buffer,
-            string serverCertificateName,
-            bool canInitiateConnection,
+            byte[] buffer, 
+            string serverCertificateName, 
+            bool canInitiateConnection, 
             string connectionIDHint)
         {
             throw new NotImplementedException("This Send method is not available in the SIP UDP channel, please use an alternative overload.");

--- a/src/core/SIP/Channels/SIPWebSocketChannel.cs
+++ b/src/core/SIP/Channels/SIPWebSocketChannel.cs
@@ -29,7 +29,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -140,24 +139,11 @@ namespace SIPSorcery.SIP
 
         private CancellationTokenSource m_cts = new CancellationTokenSource();
 
-        public SIPWebSocketChannel(
-            IPEndPoint endPoint,
-            X509Certificate2 certificate) : this(endPoint, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING, certificate)
-        {
-
-        }
-
         /// <summary>
         /// Creates a SIP channel to listen for and send SIP messages over a web socket communications layer.
         /// </summary>
         /// <param name="endPoint">The IP end point to listen on and send from.</param>
-        /// <param name="sipEncoding"></param>
-        /// <param name="sipBodyEncoding"></param>
-        public SIPWebSocketChannel(
-            IPEndPoint endPoint,
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding, 
-            X509Certificate2 certificate) : base(sipEncoding, sipBodyEncoding)
+        public SIPWebSocketChannel(IPEndPoint endPoint, X509Certificate2 certificate) : base()
         {
             if (endPoint == null)
             {

--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -16,9 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using SIPSorcery.Sys;
-// ReSharper disable InconsistentNaming
 
 namespace SIPSorcery.SIP
 {
@@ -76,8 +74,6 @@ namespace SIPSorcery.SIP
                 return _userAgentVersion;
             }
         }
-
-        public static Encoding DEFAULT_ENCODING = Encoding.UTF8;
 
         /// <summary>
         /// Gets the default SIP port for the protocol. 
@@ -227,7 +223,7 @@ namespace SIPSorcery.SIP
         /// <returns>True if the protocol is connectionless.</returns>
         public static bool IsConnectionless(SIPProtocolsEnum protocol)
         {
-            if (protocol == SIPProtocolsEnum.udp)
+            if(protocol == SIPProtocolsEnum.udp)
             {
                 return true;
             }

--- a/src/core/SIP/SIPMessageBase.cs
+++ b/src/core/SIP/SIPMessageBase.cs
@@ -32,17 +32,6 @@ namespace SIPSorcery.SIP
 
         protected byte[] _body;
 
-        public Encoding SIPEncoding { get;protected set; }
-        public Encoding SIPBodyEncoding { get; protected set; }
-
-        public SIPMessageBase():this(SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING){}
-
-        public SIPMessageBase(Encoding sipEncoding, Encoding sipBodyEncoding)
-        {
-            SIPEncoding = sipEncoding;
-            SIPBodyEncoding = sipBodyEncoding;
-        }
-
         /// <summary>
         /// The SIP request/response's headers collection.
         /// </summary>
@@ -58,7 +47,7 @@ namespace SIPSorcery.SIP
             {
                 if (_body != null)
                 {
-                    return SIPBodyEncoding.GetString(_body);
+                    return Encoding.UTF8.GetString(_body);
                 }
                 else
                 {
@@ -73,7 +62,7 @@ namespace SIPSorcery.SIP
                 }
                 else
                 {
-                    _body = SIPBodyEncoding.GetBytes(value);
+                    _body = Encoding.UTF8.GetBytes(value);
                 }
             }
         }
@@ -122,7 +111,7 @@ namespace SIPSorcery.SIP
 
             if (_body != null && _body.Length > 0)
             {
-                var headerBytes = SIPEncoding.GetBytes(headers);
+                var headerBytes = Encoding.UTF8.GetBytes(headers);
                 byte[] buffer = new byte[headerBytes.Length + _body.Length];
                 Buffer.BlockCopy(headerBytes, 0, buffer, 0, headerBytes.Length);
                 Buffer.BlockCopy(_body, 0, buffer, headerBytes.Length, _body.Length);
@@ -130,7 +119,7 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                return SIPEncoding.GetBytes(headers);
+                return Encoding.UTF8.GetBytes(headers);
             }
         }
     }

--- a/src/core/SIP/SIPMessageBuffer.cs
+++ b/src/core/SIP/SIPMessageBuffer.cs
@@ -26,15 +26,6 @@ namespace SIPSorcery.SIP
     /// </summary>
     public class SIPMessageBuffer
     {
-        public readonly Encoding SIPEncoding;
-        public readonly Encoding SIPBodyEncoding;
-
-        public SIPMessageBuffer(Encoding sipEncoding, Encoding sipBodyEncoding)
-        {
-            SIPEncoding = sipEncoding;
-            SIPBodyEncoding = sipBodyEncoding;
-        }
-
         private const string SIP_RESPONSE_PREFIX = "SIP";
         private const string SIP_MESSAGE_IDENTIFIER = "SIP";    // String that must be in a message buffer to be recognised as a SIP message and processed.
 
@@ -51,7 +42,7 @@ namespace SIPSorcery.SIP
             {
                 if (RawBuffer != null)
                 {
-                    return SIPEncoding.GetString(RawBuffer);
+                    return Encoding.UTF8.GetString(RawBuffer);
                 }
                 else
                 {
@@ -70,27 +61,14 @@ namespace SIPSorcery.SIP
         public SIPEndPoint RemoteSIPEndPoint;               // The remote IP socket the message was received from or sent to.
         public SIPEndPoint LocalSIPEndPoint;                // The local SIP socket the message was received on or sent from.
 
-        public static SIPMessageBuffer ParseSIPMessage(
-            byte[] buffer,
-            SIPEndPoint localSIPEndPoint,
-            SIPEndPoint remoteSIPEndPoint) =>
-            ParseSIPMessage(buffer, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING, localSIPEndPoint, localSIPEndPoint);
-
         /// <summary>
         /// Attempts to parse a SIP message from a single buffer that can only contain a single message.
         /// </summary>
         /// <param name="buffer">The buffer that will be parsed for a SIP message.</param>
-        /// <param name="sipBodyEncoding">SIP payload encoding</param>
         /// <param name="localSIPEndPoint">The end point the message was received on.</param>
         /// <param name="remoteSIPEndPoint">The end point the message was received from.</param>
-        /// <param name="sipEncoding">SIP protocol encoding, according to RFC should be UTF-8 </param>
         /// <returns>If successful a SIP message or null if not.</returns>
-        public static SIPMessageBuffer ParseSIPMessage(
-            byte[] buffer, 
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding,
-            SIPEndPoint localSIPEndPoint, 
-            SIPEndPoint remoteSIPEndPoint)
+        public static SIPMessageBuffer ParseSIPMessage(byte[] buffer, SIPEndPoint localSIPEndPoint, SIPEndPoint remoteSIPEndPoint)
         {
 
             if (buffer == null || buffer.Length < m_minFirstLineLength)
@@ -109,7 +87,7 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                var sipMessage = new SIPMessageBuffer(sipEncoding,sipBodyEncoding);
+                var sipMessage = new SIPMessageBuffer();
 
                 sipMessage.RawBuffer = buffer;
                 sipMessage.LocalSIPEndPoint = localSIPEndPoint;
@@ -121,7 +99,7 @@ namespace SIPSorcery.SIP
                     sipMessage.LocalSIPEndPoint.ConnectionID = remoteSIPEndPoint.ConnectionID;
                 }
 
-                string message = sipEncoding.GetString(buffer);
+                string message = Encoding.UTF8.GetString(buffer);
                 int endFistLinePosn = message.IndexOf(m_CRLF);
 
                 if (endFistLinePosn != -1)
@@ -165,31 +143,17 @@ namespace SIPSorcery.SIP
                 }
             }
         }
-        public static SIPMessageBuffer ParseSIPMessage(
-            string message,
-            SIPEndPoint localSIPEndPoint,
-            SIPEndPoint remoteSIPEndPoint)
-        {
-            return ParseSIPMessage(SIPConstants.DEFAULT_ENCODING.GetBytes(message), SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING, localSIPEndPoint, remoteSIPEndPoint);
-        }
 
         /// <summary>
         /// Attempts to parse a SIP message from a string containing a single SIP request or response.
         /// </summary>
         /// <param name="message">The string to parse.</param>
-        /// <param name="sipBodyEncoding"></param>
         /// <param name="localSIPEndPoint">The end point the message was received on.</param>
         /// <param name="remoteSIPEndPoint">The end point the message was received from.</param>
-        /// <param name="sipEncoding"></param>
         /// <returns>If successful a SIP message or null if not.</returns>
-        public static SIPMessageBuffer ParseSIPMessage(
-            string message,
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding,
-            SIPEndPoint localSIPEndPoint, 
-            SIPEndPoint remoteSIPEndPoint)
+        public static SIPMessageBuffer ParseSIPMessage(string message, SIPEndPoint localSIPEndPoint, SIPEndPoint remoteSIPEndPoint)
         {
-            return ParseSIPMessage(sipEncoding.GetBytes(message), sipEncoding,sipBodyEncoding, localSIPEndPoint, remoteSIPEndPoint);
+            return ParseSIPMessage(Encoding.UTF8.GetBytes(message), localSIPEndPoint, remoteSIPEndPoint);
         }
 
         //rj2: check if message could be "well"known Ping message
@@ -227,13 +191,6 @@ namespace SIPSorcery.SIP
             return false;
         }
 
-        public static byte[] ParseSIPMessageFromStream(
-            byte[] receiveBuffer,
-            int start,
-            int length,
-            out int bytesSkipped) =>
-            ParseSIPMessageFromStream(receiveBuffer, start, length, SIPConstants.DEFAULT_ENCODING, out bytesSkipped);
-
         /// <summary>
         /// Processes a buffer from a TCP read operation to extract the first full SIP message. If no full SIP 
         /// messages are available it returns null which indicates the next read should be appended to the current
@@ -242,14 +199,8 @@ namespace SIPSorcery.SIP
         /// <param name="receiveBuffer">The buffer to check for the SIP message in.</param>
         /// <param name="start">The position in the buffer to start parsing for a SIP message.</param>
         /// <param name="length">The position in the buffer that indicates the end of the received bytes.</param>
-        /// <param name="sipEncoding"></param>
         /// <returns>A byte array holding a full SIP message or if no full SIP messages are available null.</returns>
-        public static byte[] ParseSIPMessageFromStream(
-            byte[] receiveBuffer,
-            int start, 
-            int length, 
-            Encoding sipEncoding,
-            out int bytesSkipped)
+        public static byte[] ParseSIPMessageFromStream(byte[] receiveBuffer, int start, int length, out int bytesSkipped)
         {
             // NAT keep-alives can be interspersed between SIP messages. Treat any non-letter character
             // at the start of a receive as a non SIP transmission and skip over it.
@@ -273,7 +224,7 @@ namespace SIPSorcery.SIP
                 int endMessageIndex = BufferUtils.GetStringPosition(receiveBuffer, start, length, m_sipMessageDelimiter, null);
                 if (endMessageIndex != -1)
                 {
-                    int contentLength = GetContentLength(receiveBuffer, start, endMessageIndex, sipEncoding);
+                    int contentLength = GetContentLength(receiveBuffer, start, endMessageIndex);
                     int messageLength = endMessageIndex - start + m_sipMessageDelimiter.Length + contentLength;
 
                     if (length - start >= messageLength)
@@ -288,18 +239,14 @@ namespace SIPSorcery.SIP
             return null;
         }
 
-        public static int GetContentLength(byte[] buffer, int start, int end) =>
-            GetContentLength(buffer, start, end, SIPConstants.DEFAULT_ENCODING);
-
         /// <summary>
         /// Attempts to find the Content-Length header is a SIP header and extract it.
         /// </summary>
         /// <param name="buffer">The buffer to search in.</param>
         /// <param name="start">The position in the buffer to start the search from.</param>
         /// <param name="end">The position in the buffer to stop the search at.</param>
-        /// <param name="sipEncoding"></param>
         /// <returns>If the Content-Length header is found the value if contains otherwise 0.</returns>
-        public static int GetContentLength(byte[] buffer, int start, int end,Encoding sipEncoding)
+        public static int GetContentLength(byte[] buffer, int start, int end)
         {
             if (buffer == null || start > end || buffer.Length < end)
             {
@@ -307,8 +254,8 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                byte[] contentHeaderBytes = sipEncoding.GetBytes(m_CRLF + SIPSorcery.SIP.SIPHeaders.SIP_HEADER_CONTENTLENGTH.ToUpper());
-                byte[] compactContentHeaderBytes = sipEncoding.GetBytes(m_CRLF + SIPSorcery.SIP.SIPHeaders.SIP_COMPACTHEADER_CONTENTLENGTH.ToUpper());
+                byte[] contentHeaderBytes = Encoding.UTF8.GetBytes(m_CRLF + SIPSorcery.SIP.SIPHeaders.SIP_HEADER_CONTENTLENGTH.ToUpper());
+                byte[] compactContentHeaderBytes = Encoding.UTF8.GetBytes(m_CRLF + SIPSorcery.SIP.SIPHeaders.SIP_COMPACTHEADER_CONTENTLENGTH.ToUpper());
 
                 int inContentHeaderPosn = 0;
                 int inCompactContentHeaderPosn = 0;

--- a/src/core/SIP/SIPRequest.cs
+++ b/src/core/SIP/SIPRequest.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace SIPSorcery.SIP
@@ -51,40 +50,28 @@ namespace SIPSorcery.SIP
             }
         }
 
-        private SIPRequest(Encoding sipEncoding, Encoding sipBodyEncoding) : this(SIPMethodsEnum.NONE, SIPURI.None,sipEncoding,sipBodyEncoding)
-        {
-        }
-
         private SIPRequest()
+        { }
+
+        public SIPRequest(SIPMethodsEnum method, string uri)
         {
+            Method = method;
+            URI = SIPURI.ParseSIPURI(uri);
+            SIPVersion = m_sipFullVersion;
         }
 
-        public SIPRequest(SIPMethodsEnum method, string uri):this(method, SIPURI.ParseSIPURI(uri))
-        {
-        }
-
-        public SIPRequest(SIPMethodsEnum method, SIPURI uri) 
+        public SIPRequest(SIPMethodsEnum method, SIPURI uri)
         {
             Method = method;
             URI = uri;
             SIPVersion = m_sipFullVersion;
         }
 
-        public SIPRequest(SIPMethodsEnum method, SIPURI uri,Encoding sipEncoding,Encoding sipBodyEncoding):base(sipEncoding,sipBodyEncoding)
-        {
-            Method = method;
-            URI = uri;
-            SIPVersion = m_sipFullVersion;
-        }
-
-        public static SIPRequest ParseSIPRequest(SIPMessageBuffer sipMessage) =>
-            ParseSIPRequest(sipMessage, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING);
-
-        public static SIPRequest ParseSIPRequest(SIPMessageBuffer sipMessage,Encoding sipEncoding,Encoding sipBodyEncoding)
+        public static SIPRequest ParseSIPRequest(SIPMessageBuffer sipMessage)
         {
             try
             {
-                SIPRequest sipRequest = new SIPRequest(sipEncoding,sipBodyEncoding);
+                SIPRequest sipRequest = new SIPRequest();
                 sipRequest.LocalSIPEndPoint = sipMessage.LocalSIPEndPoint;
                 sipRequest.RemoteSIPEndPoint = sipMessage.RemoteSIPEndPoint;
 
@@ -131,15 +118,12 @@ namespace SIPSorcery.SIP
             }
         }
 
-        public static SIPRequest ParseSIPRequest(string sipMessageStr) =>
-            ParseSIPRequest(sipMessageStr, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING);
-
-        public static SIPRequest ParseSIPRequest(string sipMessageStr,Encoding sipEncoding,Encoding sipBodyEncoding)
+        public static SIPRequest ParseSIPRequest(string sipMessageStr)
         {
             try
             {
-                SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(sipMessageStr, sipEncoding,sipBodyEncoding, null, null);
-                return SIPRequest.ParseSIPRequest(sipMessageBuffer,sipEncoding,sipBodyEncoding);
+                SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(sipMessageStr, null, null);
+                return SIPRequest.ParseSIPRequest(sipMessageBuffer);
             }
             catch (SIPValidationException)
             {
@@ -189,8 +173,6 @@ namespace SIPSorcery.SIP
             copy.UnknownMethod = UnknownMethod;
             copy.URI = URI?.CopyOf();
             copy.Header = Header?.Copy();
-            copy.SIPEncoding = SIPEncoding;
-            copy.SIPBodyEncoding = SIPBodyEncoding;
 
             if (_body != null && _body.Length > 0)
             {

--- a/src/core/SIP/SIPResponse.cs
+++ b/src/core/SIP/SIPResponse.cs
@@ -15,7 +15,6 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
 
@@ -59,14 +58,15 @@ namespace SIPSorcery.SIP
         {
             get { return Header?.CSeqMethod + " " + StatusCode + " " + ReasonPhrase; }
         }
-        private SIPResponse(
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding) : this(SIPResponseStatusCodesEnum.None, string.Empty,sipEncoding,sipBodyEncoding)
+
+        private SIPResponse()
         { }
 
-        private SIPResponse():this(SIPResponseStatusCodesEnum.None,string.Empty)
-        { }
-
+        /// <summary>
+        /// SIPResponse Constructor.
+        /// </summary>
+        /// <param name="responseStatus">The status code for the response.</param>
+        /// <param name="reasonPhrase">Optional description for the response. Should be kept short.</param>
         public SIPResponse(
             SIPResponseStatusCodesEnum responseStatus,
             string reasonPhrase)
@@ -79,40 +79,15 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
-        /// SIPResponse Constructor.
-        /// </summary>
-        /// <param name="responseStatus">The status code for the response.</param>
-        /// <param name="reasonPhrase">Optional description for the response. Should be kept short.</param>
-        /// <param name="sipEncoding"></param>
-        /// <param name="sipBodyEncoding"></param>
-        public SIPResponse(
-            SIPResponseStatusCodesEnum responseStatus,
-            string reasonPhrase,
-            Encoding sipEncoding,
-            Encoding sipBodyEncoding):base(sipEncoding,sipBodyEncoding)
-        {
-            SIPVersion = m_sipFullVersion;
-            StatusCode = (int)responseStatus;
-            Status = responseStatus;
-            ReasonPhrase = reasonPhrase;
-            ReasonPhrase = responseStatus.ToString();
-        }
-
-        public static SIPResponse ParseSIPResponse(SIPMessageBuffer sipMessageBuffer) =>
-            ParseSIPResponse(sipMessageBuffer, sipMessageBuffer.SIPEncoding, sipMessageBuffer.SIPBodyEncoding);
-
-        /// <summary>
         /// Parses a SIP response from a SIP message object.
         /// </summary>
         /// <param name="sipMessageBuffer">The SIP message to parse a response from.</param>
-        /// <param name="sipEncoding"></param>
-        /// <param name="sipBodyEncoding"></param>
         /// <returns>A new SIP response object.</returns>
-        public static SIPResponse ParseSIPResponse(SIPMessageBuffer sipMessageBuffer,Encoding sipEncoding,Encoding sipBodyEncoding)
+        public static SIPResponse ParseSIPResponse(SIPMessageBuffer sipMessageBuffer)
         {
             try
             {
-                SIPResponse sipResponse = new SIPResponse(sipEncoding,sipBodyEncoding);
+                SIPResponse sipResponse = new SIPResponse();
                 sipResponse.LocalSIPEndPoint = sipMessageBuffer.LocalSIPEndPoint;
                 sipResponse.RemoteSIPEndPoint = sipMessageBuffer.RemoteSIPEndPoint;
                 string statusLine = sipMessageBuffer.FirstLine;
@@ -142,22 +117,17 @@ namespace SIPSorcery.SIP
             }
         }
 
-        public static SIPResponse ParseSIPResponse(string sipMessageStr) =>
-            ParseSIPResponse(sipMessageStr, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING);
-
         /// <summary>
         /// Parses a SIP response from a string.
         /// </summary>
         /// <param name="sipMessageStr">The string to parse the SIP response from.</param>
-        /// <param name="sipEncoding"></param>
-        /// <param name="sipBodyEncoding"></param>
         /// <returns>A new SIP response object.</returns>
-        public static SIPResponse ParseSIPResponse(string sipMessageStr,Encoding sipEncoding, Encoding sipBodyEncoding)
+        public static SIPResponse ParseSIPResponse(string sipMessageStr)
         {
             try
             {
-                SIPMessageBuffer sipMessage = SIPMessageBuffer.ParseSIPMessage(sipMessageStr, sipEncoding, sipBodyEncoding, null, null);
-                return SIPResponse.ParseSIPResponse(sipMessage, sipEncoding,sipBodyEncoding);
+                SIPMessageBuffer sipMessage = SIPMessageBuffer.ParseSIPMessage(sipMessageStr, null, null);
+                return SIPResponse.ParseSIPResponse(sipMessage);
             }
             catch (SIPValidationException)
             {
@@ -207,8 +177,6 @@ namespace SIPSorcery.SIP
             copy.StatusCode = StatusCode;
             copy.ReasonPhrase = ReasonPhrase;
             copy.Header = Header?.Copy();
-            copy.SIPEncoding = SIPEncoding;
-            copy.SIPBodyEncoding = SIPBodyEncoding;
 
             if (_body != null && _body.Length > 0)
             {

--- a/src/core/SIP/SIPURI.cs
+++ b/src/core/SIP/SIPURI.cs
@@ -28,8 +28,6 @@ namespace SIPSorcery.SIP
     [DataContract]
     public class SIPURI
     {
-        public static SIPURI None = new SIPURI();
-
         public const char SCHEME_ADDR_SEPARATOR = ':';
         public const char USER_HOST_SEPARATOR = '@';
         public const char PARAM_TAG_DELIMITER = ';';


### PR DESCRIPTION
Reverts sipsorcery-org/sipsorcery#595

I get two failures on the SIP web socket channel integration tests after merging this PR.

````
 SIPSorcery.SIP.IntegrationTest.SIPTransportIntegrationTest.WebSocketLoopbackLargeSendReceiveTest
   Source: SIPTransportIntegrationTest.cs line 607
   Duration: 706 ms

  Message: 
System.ApplicationException : Protocol 0 was not recognised in GetDefaultPort.

  Stack Trace: 
SIPConstants.GetDefaultPort(SIPProtocolsEnum protocol) line 102
SIPEndPoint.ctor(SIPProtocolsEnum protocol, IPAddress address, Int32 port, String channelID, String connectionID) line 108
SIPChannel.get_ListeningSIPEndPoint() line 127
<WebSocketLoopbackLargeSendReceiveTest>d__12.MoveNext() line 640
--- End of stack trace from previous location where exception was thrown ---
<>c.<ThrowAsync>b__6_0(Object state)

  Standard Output: 
19:40:58.4151 [Debug]  --> MoveNext
19:40:58.8298 [Information]  SIP WebSocket Channel created for 127.0.0.1:9001.


 SIPSorcery.SIP.IntegrationTest.SIPTransportIntegrationTest.WebSocketLoopbackSendReceiveTest
   Source: SIPTransportIntegrationTest.cs line 562
   Duration: 1.1 sec

  Message: 
System.ApplicationException : Protocol 0 was not recognised in GetDefaultPort.

  Stack Trace: 
SIPConstants.GetDefaultPort(SIPProtocolsEnum protocol) line 102
SIPEndPoint.ctor(SIPProtocolsEnum protocol, IPAddress address, Int32 port, String channelID, String connectionID) line 108
SIPChannel.get_ListeningSIPEndPoint() line 127
<WebSocketLoopbackSendReceiveTest>d__11.MoveNext() line 589
--- End of stack trace from previous location where exception was thrown ---
<>c.<ThrowAsync>b__6_0(Object state)

  Standard Output: 
19:40:23.0647 [Debug]  --> MoveNext
19:40:23.6087 [Information]  SIP WebSocket Channel created for 127.0.0.1:9000.
````