### PR TITLE
Enables ICE-TCP of TURN for WebRTC

### DIFF
--- a/src/SIPSorcery/net/ICE/IceChecklistEntry.cs
+++ b/src/SIPSorcery/net/ICE/IceChecklistEntry.cs
@@ -172,6 +172,8 @@ namespace SIPSorcery.Net
         /// </summary>
         public DateTime LastCheckSentAt = DateTime.MinValue;
 
+        internal DateTime TcpLastCheckSentAt = DateTime.MinValue;
+
         /// <summary>
         /// The number of checks that have been sent without a response.
         /// </summary>
@@ -212,6 +214,8 @@ namespace SIPSorcery.Net
         /// sent for this entry.
         /// </summary>
         public int TurnPermissionsRequestSent { get; set; } = 0;
+
+        internal int TcpBindRequestSent { get; set; } = 0;
 
         /// <summary>
         /// This field records the time a Create Permissions response was received.
@@ -313,7 +317,7 @@ namespace SIPSorcery.Net
                     }
                     else if (errCodeAttribute.ErrorCode == IceServer.STUN_CONNECTION_TIMEOUT_OR_FAILURE)
                     {
-                        TurnConnectReportAt = DateTime.UtcNow;
+                        TurnConnectReportAt = DateTime.Now;
                         retry = true;
                     }
                 }
@@ -386,7 +390,7 @@ namespace SIPSorcery.Net
                     ? connectionIdAttribute.ConnectionId
                     : 0;
 
-                TurnConnectReportAt = DateTime.UtcNow;
+                TurnConnectReportAt = DateTime.Now;
                 TurnConnectRequestSent = 0;
 
                 //After connect request, need ConnectBind
@@ -399,10 +403,11 @@ namespace SIPSorcery.Net
             }
             else if (stunResponse.Header.MessageType == STUNMessageTypesEnum.ConnectionBindSuccess)
             {
-                logger.LogDebug("A TURN ConnectBind sucess response was received from ICE server {IceServer} (TxID: {TransactionId}).",
+                logger.LogDebug("A TURN ConnectionBind sucess response was received from ICE server {IceServer} (TxID: {TransactionId}).",
                     LocalCandidate.IceServer._uri, Encoding.ASCII.GetString(stunResponse.Header.TransactionId));
 
                 TurnConnectBindedAt = TurnConnectReportAt = DateTime.Now;
+                TurnConnectRequestSent = 0;
 
                 //After TCP ConnectBind, we need underlying STUN bind.
                 if (State == ChecklistEntryState.InProgress)

--- a/src/SIPSorcery/net/ICE/IceServer.cs
+++ b/src/SIPSorcery/net/ICE/IceServer.cs
@@ -95,6 +95,10 @@ namespace SIPSorcery.Net
         /// </summary>
         internal const int STUN_STALE_NONCE_ERROR_CODE = 438;
 
+        internal const int STUN_CONNECTION_ALREADY_EXISTS = 446;
+
+        internal const int STUN_CONNECTION_TIMEOUT_OR_FAILURE = 447;
+
         internal STUNUri _uri;
         internal string _username;
         internal string _password;
@@ -178,7 +182,24 @@ namespace SIPSorcery.Net
         /// </summary>
         internal int ErrorResponseCount = 0;
 
+        /// <summary>
+        /// Transport protocol for connecting with the server.
+        /// </summary>
+        /// <remarks>
+        /// Not to be confused of the protocol for allocated ICE relay candidate with TURN (<see cref="IceRelayProtocol"/>).
+        /// </remarks>
         public ProtocolType Protocol { get { return _uri.Protocol; } }
+
+        /// <summary>
+        /// Protocol of the ICE relay candidate to be allocated.
+        /// </summary>
+        /// <remarks>
+        /// Only affects TURN server usage.
+        /// Defaults to <see cref="ProtocolType.Udp"/>
+        /// </remarks>
+        public ProtocolType IceRelayProtocol { get; set; } = ProtocolType.Udp;
+
+        internal STUNUri _secondaryRelayUri;
 
         public STUNUri Uri { get { return _uri; } }
 
@@ -329,9 +350,8 @@ namespace SIPSorcery.Net
 
             if (type == RTCIceCandidateType.srflx && ServerReflexiveEndPoint != null)
             {
-                // TODO: Currently implementation always use UDP candidates as we will only support TURN TCP Transport.
-                //var srflxProtocol = _uri.Protocol == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
-                var srflxProtocol = RTCIceProtocol.udp;
+                var srflxProtocol = _uri.Protocol == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
+                
                 candidate.SetAddressProperties(srflxProtocol, ServerReflexiveEndPoint.Address, (ushort)ServerReflexiveEndPoint.Port,
                                 type, null, 0);
                 candidate.IceServer = this;
@@ -340,9 +360,7 @@ namespace SIPSorcery.Net
             }
             else if (type == RTCIceCandidateType.relay && RelayEndPoint != null)
             {
-                // TODO: Currently implementation always use UDP candidates as we will only support TURN TCP Transport.
-                //var relayProtocol = _uri.Protocol == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
-                var relayProtocol = RTCIceProtocol.udp;
+                var relayProtocol = IceRelayProtocol == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
 
                 candidate.SetAddressProperties(relayProtocol, RelayEndPoint.Address, (ushort)RelayEndPoint.Port,
                     type, null, 0);

--- a/src/SIPSorcery/net/ICE/IceServer.cs
+++ b/src/SIPSorcery/net/ICE/IceServer.cs
@@ -99,6 +99,11 @@ namespace SIPSorcery.Net
 
         internal const int STUN_CONNECTION_TIMEOUT_OR_FAILURE = 447;
 
+        // 10 seconds is from https://datatracker.ietf.org/doc/html/rfc6062#section-4.3
+        internal static TimeSpan waittime => TimeSpan.FromSeconds(10);
+        internal static TimeSpan rttime => TimeSpan.FromSeconds(10 / (MAX_ERRORS));
+        //internal static readonly TimeSpan rttime = TimeSpan.FromSeconds(1);
+
         internal STUNUri _uri;
         internal string _username;
         internal string _password;
@@ -185,10 +190,11 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Transport protocol for connecting with the server.
         /// </summary>
-        /// <remarks>
-        /// Not to be confused of the protocol for allocated ICE relay candidate with TURN (<see cref="IceRelayProtocol"/>).
-        /// </remarks>
         public ProtocolType Protocol { get { return _uri.Protocol; } }
+        // DevNote
+        // <remarks>
+        /// Not to be confused of the protocol for allocated ICE relay candidate with TURN (<see cref="_reqIceProtocol"/>).
+        // </remarks>
 
         /// <summary>
         /// Protocol of the ICE relay candidate to be allocated.
@@ -197,7 +203,8 @@ namespace SIPSorcery.Net
         /// Only affects TURN server usage.
         /// Defaults to <see cref="ProtocolType.Udp"/>
         /// </remarks>
-        public ProtocolType IceRelayProtocol { get; set; } = ProtocolType.Udp;
+        internal ProtocolType _reqIceProtocol { get; set; } = ProtocolType.Udp;
+        //public ProtocolType IceRelayProtocol { get; set; } = ProtocolType.Udp;
 
         internal STUNUri _secondaryRelayUri;
 
@@ -360,7 +367,7 @@ namespace SIPSorcery.Net
             }
             else if (type == RTCIceCandidateType.relay && RelayEndPoint != null)
             {
-                var relayProtocol = IceRelayProtocol == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
+                var relayProtocol = _reqIceProtocol == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
 
                 candidate.SetAddressProperties(relayProtocol, RelayEndPoint.Address, (ushort)RelayEndPoint.Port,
                     type, null, 0);

--- a/src/SIPSorcery/net/ICE/RTCIceCandidate.cs
+++ b/src/SIPSorcery/net/ICE/RTCIceCandidate.cs
@@ -31,6 +31,8 @@ namespace SIPSorcery.Net
         public const string REMOTE_PORT_KEY = "rport";
         public const string CANDIDATE_PREFIX = "candidate";
 
+        public const ushort TCP_DISCARD_PORT = 9;
+
         /// <summary>
         /// The ICE server (STUN or TURN) the candidate was generated from.
         /// Will be null for non-ICE server candidates.
@@ -127,6 +129,7 @@ namespace SIPSorcery.Net
                 component = iceCandidate.component;
                 address = iceCandidate.address;
                 port = iceCandidate.port;
+                protocol = iceCandidate.protocol;
                 type = iceCandidate.type;
                 tcpType = iceCandidate.tcpType;
                 relatedAddress = iceCandidate.relatedAddress;

--- a/src/SIPSorcery/net/ICE/RtpIceChannel.cs
+++ b/src/SIPSorcery/net/ICE/RtpIceChannel.cs
@@ -67,14 +67,19 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Crypto.Digests;
 using SIPSorcery.Sys;
 
@@ -585,6 +590,9 @@ namespace SIPSorcery.Net
         /// </remarks>
         public Func<string, Task<IPAddress[]>> MdnsGetAddresses;
 
+        /// <summary>
+        /// STUN/TURN Control sockets by URI
+        /// </summary>
         public Dictionary<STUNUri, Socket> RtpTcpSocketByUri { get; private set; } = new Dictionary<STUNUri, Socket>();
 
         protected Dictionary<STUNUri, IceTcpReceiver> m_rtpTcpReceiverByUri = new Dictionary<STUNUri, IceTcpReceiver>();
@@ -596,8 +604,20 @@ namespace SIPSorcery.Net
         /// with ICE connectivity checks.
         /// </summary>
         public RtpIceChannel() :
-            this(null, RTCIceComponent.rtp)
+            this(null, RTCIceComponent.rtp, useTcp: false)
         { }
+
+        public RtpIceChannel(
+            IPAddress bindAddress,
+            RTCIceComponent component,
+            List<RTCIceServer> iceServers = null,
+            RTCIceTransportPolicy policy = RTCIceTransportPolicy.all,
+            bool includeAllInterfaceAddresses = false,
+            int bindPort = 0,
+            PortRange rtpPortRange = null)
+            : this(bindAddress, component, iceServers, policy, false, includeAllInterfaceAddresses, bindPort, rtpPortRange)
+        {
+        }
 
         /// <summary>
         /// Creates a new instance of an RTP ICE channel to provide RTP channel functions 
@@ -610,6 +630,7 @@ namespace SIPSorcery.Net
         /// for cases where RTP and RTCP are multiplexed the component is set to RTP.</param>
         /// <param name="iceServers">A list of STUN or TURN servers that can be used by this ICE agent.</param>
         /// <param name="policy">Determines which ICE candidates can be used in this RTP ICE Channel.</param>
+        /// <param name="useTcp">If set to true then the RTP channel will use TCP instead of UDP.</param>
         /// <param name="includeAllInterfaceAddresses">If set to true then IP addresses from ALL local  
         /// interfaces will be used for host ICE candidates. If left as the default false value host 
         /// candidates will be restricted to the single interface that the OS routing table matches to
@@ -622,10 +643,11 @@ namespace SIPSorcery.Net
             RTCIceComponent component,
             List<RTCIceServer> iceServers = null,
             RTCIceTransportPolicy policy = RTCIceTransportPolicy.all,
+            bool useTcp = false,
             bool includeAllInterfaceAddresses = false,
             int bindPort = 0,
             PortRange rtpPortRange = null) :
-            base(false, bindAddress, bindPort, rtpPortRange)
+            base(false, bindAddress, useTcp, bindPort, rtpPortRange)
         {
             _bindAddress = bindAddress;
             Component = component;
@@ -650,16 +672,15 @@ namespace SIPSorcery.Net
             });
 
             _localChecklistCandidate.SetAddressProperties(
-                RTCIceProtocol.udp,
+                useTcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp,
                 base.RTPLocalEndPoint.Address,
+                //useTcp ? RTCIceCandidate.TCP_DISCARD_PORT :
                 (ushort)base.RTPLocalEndPoint.Port,
                 RTCIceCandidateType.host,
                 null,
                 0);
 
-            // Create TCP Socket to implement TURN Control
-            // Take a note that TURN Control will only use TCP for CreatePermissions/Allocate/BindRequests/Data
-            // Ice Candidates returned by relay will always be UDP based.
+            // Create Socket for TURN Control over TCP
             var tcpIceServers = _iceServers != null ?
                                     _iceServers.FindAll(a =>
                                        a != null &&
@@ -721,8 +742,12 @@ namespace SIPSorcery.Net
             {
                 _startedGatheringAt = DateTime.Now;
 
-                // Start listening on the UDP socket.
-                base.Start();
+                // TODO: Remove when TCP is implemented for direct RTP
+                if (RtpSocket.ProtocolType == ProtocolType.Udp)
+                {
+                    // Start listening on the UDP socket.
+                    base.Start();
+                }
                 StartTcpRtpReceiver();
 
                 IceGatheringState = RTCIceGatheringState.gathering;
@@ -888,9 +913,17 @@ namespace SIPSorcery.Net
                 // This implementation currently only supports audio and video multiplexed on a single channel.
                 OnIceCandidateError?.Invoke(candidate, $"Remote ICE candidate only supports multiplexed media, excluding remote candidate with non-zero sdpMLineIndex of {candidate.sdpMLineIndex}.");
             }
-            else if (candidate.protocol != RTCIceProtocol.udp)
+            // This should be invalid conditional since even failed parsing of protocol at SDP will result in 0 = RTCIceProtocol.udp
+            // TODO: remove /or/ catch unsupported protocol at SDP/candidate signalling parsing /or/ start enum value at RTCIceProtocol.udp = 1
+            else if (candidate.protocol switch
+                {
+                    RTCIceProtocol.udp => false,
+                    RTCIceProtocol.tcp => false,
+                    _ => true
+                }
+                )
             {
-                // This implementation currently only supports UDP for RTP communications.
+                // Unimplemented special cases Protocol is used. (TCP/UDP should be OK)
                 OnIceCandidateError?.Invoke(candidate, $"Remote ICE candidate has an unsupported transport protocol {candidate.protocol}.");
             }
             else if (IPAddress.TryParse(candidate.address, out var addr) &&
@@ -1038,7 +1071,10 @@ namespace SIPSorcery.Net
             foreach (var localAddress in localAddresses)
             {
                 var hostCandidate = new RTCIceCandidate(init);
-                hostCandidate.SetAddressProperties(RTCIceProtocol.udp, localAddress, (ushort)base.RTPPort, RTCIceCandidateType.host, null, 0);
+
+                var iceProto = RtpSocket.ProtocolType == ProtocolType.Tcp ? RTCIceProtocol.tcp : RTCIceProtocol.udp;
+
+                hostCandidate.SetAddressProperties(iceProto, localAddress, (ushort)base.RTPPort, RTCIceCandidateType.host, null, 0);
 
                 // We currently only support a single multiplexed connection for all data streams and RTCP.
                 if (hostCandidate.component == RTCIceComponent.rtp && hostCandidate.sdpMLineIndex == SDP_MLINE_INDEX)
@@ -1050,6 +1086,40 @@ namespace SIPSorcery.Net
             }
 
             return hostCandidates;
+        }
+
+                                var iceServerState = new IceServer(stunUri, iceServerID, iceServer.username, iceServer.credential);
+
+                                // Check whether the server end point can be set. IF it can't a DNS lookup will be required.
+                                if (IPAddress.TryParse(iceServerState._uri.Host, out var serverIPAddress))
+                                {
+                                    iceServerState.ServerEndPoint = new IPEndPoint(serverIPAddress, iceServerState._uri.Port);
+                                    logger.LogDebug("ICE server end point for {Uri} set to {EndPoint}.", iceServerState._uri, iceServerState.ServerEndPoint);
+                                }
+
+                                if (stunUri.Scheme == STUNSchemesEnum.turn && iceServer.X_ICERelayProtocol == RTCIceProtocol.tcp)
+                                {
+                                    iceServerState.IceRelayProtocol = ProtocolType.Tcp;
+                                    logger.LogDebug("Will request TCP relay candidate from ICE server {Uri}", iceServerState._uri);
+                                }
+
+                                _iceServerConnections.TryAdd(stunUri, iceServerState);
+
+                                iceServerID++;
+                                if (iceServerID > IceServer.MAXIMUM_ICE_SERVER_ID)
+                                {
+                                    logger.LogWarning("The maximum number of ICE servers for the session has been reached.");
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            logger.LogWarning("RTP ICE Channel could not parse ICE server URL {url}.", url);
+                        }
+                    }
+                }
+            }
         }
 
         private void RefreshTurn(Object state)
