### PR TITLE
Bug Fixes: race conditions where the System.Threading.Time callbacks can be called before constructor returns.

### DIFF
--- a/src/app/Media/Sources/AudioExtrasSource.cs
+++ b/src/app/Media/Sources/AudioExtrasSource.cs
@@ -322,7 +322,8 @@ namespace SIPSorcery.Media
                     }
                     else if (_audioOpts.AudioSource == AudioSourcesEnum.Silence)
                     {
-                        _sendSampleTimer = new Timer(SendSilenceSample, null, 0, _audioSamplePeriodMilliseconds);
+                        _sendSampleTimer = new Timer(SendSilenceSample);
+                        _sendSampleTimer.Change(0, _audioSamplePeriodMilliseconds);
                     }
                     else if (_audioOpts.AudioSource == AudioSourcesEnum.PinkNoise ||
                          _audioOpts.AudioSource == AudioSourcesEnum.WhiteNoise ||
@@ -344,7 +345,8 @@ namespace SIPSorcery.Media
                                 break;
                         }
 
-                        _sendSampleTimer = new Timer(SendSignalGeneratorSample, null, 0, _audioSamplePeriodMilliseconds);
+                        _sendSampleTimer = new Timer(SendSignalGeneratorSample);
+                        _sendSampleTimer.Change(0, _audioSamplePeriodMilliseconds);
                     }
                     else if (_audioOpts.AudioSource == AudioSourcesEnum.Music)
                     {
@@ -365,7 +367,8 @@ namespace SIPSorcery.Media
                             _musicStreamReader = new BinaryReader(new FileStream(_audioOpts.MusicFile, FileMode.Open, FileAccess.Read));
                         }
 
-                        _sendSampleTimer = new Timer(SendMusicSample, null, 0, _audioSamplePeriodMilliseconds);
+                        _sendSampleTimer = new Timer(SendMusicSample);
+                        _sendSampleTimer.Change(0, _audioSamplePeriodMilliseconds);
                     }
                 }
             }

--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -216,11 +216,13 @@ namespace SIPSorcery.SIP.App
 
             if (callbackPeriod < REGISTER_MINIMUM_EXPIRY * 1000)
             {
-                m_registrationTimer = new Timer(DoRegistration, null, 0, REGISTER_MINIMUM_EXPIRY * 1000);
+                m_registrationTimer = new Timer(DoRegistration);
+                m_registrationTimer.Change(0, REGISTER_MINIMUM_EXPIRY * 1000);
             }
             else
             {
-                m_registrationTimer = new Timer(DoRegistration, null, 0, callbackPeriod);
+                m_registrationTimer = new Timer(DoRegistration);
+                m_registrationTimer.Change(0, callbackPeriod);
             }
         }
 

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -556,7 +556,8 @@ namespace SIPSorcery.SIP.App
                 if (ringTimeout > 0)
                 {
                     logger.LogDebug("Setting ring timeout of {RingTimeout}s.", ringTimeout);
-                    _ringTimeout = new Timer((state) => m_uac?.Cancel(), null, ringTimeout * 1000, Timeout.Infinite);
+                    _ringTimeout = new Timer((state) => m_uac?.Cancel());
+                    _ringTimeout.Change(ringTimeout * 1000, Timeout.Infinite);
                 }
 
                 // This initiates the call but does not wait for an answer.

--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -745,7 +745,8 @@ namespace SIPSorcery.Net
 
                 if (_iceServerResolver.IceServers?.Count > 0)
                 {
-                    _processIceServersTimer = new Timer(CheckIceServers, null, 0, Ta);
+                    _processIceServersTimer = new Timer(CheckIceServers);
+                    _processIceServersTimer.Change(0, Ta);
                 }
                 else
                 {
@@ -754,7 +755,8 @@ namespace SIPSorcery.Net
                     OnIceGatheringStateChange?.Invoke(IceGatheringState);
                 }
 
-                _connectivityChecksTimer = new Timer(DoConnectivityCheck, null, 0, Ta);
+                _connectivityChecksTimer = new Timer(DoConnectivityCheck);
+                _connectivityChecksTimer.Change(0, Ta);
             }
         }
 
