### PR TITLE
Fix REMB Feedback for multiple ssrc's

### DIFF
--- a/src/net/RTCP/RTCPCompoundPacket.cs
+++ b/src/net/RTCP/RTCPCompoundPacket.cs
@@ -125,7 +125,7 @@ namespace SIPSorcery.Net
                             break;
                         default:
                             offset = Int32.MaxValue;
-                            logger.LogWarning("RTCPCompoundPacket did not recognise packet type ID {PacketTypeID}. {Packet}", packetTypeID, packet.HexStr());
+                            logger.LogWarning("RTCPCompoundPacket did not recognise packet type ID {PacketTypeID}. {Packet}", packetTypeID, buffer.HexStr());
                             break;
                     }
                 }

--- a/test/unit/net/RTCP/RTCFeedbackUnitTest.cs
+++ b/test/unit/net/RTCP/RTCFeedbackUnitTest.cs
@@ -94,5 +94,46 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(rtcpREMB.BitrateMantissa, parsedREMB.BitrateMantissa);
             Assert.Equal(rtcpREMB.FeedbackSSRC, parsedREMB.FeedbackSSRC);
         }
+        
+        /// <summary>
+        /// Tests that an RTCPFeedback for REMB payload with multiple SSRCs can
+        /// be correctly serialised and deserialised.
+        /// </summary>
+        [Fact]
+        public void RoundtripREMBUnitTestMultipleSsrcs()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            uint senderSsrc = 33;
+            uint mediaSsrc = 44;
+
+            RTCPFeedback rtcpREMB = new RTCPFeedback(senderSsrc, mediaSsrc, PSFBFeedbackTypesEnum.AFB)
+            {
+                SENDER_PAYLOAD_SIZE = 8 + 12+4+4, // 8 bytes from (SenderSSRC + MediaSSRC) + extra 12 bytes from REMB Definition +2x extra 8 bytes for SSRCs
+                UniqueID = "REMB",
+                NumSsrcs = 3,
+                BitrateExp = 4,
+                BitrateMantissa = 222242u,
+                FeedbackSSRCs = new uint[]{0x4a8eec30,0x4a8eec44,0x4a8eec58}
+            };
+            byte[] buffer = rtcpREMB.GetBytes();
+
+            logger.LogDebug("Serialised REMB: {Buffer}", BufferUtils.HexStr(buffer));
+
+            RTCPFeedback parsedREMB = new RTCPFeedback(buffer);
+            var parsedBuffer = parsedREMB.GetBytes();
+            Assert.Equal(parsedBuffer, buffer);
+            Assert.Equal(RTCPReportTypesEnum.PSFB, parsedREMB.Header.PacketType);
+            Assert.Equal(PSFBFeedbackTypesEnum.AFB, parsedREMB.Header.PayloadFeedbackMessageType);
+            Assert.Equal(senderSsrc, parsedREMB.SenderSSRC);
+            Assert.Equal(mediaSsrc, parsedREMB.MediaSSRC);
+            Assert.Equal(rtcpREMB.UniqueID, parsedREMB.UniqueID);
+            Assert.Equal(rtcpREMB.NumSsrcs, parsedREMB.NumSsrcs);
+            Assert.Equal(rtcpREMB.BitrateExp, parsedREMB.BitrateExp);
+            Assert.Equal(rtcpREMB.BitrateMantissa, parsedREMB.BitrateMantissa);
+            Assert.Equal(rtcpREMB.FeedbackSSRC, parsedREMB.FeedbackSSRC);
+            Assert.Equal(rtcpREMB.FeedbackSSRCs, parsedREMB.FeedbackSSRCs);
+        }
     }
 }

--- a/test/unit/net/RTCP/RTCPCompoundPacketUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPCompoundPacketUnitTest.cs
@@ -111,5 +111,21 @@ namespace SIPSorcery.Net.UnitTests
 
             Assert.NotNull(cp);
         }
+        
+        [Fact]
+        public void ParseChromeRtcpPacketWith6SSRCsUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var buffer = TypeExtensions.ParseHexStr("81C9000700000001497EB0250000000000009CA200000A0500000000000000008FCE000A000000010000000052454D42060B29711CAB48A626A3FADE2EE30A21497EB0255C6A292A604EEAC8");
+
+            RTCPCompoundPacket cp = new RTCPCompoundPacket(buffer);
+            Assert.Equal(6, cp.Feedback.NumSsrcs);
+            Assert.Equal(6, cp.Feedback.FeedbackSSRCs.Length);
+            Assert.Equal( 8 + 12 + (5*4),  cp.Feedback.SENDER_PAYLOAD_SIZE);//// 8 bytes from (SenderSSRC + MediaSSRC) + extra 12 bytes from REMB Definition +5x extra 4 bytes for SSRCs
+            Assert.NotNull(cp);
+        }
+
     }
 }


### PR DESCRIPTION
this is a revive of #1467 which was a revice of #1466

i create a draft as i cant test some of the unit-tests(no windows availlable)

this time, we have
no breaking-change
working unit test for old variant
added unit test for new variant with multiple ssrc's

<img width="1264" height="969" alt="image" src="https://github.com/user-attachments/assets/a9a17080-4993-4679-ae3a-2e778aaebe03" />

It seems, these tests are windows only? (no ntdll for linux...)
The time tests failing seems to be because of me not being in UTC.. maybe use DateTimeOffset?