@@ -1249,7 +1319,7 @@ namespace SIPSorcery.Net
 
                 if (relayCandidate != null)
                 {
-                    logger.LogDebug("Adding relay ICE candidate for ICE server {Uri} and {EndPoint}.", iceServer._uri, iceServer.RelayEndPoint);
+                    logger.LogDebug("Adding relay ICE candidate for ICE server {Uri} on {RelayProtocol}:{EndPoint}.", iceServer._uri, iceServer.IceRelayProtocol, iceServer.RelayEndPoint);
 
                     _candidates.Add(relayCandidate);
                     OnIceCandidate?.Invoke(relayCandidate);
@@ -1676,6 +1746,15 @@ namespace SIPSorcery.Net
                 return;
             }
 
+            if (candidatePair.LocalCandidate.protocol != candidatePair.RemoteCandidate.protocol)
+            {
+                logger.LogWarning("ICE local and remote candidate protocols do not match, state being set to failed: {LocalProtocol}->{RemoteProtocol}.",
+                    candidatePair.LocalCandidate.protocol, candidatePair.RemoteCandidate.protocol);
+
+                candidatePair.State = ChecklistEntryState.Failed;
+                return;
+            }
+
             if (candidatePair.FirstCheckSentAt == DateTime.MinValue)
             {
                 candidatePair.FirstCheckSentAt = DateTime.Now;
@@ -1687,9 +1766,10 @@ namespace SIPSorcery.Net
             candidatePair.RequestTransactionID = Crypto.GetRandomString(STUNHeader.TRANSACTION_ID_LENGTH);
 
             bool isRelayCheck = candidatePair.LocalCandidate.type == RTCIceCandidateType.relay;
-            //bool isTcpProtocol = candidatePair.LocalCandidate.IceServer?.Protocol == ProtocolType.Tcp;
+            bool isProtoTcp = candidatePair.LocalCandidate.protocol == RTCIceProtocol.tcp;
 
-            if (isRelayCheck && candidatePair.TurnPermissionsResponseAt == DateTime.MinValue)
+            // allow peer to send/connect to relay first
+            if (candidatePair.TurnPermissionsResponseAt == DateTime.MinValue)
             {
                 if (candidatePair.TurnPermissionsRequestSent >= IceServer.MAX_REQUESTS)
                 {
@@ -1705,6 +1785,71 @@ namespace SIPSorcery.Net
                     SendTurnCreatePermissionsRequest(candidatePair.RequestTransactionID, candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint);
                 }
             }
+            // then do prerequisites if the relay candidate is TCP instead of UDP,
+            else if (isRelayCheck && isProtoTcp && candidatePair.TurnConnectBindedAt == DateTime.MinValue)
+            {
+                // we either got ConnectAttempt Indication or we are initiator got connectionid,
+                // we should send a ConnectionBind request to the TURN server
+                if (candidatePair.TurnConnectionId != 0)
+                {
+                    if (candidatePair.TurnConnectRequestSent >= IceServer.MAX_ERRORS)
+                    {
+                        logger.LogDebug("ICE RTP channel failed to request ConnectionBind to {RemoteEndPoint} after {TurnRequestSent} attempts.",
+                            candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.TurnConnectRequestSent);
+
+                        candidatePair.State = ChecklistEntryState.Failed;
+                    }
+                    else
+                    {
+                        logger.LogDebug("ICE RTP channel sending ConnectionBind request to server {IceServerUri} for peer {RemoteEndPoint} (TxID: {RequestTransactionID}).",
+                            candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
+
+                        candidatePair.TurnConnectRequestSent++;
+
+                        SendTurnConnectBindRequest(candidatePair.RequestTransactionID, candidatePair.TurnConnectionId,
+                            candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint);
+
+                        candidatePair.TurnConnectReportAt = DateTime.Now;
+                    }
+                }
+                // we requested Allocate and we are controller (initiator), we should send a Connect request to the TURN server
+                else if (IsController)
+                {
+                    if (DateTime.Now - candidatePair.TurnConnectReportAt >= TimeSpan.FromSeconds(10))
+                    {
+                        if (candidatePair.TurnConnectRequestSent >= IceServer.MAX_ERRORS)
+                        {
+                            logger.LogDebug("ICE RTP channel failed to request Connect to {IceServerUri} after {TurnRequestSent} attempts.",
+                                candidatePair.LocalCandidate.IceServer._uri, candidatePair.TurnConnectRequestSent);
+
+                            candidatePair.State = ChecklistEntryState.Failed;
+                        }
+                        else
+                        {
+                            logger.LogDebug("ICE RTP channel sending Connect request to {IceServerUri} for peer {RemoteCandidate} (TxID: {RequestTransactionID}).",
+                                candidatePair.LocalCandidate.IceServer._uri, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
+
+                            candidatePair.TurnConnectRequestSent++;
+
+                            SendTurnConnectRequest(candidatePair.RequestTransactionID,
+                                candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint);
+
+                            candidatePair.TurnConnectReportAt = DateTime.Now;
+                        }
+                    }
+                    else
+                    {
+                        // Workaround to prevent being timed out,
+                        // TODO: should probably provide way to increase time out for TURN server when TCP relay candidate.
+                        candidatePair.FirstCheckSentAt = candidatePair.TurnConnectReportAt + TimeSpan.FromSeconds(10);
+                    }
+                }
+                // we are not controller (responder), we should wait for the controller to send Connect request
+                else
+                {
+                    candidatePair.State = ChecklistEntryState.Frozen;
+                }
+            }
             else
             {
                 if (candidatePair.LocalCandidate.type == RTCIceCandidateType.relay)
@@ -1718,6 +1863,101 @@ namespace SIPSorcery.Net
                     logger.LogDebug("ICE RTP channel sending connectivity check for {LocalCandidate}->{RemoteCandidate} from {LocalEndPoint} to {RemoteEndPoint} (use candidate {SetUseCandidate}).", candidatePair.LocalCandidate.ToShortString(), candidatePair.RemoteCandidate.ToShortString(), base.RTPLocalEndPoint, remoteEndPoint, setUseCandidate);
                 }
                 SendSTUNBindingRequest(candidatePair, setUseCandidate);
+            }
+        }
+
+        private void SendTurnConnectRequest(string requestTransactionID, IceServer iceServer, IPEndPoint destinationEndPoint)
+        {
+            var stunMsg = new STUNMessage(STUNMessageTypesEnum.Connect);
+            stunMsg.Header.TransactionId = Encoding.ASCII.GetBytes(requestTransactionID);
+
+            stunMsg.Attributes.Add(new STUNXORAddressAttribute(STUNAttributeTypesEnum.XORPeerAddress,
+                    destinationEndPoint.Port, destinationEndPoint.Address,
+                    stunMsg.Header.TransactionId));
+
+            byte[] stunMsgBytes;
+
+            if (iceServer.Nonce != null && iceServer.Realm != null && iceServer._username != null && iceServer._password != null)
+            {
+                stunMsgBytes = GetAuthenticatedStunRequest(stunMsg, iceServer._username, iceServer.Realm, iceServer._password, iceServer.Nonce);
+            }
+            else
+            {
+                stunMsgBytes = stunMsg.ToByteBuffer(null, false);
+            }
+
+            var sendResult = SendOverTCP(iceServer, stunMsgBytes);
+
+            if (sendResult != SocketError.Success)
+            {
+                logger.LogWarning("Error sending TURN Connect request {OutstandingRequestsSent} for {Uri} to {RemoteEndPoint}. {SendResult}.",
+                    iceServer.OutstandingRequestsSent, iceServer._uri, destinationEndPoint, sendResult);
+            }
+            else
+            {
+                OnStunMessageSent?.Invoke(stunMsg, iceServer.ServerEndPoint, false);
+            }
+        }
+
+        private void SendTurnConnectBindRequest(string requestTransactionID, uint turnConnectionId, IceServer iceServer, IPEndPoint destinationEndPoint)
+        {
+            // creates new TCP data relay channel to remote peer if not exists
+            var uri = STUNUri.ParseSTUNUri($"{destinationEndPoint.Address}:{destinationEndPoint.Port}?transport=tcp");
+            if (uri != null && !RtpTcpSocketByUri.ContainsKey(uri))
+            {
+                NetServices.CreateRtpSocket(false, ProtocolType.Tcp, null, 0, null, true, true, out var rtpTcpSocket, out _);
+
+                if (rtpTcpSocket == null)
+                {
+                    throw new ApplicationException("The RTP channel was not able to create an RTP socket.");
+                }
+
+                RtpTcpSocketByUri.Add(uri, rtpTcpSocket);
+
+                if (uri != null && !m_rtpTcpReceiverByUri.ContainsKey(uri) && rtpTcpSocket != null)
+                {
+                    var rtpTcpReceiver = new IceTcpReceiver(rtpTcpSocket);
+
+                    Action<string> onClose = (reason) =>
+                    {
+                        CloseTcp(rtpTcpReceiver, reason);
+                    };
+                    rtpTcpReceiver.OnPacketReceived += OnRTPPacketTCPRelayReceived;
+                    rtpTcpReceiver.OnClosed += onClose;
+                    rtpTcpReceiver.BeginReceiveFrom();
+
+                    m_rtpTcpReceiverByUri.Add(uri, rtpTcpReceiver);
+                }
+                
+                iceServer._secondaryRelayUri = uri;
+            }
+
+            var stunMsg = new STUNMessage(STUNMessageTypesEnum.ConnectionBind);
+            stunMsg.Header.TransactionId = Encoding.ASCII.GetBytes(requestTransactionID);
+
+            stunMsg.Attributes.Add(new STUNConnectionIdAttribute(turnConnectionId));
+
+            byte[] stunMsgBytes;
+
+            if (iceServer.Nonce != null && iceServer.Realm != null && iceServer._username != null && iceServer._password != null)
+            {
+                stunMsgBytes = GetAuthenticatedStunRequest(stunMsg, iceServer._username, iceServer.Realm, iceServer._password, iceServer.Nonce);
+            }
+            else
+            {
+                stunMsgBytes = stunMsg.ToByteBuffer(null, false);
+            }
+
+            var sendResult = SendOverTCP(uri, stunMsgBytes, iceServer.ServerEndPoint);
+
+            if (sendResult != SocketError.Success)
+            {
+                logger.LogWarning("Error sending TURN ConnectionBind request {OutstandingRequestsSent} to {RemoteEndPoint}. {SendResult}.",
+                    iceServer.OutstandingRequestsSent, destinationEndPoint, sendResult);
+            }
+            else
+            {
+                OnStunMessageSent?.Invoke(stunMsg, destinationEndPoint, false);
             }
         }
 
@@ -1752,9 +1992,16 @@ namespace SIPSorcery.Net
 
             if (candidatePair.LocalCandidate.type == RTCIceCandidateType.relay)
             {
-                IPEndPoint relayServerEP = candidatePair.LocalCandidate.IceServer.ServerEndPoint;
-                var protocol = candidatePair.LocalCandidate.IceServer.Protocol;
-                SendRelay(protocol, candidatePair.RemoteCandidate.DestinationEndPoint, stunReqBytes, relayServerEP, candidatePair.LocalCandidate.IceServer);
+                if (candidatePair.LocalCandidate.protocol == RTCIceProtocol.tcp)
+                {
+                    SendOverTCP(candidatePair.LocalCandidate.IceServer._secondaryRelayUri, stunReqBytes, candidatePair.LocalCandidate.IceServer.ServerEndPoint);
+                }
+                else
+                {
+                    IPEndPoint relayServerEP = candidatePair.LocalCandidate.IceServer.ServerEndPoint;
+                    var protocol = candidatePair.LocalCandidate.IceServer.Protocol;
+                    SendRelay(protocol, candidatePair.RemoteCandidate.DestinationEndPoint, stunReqBytes, relayServerEP, candidatePair.LocalCandidate.IceServer);
+                }
             }
             else
             {
@@ -1842,6 +2089,7 @@ namespace SIPSorcery.Net
         /// </remarks>
         /// <param name="stunMessage">The STUN message received.</param>
         /// <param name="remoteEndPoint">The remote end point the STUN packet was received from.</param>
+        /// <param name="wasRelayed">The message was encapsulated within TURN data connection.</param>
         public async Task ProcessStunMessage(STUNMessage stunMessage, IPEndPoint remoteEndPoint, bool wasRelayed)
         {
             if (_closed)
@@ -1853,6 +2101,7 @@ namespace SIPSorcery.Net
 
             // Check if the  STUN message is for an ICE server check.
             var iceServer = GetIceServerForTransactionID(stunMessage.Header.TransactionId);
+
             if (iceServer != null)
             {
                 bool candidatesAvailable = iceServer.GotStunResponse(stunMessage, remoteEndPoint);
@@ -1871,6 +2120,31 @@ namespace SIPSorcery.Net
                 if (stunMessage.Header.MessageType == STUNMessageTypesEnum.BindingRequest)
                 {
                     GotStunBindingRequest(stunMessage, remoteEndPoint, wasRelayed);
+                }
+                else if (stunMessage.Header.MessageType == STUNMessageTypesEnum.ConnectionAttemptIndication)
+                {
+                    var connaddr = ((STUNXORAddressAttribute)stunMessage.Attributes
+                        .FirstOrDefault(x => x.AttributeType == STUNAttributeTypesEnum.XORPeerAddress))
+                        .GetIPEndPoint();
+
+                    logger.LogDebug("A ConnectionAttempt Indication was received for remote {RemoteAdress}.", connaddr);
+
+                    var bytes = stunMessage.Attributes.FirstOrDefault(x => x.AttributeType == STUNAttributeTypesEnum.ConnectionId)?.Value;
+
+                    lock (_checklistLock)
+                    {
+                        _checklist.Where(x => x.State == ChecklistEntryState.Frozen
+                                            && x.RemoteCandidate.DestinationEndPoint.Equals(connaddr))
+                            .ToList().ForEach(x =>
+                            {
+                                x.TurnConnectionId = BitConverter.IsLittleEndian ?
+                                                     NetConvert.DoReverseEndian(BitConverter.ToUInt32(bytes, 0)) :
+                                                     BitConverter.ToUInt32(bytes, 0);
+                                //x.FirstCheckSentAt = DateTime.MinValue;
+                                x.State = ChecklistEntryState.Waiting;
+                            });
+
+                    }
                 }
                 else if (stunMessage.Header.MessageClass == STUNClassTypesEnum.ErrorResponse ||
                          stunMessage.Header.MessageClass == STUNClassTypesEnum.SuccessResponse)
@@ -2125,8 +2399,15 @@ namespace SIPSorcery.Net
 
                         if (wasRelayed)
                         {
-                            var protocol = matchingChecklistEntry.LocalCandidate.IceServer.Protocol;
-                            SendRelay(protocol, remoteEndPoint, stunRespBytes, matchingChecklistEntry.LocalCandidate.IceServer.ServerEndPoint, matchingChecklistEntry.LocalCandidate.IceServer);
+                            if (matchingChecklistEntry.LocalCandidate.protocol == RTCIceProtocol.tcp)
+                            {
+                                SendOverTCP(matchingChecklistEntry.LocalCandidate.IceServer._secondaryRelayUri, stunRespBytes, matchingChecklistEntry.LocalCandidate.IceServer.ServerEndPoint);
+                            }
+                            else
+                            {
+                                var protocol = matchingChecklistEntry.LocalCandidate.IceServer.Protocol;
+                                SendRelay(protocol, remoteEndPoint, stunRespBytes, matchingChecklistEntry.LocalCandidate.IceServer.ServerEndPoint, matchingChecklistEntry.LocalCandidate.IceServer);
+                            }
                             OnStunMessageSent?.Invoke(stunResponse, remoteEndPoint, true);
                         }
                         else
@@ -2243,7 +2524,11 @@ namespace SIPSorcery.Net
 
             STUNMessage allocateRequest = new STUNMessage(STUNMessageTypesEnum.Allocate);
             allocateRequest.Header.TransactionId = Encoding.ASCII.GetBytes(iceServer.TransactionID);
-            allocateRequest.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.RequestedTransport, STUNAttributeConstants.UdpTransportType));
+
+            allocateRequest.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.RequestedTransport,
+                iceServer.IceRelayProtocol == ProtocolType.Tcp ?
+                STUNAttributeConstants.TcpTransportType : STUNAttributeConstants.UdpTransportType));
+
             allocateRequest.Attributes.Add(
                 new STUNAttribute(STUNAttributeTypesEnum.RequestedAddressFamily,
                 iceServer.ServerEndPoint.AddressFamily == AddressFamily.InterNetwork ?
@@ -2260,13 +2545,31 @@ namespace SIPSorcery.Net
                 allocateReqBytes = allocateRequest.ToByteBuffer(null, false);
             }
 
-            var sendResult = iceServer.Protocol == ProtocolType.Tcp ?
-                                SendOverTCP(iceServer, allocateReqBytes) :
-                                base.Send(RTPChannelSocketsEnum.RTP, iceServer.ServerEndPoint, allocateReqBytes);
+            SocketError sendResult;
+            if (iceServer.Protocol == ProtocolType.Tcp)
+            {
+                sendResult = SendOverTCP(iceServer, allocateReqBytes);
+            }
+            else
+            {
+                // technically we could use TCP relay even if we use UDP when using standard-deviating TURN server,
+                // but RFC 6062 section 4-5 enforces this for standard TURN server.
+                // https://datatracker.ietf.org/doc/html/rfc6062#section-4.1
+                if (iceServer.IceRelayProtocol == ProtocolType.Tcp)
+                {
+                    sendResult = SocketError.ProtocolType;
+                    logger.LogWarning("Cannot allocate TCP relay with TURN when using UDP transport with TURN server. " +
+                        "Use [?{STUNTransportScheme}] on the iceServers' urls. ", STUNUri.SCHEME_TRANSPORT_TCP);
+                }
+                else
+                {
+                    sendResult = base.Send(RTPChannelSocketsEnum.RTP, iceServer.ServerEndPoint, allocateReqBytes);
+                }
+            }
 
             if (sendResult != SocketError.Success)
             {
-                logger.LogWarning("Error sending TURN Allocate request {OutstandingRequestsSent} for {Uri} to {ServerEndPoint}. {SendResult}.",
+                logger.LogWarning("Error sending TURN Allocate request {OutstandingRequestsSent} for {Uri} to {ServerEndPoint}. Error = [{SendResult}].",
                     iceServer.OutstandingRequestsSent, iceServer._uri, iceServer.ServerEndPoint, sendResult);
             }
             else
@@ -2391,47 +2694,7 @@ namespace SIPSorcery.Net
             {
                 try
                 {
-                    //Connect to destination
-                    RtpTcpSocketByUri.TryGetValue(iceServer?._uri, out Socket sendSocket);
-                    //LastRtpDestination = dstEndPoint;
-
-                    if (sendSocket == null)
-                    {
-                        return SocketError.Fault;
-                    }
-
-                    //Prevent Send to IPV4 while socket is IPV6 (Mono Error)
-                    if (dstEndPoint.AddressFamily == AddressFamily.InterNetwork && sendSocket.AddressFamily != dstEndPoint.AddressFamily)
-                    {
-                        dstEndPoint = new IPEndPoint(dstEndPoint.Address.MapToIPv6(), dstEndPoint.Port);
-                    }
-
-                    Func<IPEndPoint, IPEndPoint, bool> equals = (IPEndPoint e1, IPEndPoint e2) =>
-                    {
-                        return e1.Port == e2.Port && e1.Address.Equals(e2.Address);
-                    };
-
-                    if (!sendSocket.Connected || !(sendSocket.RemoteEndPoint is IPEndPoint) || !equals(sendSocket.RemoteEndPoint as IPEndPoint, dstEndPoint))
-                    {
-                        if (sendSocket.Connected)
-                        {
-                            logger.LogDebug("SendOverTCP request disconnect.");
-                            sendSocket.Disconnect(true);
-                        }
-                        sendSocket.Connect(dstEndPoint);
-
-                        logger.LogDebug("SendOverTCP status: {Status} endpoint: {EndPoint}", sendSocket.Connected, dstEndPoint);
-                    }
-
-                    //Fix ReceiveFrom logic if any previous exception happens
-                    m_rtpTcpReceiverByUri.TryGetValue(iceServer?._uri, out IceTcpReceiver rtpTcpReceiver);
-                    if (rtpTcpReceiver != null && !rtpTcpReceiver.IsRunningReceive && !rtpTcpReceiver.IsClosed)
-                    {
-                        rtpTcpReceiver.BeginReceiveFrom();
-                    }
-
-                    sendSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint, EndSendToTCP, sendSocket);
-                    return SocketError.Success;
+                    return SendOverTCP(iceServer?._uri, buffer, dstEndPoint);
                 }
                 catch (ObjectDisposedException) // Thrown when socket is closed. Can be safely ignored.
                 {
@@ -2447,6 +2710,51 @@ namespace SIPSorcery.Net
                     return SocketError.Fault;
                 }
             }
+        }
+
+        private SocketError SendOverTCP(STUNUri uri, byte[] buffer, IPEndPoint dstEndPoint)
+        {
+            //Connect to destination
+            RtpTcpSocketByUri.TryGetValue(uri, out Socket sendSocket);
+            //LastRtpDestination = dstEndPoint;
+
+            if (sendSocket == null)
+            {
+                return SocketError.Fault;
+            }
+
+            //Prevent Send to IPV4 while socket is IPV6 (Mono Error)
+            if (dstEndPoint.AddressFamily == AddressFamily.InterNetwork && sendSocket.AddressFamily != dstEndPoint.AddressFamily)
+            {
+                dstEndPoint = new IPEndPoint(dstEndPoint.Address.MapToIPv6(), dstEndPoint.Port);
+            }
+
+            Func<IPEndPoint, IPEndPoint, bool> equals = (IPEndPoint e1, IPEndPoint e2) =>
+            {
+                return e1.Port == e2.Port && e1.Address.Equals(e2.Address);
+            };
+
+            if (!sendSocket.Connected || !(sendSocket.RemoteEndPoint is IPEndPoint) || !equals(sendSocket.RemoteEndPoint as IPEndPoint, dstEndPoint))
+            {
+                if (sendSocket.Connected)
+                {
+                    logger.LogDebug("SendOverTCP request disconnect.");
+                    sendSocket.Disconnect(true);
+                }
+                sendSocket.Connect(dstEndPoint);
+
+                logger.LogDebug("SendOverTCP status: {Status} endpoint: {EndPoint}", sendSocket.Connected, dstEndPoint);
+            }
+
+            //Fix ReceiveFrom logic if any previous exception happens
+            m_rtpTcpReceiverByUri.TryGetValue(uri, out IceTcpReceiver rtpTcpReceiver);
+            if (rtpTcpReceiver != null && !rtpTcpReceiver.IsRunningReceive && !rtpTcpReceiver.IsClosed)
+            {
+                rtpTcpReceiver.BeginReceiveFrom();
+            }
+
+            sendSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint, EndSendToTCP, sendSocket);
+            return SocketError.Success;
         }
 
         protected virtual void EndSendToTCP(IAsyncResult ar)
