### PR TITLE
Fix UnobservedTaskException from skipped EndReceiveFrom on close (#1494)

### DIFF
--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -161,6 +161,10 @@ namespace SIPSorcery.SIP
                         SIPMessageReceived?.Invoke(this, localEndPoint, remoteEndPoint, sipMsgBuffer);
                     }
                 }
+                else
+                {
+                    m_udpSocket.EndReceiveFromClosed(ar, ref remoteEP);
+                }
             }
             catch (SocketException sockExcp)
             {

--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -198,16 +198,20 @@ namespace SIPSorcery.Net
             {
                 try
                 {
+                    EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
                     // When socket is closed the object will be disposed of in the middle of a receive.
                     if (!m_isClosed)
                     {
-                        EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
                         int bytesRead = m_socket.EndReceiveFrom(ar, ref remoteEP);
 
                         if (bytesRead > 0)
                         {
                             ProcessRawBuffer(bytesRead + m_recvOffset, remoteEP as IPEndPoint);
                         }
+                    }
+                    else
+                    {
+                        m_socket.EndReceiveFromClosed(ar, ref remoteEP);
                     }
 
                     // If there is still data available it should be read now. This is more efficient than calling
@@ -219,7 +223,7 @@ namespace SIPSorcery.Net
                     {
                         while (!m_isClosed && m_socket.Available > 0)
                         {
-                            EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
+                            remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
                             var recvLength = m_recvBuffer.Length - m_recvOffset;
                             //Discard fragmentation buffer as seems that we will have an incorrect result based in cached values
                             if (recvLength <= 0 || m_recvOffset < 0)

--- a/src/net/RTP/UdpReceiver.cs
+++ b/src/net/RTP/UdpReceiver.cs
@@ -161,10 +161,10 @@ public class UdpReceiver
     {
         try
         {
+            EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
             // When socket is closed the object will be disposed of in the middle of a receive.
             if (!m_isClosed)
             {
-                EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
                 int bytesRead = m_socket.EndReceiveFrom(ar, ref remoteEP);
 
                 if (bytesRead > 0)
@@ -183,6 +183,10 @@ public class UdpReceiver
                     CallOnPacketReceivedCallback(m_localEndPoint.Port, remoteEP as IPEndPoint, packetBuffer);
                 }
             }
+            else
+            {
+                m_socket.EndReceiveFromClosed(ar, ref remoteEP);
+            }
 
             // If there is still data available it should be read now. This is more efficient than calling
             // BeginReceiveFrom which will incur the overhead of creating the callback and then immediately firing it.
@@ -193,7 +197,7 @@ public class UdpReceiver
             {
                 while (!m_isClosed && m_socket.Available > 0)
                 {
-                    EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
+                    remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
                     int bytesReadSync = m_socket.ReceiveFrom(m_recvBuffer, 0, m_recvBuffer.Length, SocketFlags.None, ref remoteEP);
 
                     if (bytesReadSync > 0)

--- a/src/sys/Net/SocketExtensions.cs
+++ b/src/sys/Net/SocketExtensions.cs
@@ -1,0 +1,35 @@
+// Adapted from lostmsu's fix for #1494.
+// See https://github.com/sipsorcery-org/sipsorcery/issues/1494
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace SIPSorcery.Sys
+{
+    static class SocketExtensions
+    {
+        /// <summary>
+        /// Completes a pending <see cref="Socket.EndReceiveFrom"/> on a socket that
+        /// is already closed. Per the .NET APM contract, <c>End*</c> must always be
+        /// called for every <c>Begin*</c>. Skipping the call leaves the underlying
+        /// <see cref="IAsyncResult"/> task uncompleted, which surfaces as an
+        /// <c>UnobservedTaskException</c> that can crash the process.
+        /// </summary>
+        public static void EndReceiveFromClosed(this Socket socket, IAsyncResult asyncResult, ref EndPoint ep)
+        {
+            try
+            {
+                socket.EndReceiveFrom(asyncResult, ref ep);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Socket has been closed, ignore.
+            }
+            catch (SocketException abort) when (abort.SocketErrorCode == SocketError.OperationAborted)
+            {
+                // Socket has been closed, ignore.
+            }
+        }
+    }
+}

--- a/test/unit/net/RTP/UdpReceiverUnitTest.cs
+++ b/test/unit/net/RTP/UdpReceiverUnitTest.cs
@@ -1,0 +1,144 @@
+//-----------------------------------------------------------------------------
+// Filename: UdpReceiverUnitTest.cs
+//
+// Description: Unit tests for the UdpReceiver class, specifically verifying
+// that closing a receiver while it has a pending BeginReceiveFrom does not
+// leave an unobserved IAsyncResult (issue #1494).
+//
+// Author(s):
+// CraziestPower
+//
+// History:
+// 16 Feb 2026	CraziestPower	Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class UdpReceiverUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public UdpReceiverUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Verifies that closing a UdpReceiver while a BeginReceiveFrom is pending
+        /// does not produce an UnobservedTaskException. This is the scenario described
+        /// in issue #1494: the APM End* call must always be made for every Begin* call.
+        /// </summary>
+        [Fact]
+        public async Task CloseWhileReceivingDoesNotThrowUnobservedException()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            AggregateException capturedException = null;
+
+            EventHandler<UnobservedTaskExceptionEventArgs> handler = (s, e) =>
+            {
+                capturedException = e.Observed ? null : e.Exception;
+                e.SetObserved();
+            };
+
+            TaskScheduler.UnobservedTaskException += handler;
+            try
+            {
+                // Create a UDP socket bound to a random port.
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+                var receiver = new UdpReceiver(socket);
+
+                // Start the async receive loop.
+                receiver.BeginReceiveFrom();
+                Assert.True(receiver.IsRunningReceive);
+
+                // Close while the receive is pending — this is the #1494 trigger.
+                receiver.Close("test shutdown");
+                Assert.True(receiver.IsClosed);
+
+                // Give the async callback time to fire and the finalizer to run.
+                await Task.Delay(250);
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                await Task.Delay(250);
+
+                Assert.Null(capturedException);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= handler;
+            }
+
+            logger.LogDebug("-----------------------------------------");
+        }
+
+        /// <summary>
+        /// Verifies that the OnClosed event fires with the reason string when
+        /// Close is called on a UdpReceiver.
+        /// </summary>
+        [Fact]
+        public void CloseFiresOnClosedEvent()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+            var receiver = new UdpReceiver(socket);
+
+            string closedReason = null;
+            receiver.OnClosed += reason => closedReason = reason;
+
+            receiver.Close("unit test close");
+
+            Assert.True(receiver.IsClosed);
+            Assert.Equal("unit test close", closedReason);
+
+            logger.LogDebug("-----------------------------------------");
+        }
+
+        /// <summary>
+        /// Verifies that calling Close multiple times only fires OnClosed once
+        /// and does not throw.
+        /// </summary>
+        [Fact]
+        public void DoubleCloseDoesNotThrow()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+            var receiver = new UdpReceiver(socket);
+
+            int closedCount = 0;
+            receiver.OnClosed += _ => Interlocked.Increment(ref closedCount);
+
+            receiver.Close("first");
+            receiver.Close("second");
+
+            Assert.True(receiver.IsClosed);
+            Assert.Equal(1, closedCount);
+
+            logger.LogDebug("-----------------------------------------");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #1494: `UnobservedTaskException` caused by skipping `EndReceiveFrom` when a socket is closed while a `BeginReceiveFrom` is pending.
- Per the .NET APM contract, `End*` must always be called for every `Begin*`. When the receiver was closed mid-receive, the `EndReceiveFrom` call was skipped entirely, leaving the `IAsyncResult` dangling as an unobserved task that could crash the process.
- Added `SocketExtensions.EndReceiveFromClosed()` helper method (approach adapted from @lostmsu's suggestion in #1494) and wired it into the `else` branch of `EndReceiveFrom` in `UdpReceiver`, `RtpIceChannel`, and `SIPUDPChannel`.

## Files changed

| File | Change |
|------|--------|
| `src/sys/Net/SocketExtensions.cs` | New helper: calls `EndReceiveFrom` and swallows `ObjectDisposedException` / `OperationAborted` |
| `src/net/RTP/UdpReceiver.cs` | Move `remoteEP` before `if`, add `else { EndReceiveFromClosed }` |
| `src/net/ICE/RtpIceChannel.cs` | Same pattern |
| `src/core/SIP/Channels/SIPUDPChannel.cs` | Same pattern (remoteEP already in scope) |
| `test/unit/net/RTP/UdpReceiverUnitTest.cs` | 3 new tests including regression test that verifies no `UnobservedTaskException` on close |

## Test plan

- [x] New `CloseWhileReceivingDoesNotThrowUnobservedException` test — verified it **fails** without the fix and **passes** with it
- [x] `CloseFiresOnClosedEvent` — verifies `OnClosed` event fires with reason
- [x] `DoubleCloseDoesNotThrow` — verifies idempotent close
- [x] Full unit test suite passes (564 passed, 8 skipped)

## Attribution

The `EndReceiveFromClosed` approach is adapted from @lostmsu's analysis in #1494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)