### PR TITLE
Fix m-line ordering in SDP offers to match track insertion order

### DIFF
--- a/src/net/RTP/Streams/MediaStream.cs
+++ b/src/net/RTP/Streams/MediaStream.cs
@@ -69,6 +69,12 @@ namespace SIPSorcery.Net
         public int Index = -1;
 
         /// <summary>
+        /// Tracks the global order in which this stream was added to the session,
+        /// across all media types. Used to preserve m-line ordering per RFC 3264 §8.
+        /// </summary>
+        public int MediaInsertionOrder = -1;
+
+        /// <summary>
         /// Fires when the connection for a media type is classified as timed out due to not
         /// receiving any RTP or RTCP packets within the given period.
         /// </summary>


### PR DESCRIPTION
## Summary

- Fix `GetMediaStreams()` to preserve the order tracks were added, rather than always emitting audio→video→text. This ensures SDP offers comply with RFC 3264 §8 (stable m-line positions across renegotiations) and RFC 8829/JSEP §5.2.1 (initial offer follows transceiver insertion order).
- Add `MediaInsertionOrder` field to `MediaStream` and a global counter in `RTPSession` to track insertion order across all media types.
- Deduplicate three identical foreach loops in `GetMediaStreams()` into a single `Concat`-based iteration.

Fixes #1476

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 578 passed, 0 failed
- [x] New test: video added first → video m-line at index 0 in offer
- [x] New test: audio added first → audio m-line at index 0 (backward compat)
- [ ] Manual verification with a browser WebRTC endpoint where video is added before audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)