@@ -2493,6 +2801,25 @@ namespace SIPSorcery.Net
             md5Digest.DoFinal(hash, 0);
 
             return stunRequest.ToByteBuffer(hash, true);
+        }
+
+        void OnRTPPacketTCPRelayReceived(UdpReceiver receiver, int localPort, IPEndPoint remoteEndPoint, byte[] packet)
+        {
+            if (packet?.Length > 0)
+            {
+                base.LastRtpDestination = remoteEndPoint;
+
+                if (packet[0] == 0x00 || packet[0] == 0x01)
+                {
+                    // STUN packet.
+                    var stunMessage = STUNMessage.ParseSTUNMessage(packet, packet.Length);
+                    _ = ProcessStunMessage(stunMessage, remoteEndPoint, true);
+                }
+                else
+                {
+                    OnRTPDataReceived?.Invoke(localPort, remoteEndPoint, packet);
+                }
+            }
         }
 
         /// <summary>
@@ -2585,10 +2912,17 @@ namespace SIPSorcery.Net
                 NominatedEntry.RemoteCandidate.DestinationEndPoint.Address.Equals(dstEndPoint.Address) &&
                 NominatedEntry.RemoteCandidate.DestinationEndPoint.Port == dstEndPoint.Port)
             {
-                // A TURN relay channel is being used to communicate with the remote peer.
-                var protocol = NominatedEntry.LocalCandidate.IceServer.Protocol;
-                var serverEndPoint = NominatedEntry.LocalCandidate.IceServer.ServerEndPoint;
-                return SendRelay(protocol, dstEndPoint, buffer, serverEndPoint, NominatedEntry.LocalCandidate.IceServer);
+                if (NominatedEntry.LocalCandidate.protocol == RTCIceProtocol.tcp)
+                {
+                    return SendOverTCP(NominatedEntry.LocalCandidate.IceServer._secondaryRelayUri, buffer, NominatedEntry.LocalCandidate.IceServer.ServerEndPoint);
+                }
+                else
+                {
+                    // A TURN relay channel is being used to communicate with the remote peer.
+                    var protocol = NominatedEntry.LocalCandidate.IceServer.Protocol;
+                    var serverEndPoint = NominatedEntry.LocalCandidate.IceServer.ServerEndPoint;
+                    return SendRelay(protocol, dstEndPoint, buffer, serverEndPoint, NominatedEntry.LocalCandidate.IceServer);
+                }
             }
             else
             {

--- a/src/SIPSorcery/net/ICE/RtpIceChannel.cs
+++ b/src/SIPSorcery/net/ICE/RtpIceChannel.cs
@@ -802,12 +802,12 @@ namespace SIPSorcery.Net
             }
         }
 