@@ -1111,7 +1113,8 @@ namespace SIPSorcery.Net
             {
                 logger.LogDebug("ICE RTP channel stopping ICE server checks in gathering state {IceGatheringState} and connection state {IceConnectionState}.", IceGatheringState, IceConnectionState);
                 _refreshTurnTimer?.Dispose();
-                _refreshTurnTimer = new Timer(RefreshTurn, null, 0, 2000);
+                _refreshTurnTimer = new Timer(RefreshTurn);
+                _refreshTurnTimer.Change(0, 2000);
                 _processIceServersTimer.Dispose();
                 return;
             }

--- a/src/net/RTCP/RTCPSession.cs
+++ b/src/net/RTCP/RTCPSession.cs
@@ -208,7 +208,8 @@ namespace SIPSorcery.Net
 
                 // Schedule an immediate sender report.
                 var interval = GetNextRtcpInterval(RTCP_MINIMUM_REPORT_PERIOD_MILLISECONDS);
-                m_rtcpReportTimer = new Timer(SendReportTimerCallback, null, interval, Timeout.Infinite);
+            m_rtcpReportTimer = new Timer(SendReportTimerCallback);
+            m_rtcpReportTimer.Change(interval, Timeout.Infinite);
             }
         }
 
@@ -362,7 +363,8 @@ namespace SIPSorcery.Net
                         var interval = GetNextRtcpInterval(RTCP_MINIMUM_REPORT_PERIOD_MILLISECONDS);
                         if (m_rtcpReportTimer == null)
                         {
-                            m_rtcpReportTimer = new Timer(SendReportTimerCallback, null, interval, Timeout.Infinite);
+                            m_rtcpReportTimer = new Timer(SendReportTimerCallback);
+                            m_rtcpReportTimer.Change(interval, Timeout.Infinite);
                         }
                         else
                         {

--- a/src/net/SCTP/SctpAssociation.cs
+++ b/src/net/SCTP/SctpAssociation.cs
@@ -522,7 +522,8 @@ namespace SIPSorcery.Net
                                 SendPacket(cookieEchoPkt);
                                 SetState(SctpAssociationState.CookieEchoed);
 
-                                _t1Cookie = new Timer(T1CookieTimerExpired, cookieEchoPkt, T1_COOKIE_TIMER_MILLISECONDS, T1_COOKIE_TIMER_MILLISECONDS);
+                                _t1Cookie = new Timer(T1CookieTimerExpired, cookieEchoPkt, Timeout.Infinite, Timeout.Infinite);
+                                _t1Cookie.Change(T1_COOKIE_TIMER_MILLISECONDS, T1_COOKIE_TIMER_MILLISECONDS);
                             }
                             break;
 
@@ -707,7 +708,8 @@ namespace SIPSorcery.Net
                 byte[] buffer = init.GetBytes();
                 _sctpTransport.Send(ID, buffer, 0, buffer.Length);
 
-                _t1Init = new Timer(T1InitTimerExpired, init, T1_INIT_TIMER_MILLISECONDS, T1_INIT_TIMER_MILLISECONDS);
+                _t1Init = new Timer(T1InitTimerExpired, init, Timeout.Infinite, Timeout.Infinite);
+                _t1Init.Change(T1_INIT_TIMER_MILLISECONDS, T1_INIT_TIMER_MILLISECONDS);
             }
         }
 


### PR DESCRIPTION
Bug: Instances of System.Threading.Timer can start a callback before the constructor of the Timer has returned. Particularly when the dueTime parameter is set to 0. In certain cases the timer attempts to dispose itself via its callback. This can cause exceptions that will crash the running app.

This was witnessed in the RtpIceChannel.CheckIceServers

`Application: App.exe
CoreCLR Version: 8.0.1124.51707
.NET Version: 8.0.11
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException: Object reference not set to an instance of an object.
   at SIPSorcery.Net.RtpIceChannel.CheckIceServers(Object state) in C:\Git\App\Common\sipsorcery\src\net\ICE\RtpIceChannel.cs:line 1184
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()`

I created a simple app to illustrate the issue:
<img width="2223" height="1079" alt="TimerIssue" src="https://github.com/user-attachments/assets/224e0eeb-65c7-44f8-aa11-3a9a009a6221" />

The instances of the System.Threading.Timer have been changed to use the pattern of starting the timer after the contructor has returned. This ensures that the race is avoided.
