### PR TITLE
Fix createAnswer generating invalid SDP setup:actpass (#1463)

### DIFF
--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1035,17 +1035,17 @@ namespace SIPSorcery.Net
                     }
                 }
 
-                //if (answerSdp.Media.Any(x => x.Media == SDPMediaTypesEnum.audio))
-                //{
-                //    var audioAnnouncement = answerSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.audio).Single();
-                //    audioAnnouncement.IceRole = IceRole;
-                //}
+                // RFC 4145 Section 4.1: An SDP answer MUST use setup:active or
+                // setup:passive, never setup:actpass. Ensure all media
+                // announcements carry the resolved role.
+                var answerRole = (IceRole == IceRolesEnum.active)
+                    ? IceRolesEnum.active
+                    : IceRolesEnum.passive;
 
-                //if (answerSdp.Media.Any(x => x.Media == SDPMediaTypesEnum.video))
-                //{
-                //    var videoAnnouncement = answerSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.video).Single();
-                //    videoAnnouncement.IceRole = IceRole;
-                //}
+                foreach (var ann in answerSdp.Media)
+                {
+                    ann.IceRole = answerRole;
+                }
 
                 RTCSessionDescriptionInit initDescription = new RTCSessionDescriptionInit
                 {

--- a/test/unit/net/WebRTC/RTCPeerConnectionAnswerUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionAnswerUnitTest.cs
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------------
+// Filename: RTCPeerConnectionAnswerUnitTest.cs
+//
+// Description: Unit tests for RTCPeerConnection.createAnswer().
+//
+// History:
+// 16 Feb 2026	CraziestPower	Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class RTCPeerConnectionAnswerUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public RTCPeerConnectionAnswerUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Tests that createAnswer generates a=setup:active or a=setup:passive,
+        /// never a=setup:actpass. Per RFC 4145 Section 4.1 and RFC 5763 Section 5,
+        /// an SDP answer must not contain setup:actpass.
+        /// See https://github.com/sipsorcery-org/sipsorcery/issues/1463.
+        /// </summary>
+        [Fact]
+        public void AnswerSdpSetupAttributeNotActpass()
+        {
+            // Create an offerer with a video track.
+            RTCPeerConnection offerer = new RTCPeerConnection(null);
+            var videoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            offerer.addTrack(videoTrack);
+
+            var offer = offerer.createOffer(new RTCOfferOptions());
+            Assert.NotNull(offer?.sdp);
+
+            logger.LogDebug("Offer SDP:\n{Sdp}", offer.sdp);
+
+            // Create an answerer, set the remote offer, then create the answer.
+            RTCPeerConnection answerer = new RTCPeerConnection(null);
+            var answerVideoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            answerer.addTrack(answerVideoTrack);
+
+            var setResult = answerer.setRemoteDescription(offer);
+            Assert.Equal(SetDescriptionResultEnum.OK, setResult);
+
+            var answer = answerer.createAnswer();
+            Assert.NotNull(answer?.sdp);
+
+            logger.LogDebug("Answer SDP:\n{Sdp}", answer.sdp);
+
+            // Parse the answer SDP and verify every media announcement has
+            // setup:active or setup:passive, never actpass.
+            SDP answerSdp = SDP.ParseSDPDescription(answer.sdp);
+            Assert.NotEmpty(answerSdp.Media);
+
+            foreach (var media in answerSdp.Media)
+            {
+                Assert.NotNull(media.IceRole);
+                Assert.NotEqual(IceRolesEnum.actpass, media.IceRole.Value);
+                Assert.True(
+                    media.IceRole == IceRolesEnum.active || media.IceRole == IceRolesEnum.passive,
+                    $"Answer SDP media {media.Media} had setup:{media.IceRole} instead of active or passive.");
+            }
+
+            // Also verify the raw SDP string does not contain "a=setup:actpass".
+            Assert.DoesNotContain("a=setup:actpass", answer.sdp);
+
+            offerer.close();
+            answerer.close();
+        }
+    }
+}


### PR DESCRIPTION
Closes #1463

## Summary

- Replaces commented-out IceRole code in `createAnswer()` with a loop that enforces `a=setup:active` or `a=setup:passive` on all media announcements in the SDP answer.
- Per RFC 4145 Section 4.1 and RFC 5763 Section 5, an SDP answer MUST NOT contain `a=setup:actpass` — that value is only valid in offers.
- Covers all media types (audio, video, data channels) uniformly, unlike the old commented-out code which only handled audio and video separately.

Credit to @ispysoftware for the suggested fix approach in the issue comments.

## Test plan

- [x] New unit test `AnswerSdpSetupAttributeNotActpass` verifies the answer SDP never contains `a=setup:actpass`
- [x] All existing WebRTC and SDP tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)