-        private IceTcpReceiver_ GetIceTcpReceiver(Socket tcpSocket, bool isrelay = false)
+        private IceTcpReceiver GetIceTcpReceiver(Socket tcpSocket, bool isrelay = false)
         {
-            var rtpTcpReceiver = new IceTcpReceiver_(tcpSocket);
+            var rtpTcpReceiver = new IceTcpReceiver(tcpSocket);
 
             rtpTcpReceiver.OnPacketReceived +=
-                (_, localPort, remoteEndPoint, packet) =>
+                (recv, localPort, remoteEndPoint, packet) =>
                 {
                     if (logger.IsEnabled(LogLevel.Trace))
                     {
@@ -815,7 +815,7 @@ namespace SIPSorcery.Net
                             packet.Length, tcpSocket.LocalEndPoint);
                     }
 
-                    OnPacketReceived(localPort, remoteEndPoint, packet, isrelay);
+                    OnPacketReceived(recv, localPort, remoteEndPoint, packet, isrelay);
                 };
 
             rtpTcpReceiver.OnClosed += (reason) => CloseTcp(rtpTcpReceiver, reason);
@@ -1096,39 +1096,39 @@ namespace SIPSorcery.Net
             return hostCandidates;
         }
 
-                                var iceServerState = new IceServer(stunUri, iceServerID, iceServer.username, iceServer.credential);
+        //                        var iceServerState = new IceServer(stunUri, iceServerID, iceServer.username, iceServer.credential);
 
-                                // Check whether the server end point can be set. IF it can't a DNS lookup will be required.
-                                if (IPAddress.TryParse(iceServerState._uri.Host, out var serverIPAddress))
-                                {
-                                    iceServerState.ServerEndPoint = new IPEndPoint(serverIPAddress, iceServerState._uri.Port);
-                                    logger.LogDebug("ICE server end point for {Uri} set to {EndPoint}.", iceServerState._uri, iceServerState.ServerEndPoint);
-                                }
+        //                        // Check whether the server end point can be set. IF it can't a DNS lookup will be required.
+        //                        if (IPAddress.TryParse(iceServerState._uri.Host, out var serverIPAddress))
+        //                        {
+        //                            iceServerState.ServerEndPoint = new IPEndPoint(serverIPAddress, iceServerState._uri.Port);
+        //                            logger.LogDebug("ICE server end point for {Uri} set to {EndPoint}.", iceServerState._uri, iceServerState.ServerEndPoint);
+        //                        }
 
-                                if (stunUri.Scheme == STUNSchemesEnum.turn && iceServer.X_ICERelayProtocol == RTCIceProtocol.tcp)
-                                {
-                                    iceServerState._reqIceProtocol = ProtocolType.Tcp;
-                                    logger.LogDebug("Will request TCP relay candidate from ICE server {Uri}", iceServerState._uri);
-                                }
+        //                        if (stunUri.Scheme == STUNSchemesEnum.turn && iceServer.X_ICERelayProtocol == RTCIceProtocol.tcp)
+        //                        {
+        //                            iceServerState._reqIceProtocol = ProtocolType.Tcp;
+        //                            logger.LogDebug("Will request TCP relay candidate from ICE server {Uri}", iceServerState._uri);
+        //                        }
 
-                                _iceServerConnections.TryAdd(stunUri, iceServerState);
+        //                        _iceServerConnections.TryAdd(stunUri, iceServerState);
 
