### PR TITLE
Change the definition of enum SIPExtensions to allow using as a bitfield

### DIFF
--- a/src/core/SIP/SIPHeader.cs
+++ b/src/core/SIP/SIPHeader.cs
@@ -1516,9 +1516,9 @@ namespace SIPSorcery.SIP
 
         public List<string> UnknownHeaders = new List<string>();    // Holds any unrecognised headers.
 
-        public List<SIPExtensions> RequiredExtensions = new List<SIPExtensions>();
+        public SIPExtensions RequiredExtensions = 0;
+        public SIPExtensions SupportedExtensions = 0;
         public string UnknownRequireExtension = null;
-        public List<SIPExtensions> SupportedExtensions = new List<SIPExtensions>();
 
         public bool HasAuthenticationHeader => AuthenticationHeaders.Count > 0;
 

--- a/src/core/SIPTransactions/SIPTransaction.cs
+++ b/src/core/SIPTransactions/SIPTransaction.cs
@@ -265,8 +265,8 @@ namespace SIPSorcery.SIP
                 m_sentBy = transactionRequest.Header.Vias.TopViaHeader.ContactAddress;
                 OutboundProxy = outboundProxy;
 
-                if (transactionRequest.Header.RequiredExtensions.Contains(SIPExtensions.Prack) ||
-                    transactionRequest.Header.SupportedExtensions.Contains(SIPExtensions.Prack))
+                if (transactionRequest.Header.RequiredExtensions.HasFlag(SIPExtensions.Prack) ||
+                    transactionRequest.Header.SupportedExtensions.HasFlag(SIPExtensions.Prack))
                 {
                     PrackSupported = true;
                 }

--- a/test/unit/core/SIP/SIPHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPHeaderUnitTest.cs
@@ -777,8 +777,8 @@ namespace SIPSorcery.SIP.UnitTests
             string[] headersCollection = Regex.Split(inviteHeaders, "\r\n");
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
 
-            Assert.True(sipHeader.RequiredExtensions.Contains(SIPExtensions.Prack), "The required header extensions was missing Prack.");
-            Assert.True(sipHeader.SupportedExtensions.Contains(SIPExtensions.Prack), "The supported header extensions was missing Prack.");
+            Assert.True(sipHeader.RequiredExtensions.HasFlag(SIPExtensions.Prack), "The required header extensions was missing Prack.");
+            Assert.True(sipHeader.SupportedExtensions.HasFlag(SIPExtensions.Prack), "The supported header extensions was missing Prack.");
             Assert.True(sipHeader.UnknownRequireExtension != null, "The had unknown required header extension was not correctly set.");
 
             logger.LogDebug("---------------------------------------------------");


### PR DESCRIPTION
Change the definition of enum SIPExtensions to allow using as a bitfieldeld.

In class SIPHeader, members RequiredExtensions and SupportedExtensions can now become bitfields instead of lists of enums.
This results in a smaller memory footprint.

Modify static method ParseSIPExtensions accordingly, and eliminate all string concatenations by using a StringBuilder.

> [!IMPORTANT]
> Although this approch is more idiomatic to C#, and reduces the memory footprint of the library, it is important to note that this modifies the public API, as members SupportedExtensions are RequiredExtensions are public. Please let me know what you think about it.