### PR TITLE
To compare string ignoring case, use the option StringComparison.OrdinalIgnoreCase

### DIFF
--- a/src/core/SIP/SIPEndPoint.cs
+++ b/src/core/SIP/SIPEndPoint.cs
@@ -137,11 +137,11 @@ namespace SIPSorcery.SIP
                 return null;
             }
 
-            if (sipEndPointStr.ToLower().StartsWith("udp:") ||
-                sipEndPointStr.ToLower().StartsWith("tcp:") ||
-                sipEndPointStr.ToLower().StartsWith("tls:") ||
-                sipEndPointStr.ToLower().StartsWith("ws:") ||
-                sipEndPointStr.ToLower().StartsWith("wss:"))
+            if (sipEndPointStr.StartsWith("udp:", StringComparison.OrdinalIgnoreCase) ||
+                sipEndPointStr.StartsWith("tcp:", StringComparison.OrdinalIgnoreCase) ||
+                sipEndPointStr.StartsWith("tls:", StringComparison.OrdinalIgnoreCase) ||
+                sipEndPointStr.StartsWith("ws:", StringComparison.OrdinalIgnoreCase)  ||
+                sipEndPointStr.StartsWith("wss:", StringComparison.OrdinalIgnoreCase))
             {
                 return ParseSerialisedSIPEndPoint(sipEndPointStr);
             }

--- a/src/core/SIPEvents/SIPEventPackages.cs
+++ b/src/core/SIPEvents/SIPEventPackages.cs
@@ -163,16 +163,14 @@ namespace SIPSorcery.SIP
             {
                 return false;
             }
-            else if (value.ToLower() == "cancelled" || value.ToLower() == "error" || value.ToLower() == "local-bye" ||
-                value.ToLower() == "rejected" || value.ToLower() == "replaced" || value.ToLower() == "remote-bye" ||
-                value.ToLower() == "timeout")
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+
+            return value.Equals("cancelled", StringComparison.OrdinalIgnoreCase)  ||
+                   value.Equals("error", StringComparison.OrdinalIgnoreCase)      ||
+                   value.Equals("local-bye", StringComparison.OrdinalIgnoreCase)  ||
+                   value.Equals("rejected", StringComparison.OrdinalIgnoreCase)   ||
+                   value.Equals("replaced", StringComparison.OrdinalIgnoreCase)   ||
+                   value.Equals("remote-bye", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("timeout", StringComparison.OrdinalIgnoreCase);
         }
 
         public static SIPEventDialogStateEvent Parse(string value)


### PR DESCRIPTION
This is much better for performance, as it avoids string allocations and conversion of the whole string prior to comparing. It is also idiomatic.