-                                iceServerID++;
-                                if (iceServerID > IceServer.MAXIMUM_ICE_SERVER_ID)
-                                {
-                                    logger.LogWarning("The maximum number of ICE servers for the session has been reached.");
-                                    break;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            logger.LogWarning("RTP ICE Channel could not parse ICE server URL {url}.", url);
-                        }
-                    }
-                }
-            }
-        }
+        //                        iceServerID++;
+        //                        if (iceServerID > IceServer.MAXIMUM_ICE_SERVER_ID)
+        //                        {
+        //                            logger.LogWarning("The maximum number of ICE servers for the session has been reached.");
+        //                            break;
+        //                        }
+        //                    }
+        //                }
+        //                else
+        //                {
+        //                    logger.LogWarning("RTP ICE Channel could not parse ICE server URL {url}.", url);
+        //                }
+        //            }
+        //        }
+        //    }
+        //}
 
         private void RefreshTurn(Object state)
         {
@@ -2854,16 +2854,16 @@ namespace SIPSorcery.Net
 
                     return SocketError.SocketError;
 
-                    var ep = (sendSocket.LocalEndPoint as IPEndPoint);
-                    (var ip, var port) = (ep.Address, ep.Port);
+                    //var ep = (sendSocket.LocalEndPoint as IPEndPoint);
+                    //(var ip, var port) = (ep.Address, ep.Port);
 
-                    //recreate sockets?
-                    // TODO: may modify this path if base TCP is supported
+                    ////recreate sockets?
+                    //// TODO: may modify this path if base TCP is supported
 
-                    NetServices.CreateRtpSocket(false, ProtocolType.Tcp, ip, port, null, true, true, out var reConnectSocket, out _);
+                    //NetServices.CreateRtpSocket(false, ProtocolType.Tcp, ip, port, null, true, true, out var reConnectSocket, out _);
 
-                    m_rtpTcpReceiverByUri[uri] = GetIceTcpReceiver(reConnectSocket);
-                    sendSocket = RtpTcpSocketByUri[uri] = reConnectSocket;
+                    //m_rtpTcpReceiverByUri[uri] = GetIceTcpReceiver(reConnectSocket);
+                    //sendSocket = RtpTcpSocketByUri[uri] = reConnectSocket;
                 }
 
                 sendSocket.Connect(dstEndPoint);
@@ -2954,7 +2954,8 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
-                    OnRTPDataReceived?.Invoke(localPort, remoteEndPoint, packet);
+                    //OnRTPDataReceived?.Invoke(localPort, remoteEndPoint, packet);
+                    base.OnRTPPacketReceived(receiver, localPort, remoteEndPoint, packet);
                 }
             }
         }
@@ -2968,9 +2969,9 @@ namespace SIPSorcery.Net
         /// <param name="remoteEndPoint">The remote end point of the sender.</param>
         /// <param name="packet">The raw packet received (note this may not be RTP if other protocols are being multiplexed).</param>
         protected override void OnRTPPacketReceived(UdpReceiver receiver, int localPort, IPEndPoint remoteEndPoint, byte[] packet)
-            => OnPacketReceived(localPort, remoteEndPoint, packet, false);
+            => OnPacketReceived(receiver, localPort, remoteEndPoint, packet, false);
 
-        private void OnPacketReceived(int localPort, IPEndPoint remoteEndPoint, byte[] packet, bool wasRelayed)
+        private void OnPacketReceived(UdpReceiver receiver, int localPort, IPEndPoint remoteEndPoint, byte[] packet, bool wasRelayed)
         {
             if (packet?.Length > 0)
             {
@@ -2997,7 +2998,8 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
-                    OnRTPDataReceived?.Invoke(localPort, remoteEndPoint, packet);
+                    //OnRTPDataReceived?.Invoke(localPort, remoteEndPoint, packet);
+                    base.OnRTPPacketReceived(receiver, localPort, remoteEndPoint, packet);
                 }
             }
         }

--- a/src/SIPSorcery/net/ICE/RtpIceChannel.cs
+++ b/src/SIPSorcery/net/ICE/RtpIceChannel.cs
@@ -591,8 +591,12 @@ namespace SIPSorcery.Net
         public Func<string, Task<IPAddress[]>> MdnsGetAddresses;
 
         /// <summary>
-        /// STUN/TURN Control sockets by URI
+        /// STUN/TURN server connections socket by URI
         /// </summary>
+        /// <remarks>Also see <see cref="IceServer"/>.</remarks>
+        /// Internal note:
+        /// (*) Used as control when <see cref="IceServer._reqIceProtocol"/> is <see cref="ProtocolType.Tcp"/>.
+        /// In such case the actual relay is where <see cref="STUNUri"/> from <see cref="IceServer._secondaryRelayUri"/>
         public Dictionary<STUNUri, Socket> RtpTcpSocketByUri { get; private set; } = new Dictionary<STUNUri, Socket>();
 
         protected Dictionary<STUNUri, IceTcpReceiver> m_rtpTcpReceiverByUri = new Dictionary<STUNUri, IceTcpReceiver>();
@@ -606,18 +610,6 @@ namespace SIPSorcery.Net
         public RtpIceChannel() :
             this(null, RTCIceComponent.rtp, useTcp: false)
         { }
-
-        public RtpIceChannel(
-            IPAddress bindAddress,
-            RTCIceComponent component,
-            List<RTCIceServer> iceServers = null,
-            RTCIceTransportPolicy policy = RTCIceTransportPolicy.all,
-            bool includeAllInterfaceAddresses = false,
-            int bindPort = 0,
-            PortRange rtpPortRange = null)
-            : this(bindAddress, component, iceServers, policy, false, includeAllInterfaceAddresses, bindPort, rtpPortRange)
-        {
-        }
 
         /// <summary>
         /// Creates a new instance of an RTP ICE channel to provide RTP channel functions 
@@ -643,11 +635,12 @@ namespace SIPSorcery.Net
             RTCIceComponent component,
             List<RTCIceServer> iceServers = null,
             RTCIceTransportPolicy policy = RTCIceTransportPolicy.all,
-            bool useTcp = false,
             bool includeAllInterfaceAddresses = false,
             int bindPort = 0,
-            PortRange rtpPortRange = null) :
-            base(false, bindAddress, useTcp, bindPort, rtpPortRange)
+            PortRange rtpPortRange = null,
+            bool useTcp = false
+            )
+            : base(false, bindAddress, bindPort, rtpPortRange, useTcp)
         {
             _bindAddress = bindAddress;
             Component = component;
@@ -796,15 +789,7 @@ namespace SIPSorcery.Net
 
                     if (stunUri != null && !m_rtpTcpReceiverByUri.ContainsKey(stunUri) && tcpSocket != null)
                     {
-                        var rtpTcpReceiver = new IceTcpReceiver(tcpSocket);
-
-                        Action<string> onClose = (reason) =>
-                        {
-                            CloseTcp(rtpTcpReceiver, reason);
-                        };
-                        rtpTcpReceiver.OnPacketReceived += OnRTPPacketReceived;
-                        rtpTcpReceiver.OnClosed += onClose;
-                        rtpTcpReceiver.BeginReceiveFrom();
+                        var rtpTcpReceiver = GetIceTcpReceiver(tcpSocket);
 
                         m_rtpTcpReceiverByUri.Add(stunUri, rtpTcpReceiver);
                     }
@@ -815,6 +800,27 @@ namespace SIPSorcery.Net
                 OnClosed -= CloseTcp;
                 OnClosed += CloseTcp;
             }
+        }
+
+        private IceTcpReceiver_ GetIceTcpReceiver(Socket tcpSocket, bool isrelay = false)
+        {
+            var rtpTcpReceiver = new IceTcpReceiver_(tcpSocket);
+
+            rtpTcpReceiver.OnPacketReceived +=
+                (_, localPort, remoteEndPoint, packet) =>
+                {
+                    if (logger.IsEnabled(LogLevel.Trace))
+                    {
+                        logger.LogTrace("Received {bits} bytes at {lcl}",
+                            packet.Length, tcpSocket.LocalEndPoint);
+                    }
+
+                    OnPacketReceived(localPort, remoteEndPoint, packet, isrelay);
+                };
+
+            rtpTcpReceiver.OnClosed += (reason) => CloseTcp(rtpTcpReceiver, reason);
+            rtpTcpReceiver.BeginReceiveFrom();
+            return rtpTcpReceiver;
         }
 
         protected void CloseTcp(string reason)
@@ -1079,6 +1085,8 @@ namespace SIPSorcery.Net
                 // We currently only support a single multiplexed connection for all data streams and RTCP.
                 if (hostCandidate.component == RTCIceComponent.rtp && hostCandidate.sdpMLineIndex == SDP_MLINE_INDEX)
                 {
+                    logger.LogTrace("Gathered icecandidate: {candidate}", hostCandidate.ToShortString());
+
                     hostCandidates.Add(hostCandidate);
 
                     OnIceCandidate?.Invoke(hostCandidate);
@@ -1099,7 +1107,7 @@ namespace SIPSorcery.Net
 
                                 if (stunUri.Scheme == STUNSchemesEnum.turn && iceServer.X_ICERelayProtocol == RTCIceProtocol.tcp)
                                 {
-                                    iceServerState.IceRelayProtocol = ProtocolType.Tcp;
+                                    iceServerState._reqIceProtocol = ProtocolType.Tcp;
                                     logger.LogDebug("Will request TCP relay candidate from ICE server {Uri}", iceServerState._uri);
                                 }
 
@@ -1196,6 +1204,7 @@ namespace SIPSorcery.Net
                         {
                             logger.LogDebug("RTP ICE Channel all ICE server connection checks failed, stopping ICE servers timer.");
                             _processIceServersTimer.Dispose();
+                            return;
                         }
                         else
                         {
@@ -1263,7 +1272,15 @@ namespace SIPSorcery.Net
                     // Send TURN binding request.
                     else if (_activeIceServer.ServerReflexiveEndPoint == null && _activeIceServer._uri.Scheme == STUNSchemesEnum.turn)
                     {
+                        if (_activeIceServer.Protocol == ProtocolType.Tcp
+                            && DateTime.Now - _activeIceServer.LastRequestSentAt < IceServer.rttime
+                            && _activeIceServer.LastResponseReceivedAt < _activeIceServer.LastRequestSentAt)
+                        {
+                            return;
+                        }
+
                         logger.LogDebug("Sending TURN allocate request to ICE server {Uri} with address {EndPoint}.", _activeIceServer._uri, _activeIceServer.ServerEndPoint);
+
                         _activeIceServer.Error = SendTurnAllocateRequest(_activeIceServer);
                     }
                     else
@@ -1319,7 +1336,7 @@ namespace SIPSorcery.Net
 
                 if (relayCandidate != null)
                 {
-                    logger.LogDebug("Adding relay ICE candidate for ICE server {Uri} on {RelayProtocol}:{EndPoint}.", iceServer._uri, iceServer.IceRelayProtocol, iceServer.RelayEndPoint);
+                    logger.LogDebug("Adding relay ICE candidate for ICE server {Uri} on {RelayProtocol}:{EndPoint}.", iceServer._uri, iceServer._reqIceProtocol, iceServer.RelayEndPoint);
 
                     _candidates.Add(relayCandidate);
                     OnIceCandidate?.Invoke(relayCandidate);
@@ -1535,6 +1552,11 @@ namespace SIPSorcery.Net
                 case RTCIceConnectionState.connected:
                 case RTCIceConnectionState.disconnected:
                     // Periodic checks on the nominated peer.
+                    if (logger.IsEnabled(LogLevel.Trace))
+                    {
+                        logger.LogTrace("Sending periodic connectivity check for {lcl}->{rmt}",
+                            NominatedEntry.LocalCandidate.ToShortString(), NominatedEntry.RemoteCandidate.ToShortString());
+                    }
                     SendCheckOnConnectedPair(NominatedEntry);
                     break;
 
@@ -1552,6 +1574,8 @@ namespace SIPSorcery.Net
         /// <remarks>
         /// The scheduling mechanism for ICE is specified in https://tools.ietf.org/html/rfc8445#section-6.1.4.
         /// </remarks>
+        //  TODO: Might want to check all candidate pairs concurrently and use the one that is ready first,
+        //  it will reduce the TTL, we already use async after all.
         private async void ProcessChecklist()
         {
             if (!_closed && (IceConnectionState == RTCIceConnectionState.@new ||
@@ -1768,12 +1792,24 @@ namespace SIPSorcery.Net
             bool isRelayCheck = candidatePair.LocalCandidate.type == RTCIceCandidateType.relay;
             bool isProtoTcp = candidatePair.LocalCandidate.protocol == RTCIceProtocol.tcp;
 
-            // allow peer to send/connect to relay first
-            if (candidatePair.TurnPermissionsResponseAt == DateTime.MinValue)
+            if (isProtoTcp)
             {
-                if (candidatePair.TurnPermissionsRequestSent >= IceServer.MAX_REQUESTS)
+                // The connectionful of TCP have retransmission rate on its own,
+                // so we may need to wait more than one unit of timer cycle
+                if (DateTime.Now - candidatePair.TcpLastCheckSentAt >= IceServer.rttime ||
+                    candidatePair.TurnPermissionsResponseAt >= candidatePair.TcpLastCheckSentAt
+                    || candidatePair.TurnConnectReportAt >= candidatePair.TcpLastCheckSentAt
+                    )
                 {
-                    logger.LogWarning("ICE RTP channel failed to get a Create Permissions response from {IceServerUri} after {TurnPermissionsRequestSent} attempts.", candidatePair.LocalCandidate.IceServer._uri, candidatePair.TurnPermissionsRequestSent);
+                    candidatePair.TcpLastCheckSentAt = DateTime.Now;
+
+            // allow peer to send/connect to relay first
+                    if (isRelayCheck && candidatePair.TurnPermissionsResponseAt == DateTime.MinValue)
+            {
+                        if (candidatePair.TurnPermissionsRequestSent >= IceServer.MAX_ERRORS)
+                {
+                            logger.LogWarning("ICE RTP channel failed to get a Create Permissions response from {IceServerUri} after {TurnPermissionsRequestSent} attempts.",
+                                candidatePair.LocalCandidate.IceServer._uri, candidatePair.TurnPermissionsRequestSent);
                     candidatePair.State = ChecklistEntryState.Failed;
                 }
                 else
@@ -1781,12 +1817,13 @@ namespace SIPSorcery.Net
                     // Send Create Permissions request to TURN server for remote candidate.
                     candidatePair.TurnPermissionsRequestSent++;
 
-                    logger.LogDebug("ICE RTP channel sending TURN permissions request {TurnPermissionsRequestSent} to server {IceServerUri} for peer {RemoteCandidate} (TxID: {RequestTransactionID}).", candidatePair.TurnPermissionsRequestSent, candidatePair.LocalCandidate.IceServer._uri, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
+                            logger.LogDebug("ICE RTP channel sending TURN permissions request {TurnPermissionsRequestSent} to server {IceServerUri} for peer {RemoteCandidate} (TxID: {RequestTransactionID}).",
+                                candidatePair.TurnPermissionsRequestSent, candidatePair.LocalCandidate.IceServer._uri, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
                     SendTurnCreatePermissionsRequest(candidatePair.RequestTransactionID, candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint);
                 }
             }
-            // then do prerequisites if the relay candidate is TCP instead of UDP,
-            else if (isRelayCheck && isProtoTcp && candidatePair.TurnConnectBindedAt == DateTime.MinValue)
+                    // https://datatracker.ietf.org/doc/html/rfc6062#section-4.3
+                    else if (isRelayCheck && candidatePair.TurnConnectBindedAt == DateTime.MinValue)
             {
                 // we either got ConnectAttempt Indication or we are initiator got connectionid,
                 // we should send a ConnectionBind request to the TURN server
@@ -1802,7 +1839,7 @@ namespace SIPSorcery.Net
                     else
                     {
                         logger.LogDebug("ICE RTP channel sending ConnectionBind request to server {IceServerUri} for peer {RemoteEndPoint} (TxID: {RequestTransactionID}).",
-                            candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
+                                    candidatePair.LocalCandidate.IceServer._uri, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
 
                         candidatePair.TurnConnectRequestSent++;
 
@@ -1815,7 +1852,7 @@ namespace SIPSorcery.Net
                 // we requested Allocate and we are controller (initiator), we should send a Connect request to the TURN server
                 else if (IsController)
                 {
-                    if (DateTime.Now - candidatePair.TurnConnectReportAt >= TimeSpan.FromSeconds(10))
+                            if (DateTime.Now - candidatePair.TurnConnectReportAt >= IceServer.waittime)
                     {
                         if (candidatePair.TurnConnectRequestSent >= IceServer.MAX_ERRORS)
                         {
@@ -1836,34 +1873,82 @@ namespace SIPSorcery.Net
 
                             candidatePair.TurnConnectReportAt = DateTime.Now;
                         }
+
+                                // Workaround to prevent being timed out by the checking loop since we have waittime.
+                                // TODO: should probably provide way to decide time out when using TURN server with TCP relay.
+                                candidatePair.FirstCheckSentAt = candidatePair.TurnConnectReportAt + IceServer.waittime;
+                    }
+                        }
+                        // we are not controller (responder), we should wait for the controller to send Connect request
+                    else
+                    {
+                            candidatePair.State = ChecklistEntryState.Frozen;
+                    }
+                }
+                else
+                {
+                        if (candidatePair.TcpBindRequestSent >= IceServer.MAX_REQUESTS)
+                        {
+                            logger.LogDebug("ICE RTP channel failed to bind with peer {peerEp} after {reqsents} attempts.",
+                                candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.TcpBindRequestSent);
+
+                            candidatePair.State = ChecklistEntryState.Failed;
+                }
+
+                        candidatePair.TcpBindRequestSent++;
+
+                        var localep = RtpTcpSocketByUri[candidatePair.LocalCandidate.IceServer._secondaryRelayUri].LocalEndPoint;
+                        var relayep = candidatePair.LocalCandidate.IceServer.ServerEndPoint;
+
+                        logger.LogDebug("ICE RTP channel sending connectivity check for {LocalCandidate}->{RemoteCandidate} from {LocalEndPoint} to relay at {RelayServerEndPoint} (use candidate {SetUseCandidate}).",
+                            candidatePair.LocalCandidate.ToShortString(), candidatePair.RemoteCandidate.ToShortString(), localep, relayep, setUseCandidate);
+
+                        SendSTUNBindingRequest(candidatePair, setUseCandidate);
+            }
+                }
+            }
+            // udp
+            else
+            {
+                // allow peer to send/connect to relay first
+                if (isRelayCheck && candidatePair.TurnPermissionsResponseAt == DateTime.MinValue)
+                {
+                    if (candidatePair.TurnPermissionsRequestSent >= IceServer.MAX_REQUESTS)
+                    {
+                        logger.LogWarning("ICE RTP channel failed to get a Create Permissions response from {IceServerUri} after {TurnPermissionsRequestSent} attempts.",
+                            candidatePair.LocalCandidate.IceServer._uri, candidatePair.TurnPermissionsRequestSent);
+
+                        candidatePair.State = ChecklistEntryState.Failed;
                     }
                     else
                     {
-                        // Workaround to prevent being timed out,
-                        // TODO: should probably provide way to increase time out for TURN server when TCP relay candidate.
-                        candidatePair.FirstCheckSentAt = candidatePair.TurnConnectReportAt + TimeSpan.FromSeconds(10);
+                        // Send Create Permissions request to TURN server for remote candidate.
+                        candidatePair.TurnPermissionsRequestSent++;
+
+                        logger.LogDebug("ICE RTP channel sending TURN permissions request {TurnPermissionsRequestSent} to server {IceServerUri} for peer {RemoteCandidate} (TxID: {RequestTransactionID}).",
+                            candidatePair.TurnPermissionsRequestSent, candidatePair.LocalCandidate.IceServer._uri, candidatePair.RemoteCandidate.DestinationEndPoint, candidatePair.RequestTransactionID);
+
+                        SendTurnCreatePermissionsRequest(candidatePair.RequestTransactionID,
+                            candidatePair.LocalCandidate.IceServer, candidatePair.RemoteCandidate.DestinationEndPoint);
                     }
                 }
-                // we are not controller (responder), we should wait for the controller to send Connect request
                 else
                 {
-                    candidatePair.State = ChecklistEntryState.Frozen;
-                }
-            }
-            else
-            {
                 if (candidatePair.LocalCandidate.type == RTCIceCandidateType.relay)
                 {
                     IPEndPoint relayServerEP = candidatePair.LocalCandidate.IceServer.ServerEndPoint;
-                    logger.LogDebug("ICE RTP channel sending connectivity check for {LocalCandidate}->{RemoteCandidate} from {LocalEndPoint} to relay at {RelayServerEndPoint} (use candidate {SetUseCandidate}).", candidatePair.LocalCandidate.ToShortString(), candidatePair.RemoteCandidate.ToShortString(), base.RTPLocalEndPoint, relayServerEP, setUseCandidate);
+                        logger.LogDebug("ICE RTP channel sending connectivity check for {LocalCandidate}->{RemoteCandidate} from {LocalEndPoint} to relay at {RelayServerEndPoint} (use candidate {SetUseCandidate}).",
+                            candidatePair.LocalCandidate.ToShortString(), candidatePair.RemoteCandidate.ToShortString(), base.RTPLocalEndPoint, relayServerEP, setUseCandidate);
                 }
                 else
                 {
                     IPEndPoint remoteEndPoint = candidatePair.RemoteCandidate.DestinationEndPoint;
-                    logger.LogDebug("ICE RTP channel sending connectivity check for {LocalCandidate}->{RemoteCandidate} from {LocalEndPoint} to {RemoteEndPoint} (use candidate {SetUseCandidate}).", candidatePair.LocalCandidate.ToShortString(), candidatePair.RemoteCandidate.ToShortString(), base.RTPLocalEndPoint, remoteEndPoint, setUseCandidate);
+                        logger.LogDebug("ICE RTP channel sending connectivity check for {LocalCandidate}->{RemoteCandidate} from {LocalEndPoint} to {RemoteEndPoint} (use candidate {SetUseCandidate}).",
+                            candidatePair.LocalCandidate.ToShortString(), candidatePair.RemoteCandidate.ToShortString(), base.RTPLocalEndPoint, remoteEndPoint, setUseCandidate);
                 }
                 SendSTUNBindingRequest(candidatePair, setUseCandidate);
             }
+        }
         }
 
         private void SendTurnConnectRequest(string requestTransactionID, IceServer iceServer, IPEndPoint destinationEndPoint)
@@ -1916,15 +2001,7 @@ namespace SIPSorcery.Net
 
                 if (uri != null && !m_rtpTcpReceiverByUri.ContainsKey(uri) && rtpTcpSocket != null)
                 {
-                    var rtpTcpReceiver = new IceTcpReceiver(rtpTcpSocket);
-
-                    Action<string> onClose = (reason) =>
-                    {
-                        CloseTcp(rtpTcpReceiver, reason);
-                    };
-                    rtpTcpReceiver.OnPacketReceived += OnRTPPacketTCPRelayReceived;
-                    rtpTcpReceiver.OnClosed += onClose;
-                    rtpTcpReceiver.BeginReceiveFrom();
+                    var rtpTcpReceiver = GetIceTcpReceiver(rtpTcpSocket, true);
 
                     m_rtpTcpReceiverByUri.Add(uri, rtpTcpReceiver);
                 }
@@ -2133,18 +2210,22 @@ namespace SIPSorcery.Net
 
                     lock (_checklistLock)
                     {
-                        _checklist.Where(x => x.State == ChecklistEntryState.Frozen
-                                            && x.RemoteCandidate.DestinationEndPoint.Equals(connaddr))
-                            .ToList().ForEach(x =>
+                        var matchedPair = _checklist.FirstOrDefault(x => x.State == ChecklistEntryState.Frozen
+                                            && x.LocalCandidate.type == RTCIceCandidateType.relay
+                                            && x.LocalCandidate.IceServer.ServerEndPoint.Equals(remoteEndPoint)
+                                            && x.RemoteCandidate.DestinationEndPoint.Equals(connaddr));
+
+                        if (matchedPair != null)
                             {
-                                x.TurnConnectionId = BitConverter.IsLittleEndian ?
+                            matchedPair.TurnConnectionId = BitConverter.IsLittleEndian ?
                                                      NetConvert.DoReverseEndian(BitConverter.ToUInt32(bytes, 0)) :
                                                      BitConverter.ToUInt32(bytes, 0);
-                                //x.FirstCheckSentAt = DateTime.MinValue;
-                                x.State = ChecklistEntryState.Waiting;
-                            });
 
+                            matchedPair.FirstCheckSentAt = DateTime.MinValue;
+                            matchedPair.State = ChecklistEntryState.Waiting;
+                            matchedPair.TurnConnectReportAt = DateTime.Now;
                     }
+                }
                 }
                 else if (stunMessage.Header.MessageClass == STUNClassTypesEnum.ErrorResponse ||
                          stunMessage.Header.MessageClass == STUNClassTypesEnum.SuccessResponse)
@@ -2231,6 +2312,7 @@ namespace SIPSorcery.Net
                             possibleMatchingCheckEntry = betterOptionEntry;
                             findBetterOptionOrWait = false; //possibleMatchingCheckEntry.RemoteCandidate.type == RTCIceCandidateType.relay;
                         }
+                    }
 
                         //if we still need to find a better option, we will search for matching entries with high priority that still processing
                         if (findBetterOptionOrWait)
@@ -2246,8 +2328,6 @@ namespace SIPSorcery.Net
                                 possibleMatchingCheckEntry = null;
                             }
                         }
-                    }
-                }
 
                 //Nominate Candidate if we pass in all heuristic checks from previous algorithm
                 if (possibleMatchingCheckEntry != null && possibleMatchingCheckEntry.State == ChecklistEntryState.Succeeded)
@@ -2255,6 +2335,7 @@ namespace SIPSorcery.Net
                     possibleMatchingCheckEntry.Nominated = true;
                     SendConnectivityCheck(possibleMatchingCheckEntry, true);
                 }
+            }
             }
 
             /*if (IsController && !_checklist.Any(x => x.Nominated))
@@ -2326,8 +2407,19 @@ namespace SIPSorcery.Net
                         // - The entry that has a remote candidate with an end point that matches the endpoint this STUN request came from,
                         // - And if the STUN request was relayed through a TURN server then only match is the checklist local candidate is 
                         //   also a relay type. It is possible for the same remote end point to send STUN requests directly and via a TURN server.
-                        matchingChecklistEntry = _checklist.Where(x => x.RemoteCandidate.IsEquivalentEndPoint(RTCIceProtocol.udp, remoteEndPoint) &&
+                        matchingChecklistEntry = _checklist.Where(x =>
+                            // TODO: remove one line below if host TCP candidate is supported, but need to modify the peer reflexive candidate acquiring below
+                            x.RemoteCandidate.IsEquivalentEndPoint(RTCIceProtocol.udp, remoteEndPoint) &&
+                            (
+                                //x.RemoteCandidate.DestinationEndPoint.Equals(remoteEndPoint) &&
                          (!wasRelayed || x.LocalCandidate.type == RTCIceCandidateType.relay)
+                            )
+                        // - Local candidate is of type relay with direct data (TCP) and received from the relay server.
+                            || (
+                                x.LocalCandidate.type == RTCIceCandidateType.relay
+                                && x.LocalCandidate.protocol == RTCIceProtocol.tcp
+                                && x.LocalCandidate.IceServer.ServerEndPoint.Equals(remoteEndPoint)
+                            )
                          ).FirstOrDefault();
                     }
 
@@ -2336,6 +2428,7 @@ namespace SIPSorcery.Net
                     {
                         // This STUN request has come from a socket not in the remote ICE candidates list. 
                         // Add a new remote peer reflexive candidate. 
+                        // TODO: how to know if it should be TCP or UDP? or maybe just add both?
                         RTCIceCandidate peerRflxCandidate = new RTCIceCandidate(new RTCIceCandidateInit());
                         peerRflxCandidate.SetAddressProperties(RTCIceProtocol.udp, remoteEndPoint.Address, (ushort)remoteEndPoint.Port, RTCIceCandidateType.prflx, null, 0);
                         peerRflxCandidate.SetDestinationEndPoint(remoteEndPoint);
@@ -2370,6 +2463,10 @@ namespace SIPSorcery.Net
                     }
                     else
                     {
+                        logger.LogTrace("Got STUN binding request for candidate {src}<-{dst}",
+                            matchingChecklistEntry.LocalCandidate.DestinationEndPoint,
+                            matchingChecklistEntry.RemoteCandidate.DestinationEndPoint);
+
                         // The UseCandidate attribute is only meant to be set by the "Controller" peer. This implementation
                         // will accept it irrespective of the peer roles. If the remote peer wants us to use a certain remote
                         // end point then so be it.
@@ -2396,6 +2493,10 @@ namespace SIPSorcery.Net
                         stunResponse.Header.TransactionId = bindingRequest.Header.TransactionId;
                         stunResponse.AddXORMappedAddressAttribute(remoteEndPoint.Address, remoteEndPoint.Port);
                         byte[] stunRespBytes = stunResponse.ToByteBufferStringKey(LocalIcePassword, true);
+
+                        logger.LogTrace("Sending STUN binding response for {lcl}->{rmt}.",
+                            matchingChecklistEntry.LocalCandidate.DestinationEndPoint,
+                            matchingChecklistEntry.RemoteCandidate.DestinationEndPoint);
 
                         if (wasRelayed)
                         {
@@ -2526,7 +2627,7 @@ namespace SIPSorcery.Net
             allocateRequest.Header.TransactionId = Encoding.ASCII.GetBytes(iceServer.TransactionID);
 
             allocateRequest.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.RequestedTransport,
-                iceServer.IceRelayProtocol == ProtocolType.Tcp ?
+                iceServer._reqIceProtocol == ProtocolType.Tcp ?
                 STUNAttributeConstants.TcpTransportType : STUNAttributeConstants.UdpTransportType));
 
             allocateRequest.Attributes.Add(
@@ -2555,7 +2656,7 @@ namespace SIPSorcery.Net
                 // technically we could use TCP relay even if we use UDP when using standard-deviating TURN server,
                 // but RFC 6062 section 4-5 enforces this for standard TURN server.
                 // https://datatracker.ietf.org/doc/html/rfc6062#section-4.1
-                if (iceServer.IceRelayProtocol == ProtocolType.Tcp)
+                if (iceServer._reqIceProtocol == ProtocolType.Tcp)
                 {
                     sendResult = SocketError.ProtocolType;
                     logger.LogWarning("Cannot allocate TCP relay with TURN when using UDP transport with TURN server. " +
@@ -2712,13 +2813,14 @@ namespace SIPSorcery.Net
             }
         }
 
+        private static bool IPEqual(IPEndPoint e1, IPEndPoint e2)
+        {
+            return e1 is not null && e2 is not null && e1.Port == e2.Port && e1.Address.Equals(e2.Address);
+        }
+
         private SocketError SendOverTCP(STUNUri uri, byte[] buffer, IPEndPoint dstEndPoint)
         {
-            //Connect to destination
-            RtpTcpSocketByUri.TryGetValue(uri, out Socket sendSocket);
-            //LastRtpDestination = dstEndPoint;
-
-            if (sendSocket == null)
+            if (!RtpTcpSocketByUri.TryGetValue(uri, out Socket sendSocket))
             {
                 return SocketError.Fault;
             }
@@ -2729,18 +2831,41 @@ namespace SIPSorcery.Net
                 dstEndPoint = new IPEndPoint(dstEndPoint.Address.MapToIPv6(), dstEndPoint.Port);
             }
 
-            Func<IPEndPoint, IPEndPoint, bool> equals = (IPEndPoint e1, IPEndPoint e2) =>
+            if (!sendSocket.Connected || !IPEqual(sendSocket.RemoteEndPoint as IPEndPoint, dstEndPoint))
             {
-                return e1.Port == e2.Port && e1.Address.Equals(e2.Address);
-            };
-
-            if (!sendSocket.Connected || !(sendSocket.RemoteEndPoint is IPEndPoint) || !equals(sendSocket.RemoteEndPoint as IPEndPoint, dstEndPoint))
-            {
+                var canReuse = false;
                 if (sendSocket.Connected)
                 {
                     logger.LogDebug("SendOverTCP request disconnect.");
                     sendSocket.Disconnect(true);
+                    canReuse = true;
                 }
+
+                // There were problems and are not handled in IceTcpReceiver, we will fault here.
+                if (!canReuse && IPEqual(sendSocket.RemoteEndPoint as IPEndPoint, dstEndPoint))
+                {
+                    logger.LogCritical("Something bad happened to TCP connection of {lcl}->{ep} and is no longer connected, Closing.",
+                        sendSocket.LocalEndPoint, dstEndPoint);
+
+                    if (m_rtpTcpReceiverByUri.TryGetValue(uri, out var oldIceTcpRecv))
+                    {
+                        oldIceTcpRecv.Close("Reconnection.");
+                    }
+
+                    return SocketError.SocketError;
+
+                    var ep = (sendSocket.LocalEndPoint as IPEndPoint);
+                    (var ip, var port) = (ep.Address, ep.Port);
+
+                    //recreate sockets?
+                    // TODO: may modify this path if base TCP is supported
+
+                    NetServices.CreateRtpSocket(false, ProtocolType.Tcp, ip, port, null, true, true, out var reConnectSocket, out _);
+
+                    m_rtpTcpReceiverByUri[uri] = GetIceTcpReceiver(reConnectSocket);
+                    sendSocket = RtpTcpSocketByUri[uri] = reConnectSocket;
+                }
+
                 sendSocket.Connect(dstEndPoint);
 
                 logger.LogDebug("SendOverTCP status: {Status} endpoint: {EndPoint}", sendSocket.Connected, dstEndPoint);
@@ -2753,8 +2878,20 @@ namespace SIPSorcery.Net
                 rtpTcpReceiver.BeginReceiveFrom();
             }
 
-            sendSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint, EndSendToTCP, sendSocket);
-            return SocketError.Success;
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Sent {bits} bytes {src}", buffer.Length, sendSocket.LocalEndPoint.ToString());
+            }
+
+            // there's no directional endpoint in TCP, need to call connect beforehand
+            //sendSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint, EndSendToTCP, sendSocket);
+            //sendSocket.BeginSend(buffer, 0, buffer.Length, SocketFlags.None, EndSendToTCP, sendSocket);
+
+            // synchronous is easier to maintain than async at this point
+            sendSocket.Send(buffer, 0, buffer.Length, SocketFlags.None, out var sendResult);
+
+            return sendResult;
+            //return SocketError.Success;
         }
 
         protected virtual void EndSendToTCP(IAsyncResult ar)
@@ -2814,6 +2951,49 @@ namespace SIPSorcery.Net
                     // STUN packet.
                     var stunMessage = STUNMessage.ParseSTUNMessage(packet, packet.Length);
                     _ = ProcessStunMessage(stunMessage, remoteEndPoint, true);
+                }
+                else
+                {
+                    OnRTPDataReceived?.Invoke(localPort, remoteEndPoint, packet);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event handler for packets received on the RTP UDP socket. This channel will detect STUN messages
+        /// and extract STUN messages to deal with ICE connectivity checks and TURN relays.
+        /// </summary>
+        /// <param name="receiver">The UDP receiver the packet was received on.</param>
+        /// <param name="localPort">The local port it was received on.</param>
+        /// <param name="remoteEndPoint">The remote end point of the sender.</param>
+        /// <param name="packet">The raw packet received (note this may not be RTP if other protocols are being multiplexed).</param>
+        protected override void OnRTPPacketReceived(UdpReceiver receiver, int localPort, IPEndPoint remoteEndPoint, byte[] packet)
+            => OnPacketReceived(localPort, remoteEndPoint, packet, false);
+
+        private void OnPacketReceived(int localPort, IPEndPoint remoteEndPoint, byte[] packet, bool wasRelayed)
+        {
+            if (packet?.Length > 0)
+            {
+                if (packet[0] == 0x00 && packet[1] == 0x17)
+                {
+                    wasRelayed = true;
+
+                    // TURN data indication. Extract the data payload and adjust the end point.
+                    var dataIndication = STUNMessage.ParseSTUNMessage(packet, packet.Length);
+                    var dataAttribute = dataIndication.Attributes.Where(x => x.AttributeType == STUNAttributeTypesEnum.Data).FirstOrDefault();
+                    packet = dataAttribute?.Value;
+
+                    var peerAddrAttribute = dataIndication.Attributes.Where(x => x.AttributeType == STUNAttributeTypesEnum.XORPeerAddress).FirstOrDefault();
+                    remoteEndPoint = (peerAddrAttribute as STUNXORAddressAttribute)?.GetIPEndPoint();
+                }
+
+                base.LastRtpDestination = remoteEndPoint;
+
+                if (packet[0] == 0x00 || packet[0] == 0x01)
+                {
+                    // STUN packet.
+                    var stunMessage = STUNMessage.ParseSTUNMessage(packet, packet.Length);
+                    _ = ProcessStunMessage(stunMessage, remoteEndPoint, wasRelayed);
                 }
                 else
                 {
@@ -2908,7 +3088,6 @@ namespace SIPSorcery.Net
         public override SocketError Send(RTPChannelSocketsEnum sendOn, IPEndPoint dstEndPoint, byte[] buffer)
         {
             if (NominatedEntry != null && NominatedEntry.LocalCandidate.type == RTCIceCandidateType.relay &&
-                NominatedEntry.LocalCandidate.IceServer != null &&
                 NominatedEntry.RemoteCandidate.DestinationEndPoint.Address.Equals(dstEndPoint.Address) &&
                 NominatedEntry.RemoteCandidate.DestinationEndPoint.Port == dstEndPoint.Port)
             {

--- a/src/SIPSorcery/net/RTP/RTPChannel.cs
+++ b/src/SIPSorcery/net/RTP/RTPChannel.cs
@@ -153,9 +153,10 @@ public class RTPChannel : IDisposable
     /// the RTP and control sockets to. If left empty then the IPv6 any address will be used if IPv6 is supported
     /// and fallback to the IPv4 any address.</param>
     /// <param name="bindPort">Optional. The specific port to attempt to bind the RTP port on.</param>
-    public RTPChannel(bool createControlSocket, IPAddress bindAddress, int bindPort = 0, PortRange rtpPortRange = null)
+    /// <param name="useTcp">Wheter to use TCP as transport.</param>
+    public RTPChannel(bool createControlSocket, IPAddress bindAddress, int bindPort = 0, PortRange rtpPortRange = null, bool useTcp = false)
     {
-        NetServices.CreateRtpSocket(createControlSocket, bindAddress, bindPort, rtpPortRange, out var rtpSocket, out m_controlSocket);
+        NetServices.CreateRtpSocket(createControlSocket, useTcp ? ProtocolType.Tcp : ProtocolType.Udp, bindAddress, bindPort, rtpPortRange, true, true, out var rtpSocket, out m_controlSocket);
 
         if (rtpSocket == null)
         {

--- a/src/SIPSorcery/net/RTP/RTPSession.cs
+++ b/src/SIPSorcery/net/RTP/RTPSession.cs
@@ -2228,7 +2228,7 @@ namespace SIPSorcery.Net
 
             // If RTCP is multiplexed we don't need a control socket.
             int bindPort = (rtpSessionConfig.BindPort == 0) ? 0 : rtpSessionConfig.BindPort + m_rtpChannelsCount;
-            var rtpChannel = new RTPChannel(!rtpSessionConfig.IsRtcpMultiplexed, rtpSessionConfig.BindAddress, bindPort, rtpSessionConfig.RtpPortRange);
+            var rtpChannel = new RTPChannel(!rtpSessionConfig.IsRtcpMultiplexed, rtpSessionConfig.BindAddress/*, rtpSessionConfig.UseTCP*/, bindPort, rtpSessionConfig.RtpPortRange);
 
 
             if (rtpSessionConfig.IsMediaMultiplexed)

--- a/src/SIPSorcery/net/RTP/RTPSessionConfig.cs
+++ b/src/SIPSorcery/net/RTP/RTPSessionConfig.cs
@@ -81,5 +81,10 @@ namespace SIPSorcery.Net
         public bool IsSecure { get => RtpSecureMediaOption == RtpSecureMediaOptionEnum.DtlsSrtp; }
 
         public bool UseSdpCryptoNegotiation { get => RtpSecureMediaOption == RtpSecureMediaOptionEnum.SdpCryptoNegotiation; }
+
+        /// <summary>
+        /// Optional. If specified, will use TCP as transport.
+        /// </summary>
+        public bool UseTCP { get; set; } = false;
     }
 }

--- a/src/SIPSorcery/net/STUN/STUNHeader.cs
+++ b/src/SIPSorcery/net/STUN/STUNHeader.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: STUNHeader.cs
 //
 // Description: Implements STUN header as defined in RFC5389
@@ -105,9 +105,15 @@ namespace SIPSorcery.Net
 
         // New methods defined in TURN (RFC6062).
         Connect = 0x000a,
+        ConnectSuccess = 0x0100 | Connect,
+
         ConnectionBind = 0x000b,
+        ConnectionBindSuccess = 0x0100 | ConnectionBind,
+
         ConnectionAttempt = 0x000c,
+        ConnectionAttemptIndication = 0x0010 | ConnectionAttempt,
     }
+
 
     /// <summary>
     /// The class is interpreted from the message type. It does not get explicitly

--- a/src/SIPSorcery/net/WebRTC/IRTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/IRTCPeerConnection.cs
@@ -98,6 +98,14 @@ namespace SIPSorcery.Net
         public RTCIceCredentialType credentialType;
         public string credential;
 
+        /// <summary>
+        /// Controls what ICE candidate to be allocated if using TURN server.
+        /// </summary>
+        /// <remarks>
+        /// Only affect TURN usage.
+        /// </remarks>
+        public RTCIceProtocol X_ICERelayProtocol { get; set; }
+
         public static RTCIceServer Parse(string iceServer)
         {
             var fields = iceServer.Split(';');
@@ -366,6 +374,18 @@ namespace SIPSorcery.Net
         /// Timeout for gathering local IP addresses
         /// </summary>
         public int X_GatherTimeoutMs = 30000;
+
+        /// <summary>
+        /// Forces the ICE candidates to be TCP candidate. Including TURN allocation.
+        /// </summary>
+        /// <remarks>
+        /// <b><i>WARNING, Experimental</i></b>.
+        /// <br/>Currently only works when used with <see cref="iceTransportPolicy"/> = <see cref="RTCIceTransportPolicy.relay"/>.
+        /// <br/>This disables any support for browser-based peer-to-peer (non-relay) WebRTC connections.
+        /// <br/><br/>
+        /// Also see <see cref="iceServers"/>.
+        /// </remarks>
+        public bool X_ICEForceTCP = false;
     }
 
     /// <summary>

--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -567,10 +567,10 @@ namespace SIPSorcery.Net
             RTCIceComponent.rtp,
             _configuration?.iceServers,
             _configuration != null ? _configuration.iceTransportPolicy : RTCIceTransportPolicy.all,
-            _configuration.X_ICEForceTCP,
             _configuration != null ? _configuration.X_ICEIncludeAllInterfaceAddresses : false,
             rtpSessionConfig.BindPort == 0 ? 0 : rtpSessionConfig.BindPort + m_rtpChannelsCount * 2,
-            rtpSessionConfig.RtpPortRange);
+            rtpSessionConfig.RtpPortRange,
+            _configuration.X_ICEForceTCP);
 
             if (rtpSessionConfig.IsMediaMultiplexed)
             {

--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -328,7 +328,16 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="configuration">Optional.</param>
         public RTCPeerConnection(RTCConfiguration configuration, int bindPort = 0, PortRange portRange = null, Boolean videoAsPrimary = false) :
-            base(true, true, true, configuration?.X_BindAddress, bindPort, portRange)
+            base(new RtpSessionConfig
+            {
+                IsMediaMultiplexed = true,
+                IsRtcpMultiplexed = true,
+                RtpSecureMediaOption = RtpSecureMediaOptionEnum.DtlsSrtp,
+                BindAddress = configuration?.X_BindAddress,
+                BindPort = bindPort,
+                RtpPortRange = portRange,
+                UseTCP = configuration.X_ICEForceTCP
+            })
         {
             _crypto = new BcTlsCrypto();
             _dataChannels = new RTCDataChannelCollection(useEvenIds: () => _dtlsHandle.IsClient);
@@ -352,6 +361,23 @@ namespace SIPSorcery.Net
                 if (_configuration.X_UseRtpFeedbackProfile)
                 {
                     RTP_MEDIA_PROFILE = RTP_MEDIA_FEEDBACK_PROFILE;
+                }
+
+                if (_configuration.X_ICEForceTCP)
+                {
+                    // TODO: Remove conditional block when TCP is implemented for direct RTP
+                    if (_configuration.iceTransportPolicy == RTCIceTransportPolicy.relay)
+                    {
+                        // TODO: keep logging when TCP is implemented for direct RTP
+                        logger.LogDebug("Forcing all ICE candidates to use TCP.");
+            }
+            else
+            {
+                        logger.LogWarning("Experimental {X_ICEForceTCP} is set but ICE transport policy is not {relay}, ICE candidates will not use TCP.",
+                            nameof(_configuration.X_ICEForceTCP), RTCIceTransportPolicy.relay);
+
+                        _configuration.X_ICEForceTCP = false;
+                    }
                 }
             }
             else
@@ -541,6 +567,7 @@ namespace SIPSorcery.Net
             RTCIceComponent.rtp,
             _configuration?.iceServers,
             _configuration != null ? _configuration.iceTransportPolicy : RTCIceTransportPolicy.all,
+            _configuration.X_ICEForceTCP,
             _configuration != null ? _configuration.X_ICEIncludeAllInterfaceAddresses : false,
             rtpSessionConfig.BindPort == 0 ? 0 : rtpSessionConfig.BindPort + m_rtpChannelsCount * 2,
             rtpSessionConfig.RtpPortRange);
@@ -552,8 +579,11 @@ namespace SIPSorcery.Net
 
             rtpIceChannel.OnRTPDataReceived += OnRTPDataReceived;
 
+            if (!_configuration.X_ICEForceTCP)
+            {
             // Start the RTP, and if required the Control, socket receivers and the RTCP session.
             rtpIceChannel.Start();
+            }
 
             m_rtpChannelsCount++;
 


### PR DESCRIPTION
This enables TCP relay communication.

The justification was that the network--even the TURN server network, only allows TCP.

Though, as it currently stands, the RFC is quite new and the browsers don't seem to be implementing it anytime soon, this mode will not support connection with browser-based WebRTC peers.

may close #1294

### remaining drafts:
- [ ] SecureContext (replacing DTLS handshake?)

### New `public` APIs:
- `X_ICEForceTCP` on `RTCConfiguration` of `bool`
- `X_ICERelayProtocol` on `RTCIceServer` of `RTCIceProtocol`

### Dev notes:
- `IceServer` class additional `_secondaryRelayUri` for TURN-TCP

### refs:
- [RFC 8835 - Transports for WebRTC section 3.4 - Middlebox-Related Functions](https://datatracker.ietf.org/doc/html/rfc8835#section-3.4)
- [RFC 6062 - Traversal Using Relays around NAT (TURN) Extensions for TCP Allocations](https://datatracker.ietf.org/doc/html/rfc6062)