### PR TITLE
Use the default schedulre when starting new tasks

### DIFF
--- a/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -219,7 +219,7 @@ namespace SIPSorcery.SIP
                         if (!m_isReceiveTaskRunning)
                         {
                             m_isReceiveTaskRunning = true;
-                            _ = Task.Factory.StartNew(MonitorReceiveTasks, TaskCreationOptions.LongRunning);
+                            _ = Task.Factory.StartNew(MonitorReceiveTasks, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
                         }
                     }
 

--- a/src/SIPSorcery/core/SIP/Channels/SIPTCPChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPTCPChannel.cs
@@ -155,8 +155,8 @@ namespace SIPSorcery.SIP
             {
                 m_channelSocket.Listen(MAX_TCP_CONNECTIONS);
 
-                Task.Factory.StartNew(AcceptConnections, TaskCreationOptions.LongRunning);
-                Task.Factory.StartNew(PruneConnections, TaskCreationOptions.LongRunning);
+                Task.Factory.StartNew(AcceptConnections, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                Task.Factory.StartNew(PruneConnections, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
         }
 

--- a/src/SIPSorcery/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPUDPChannel.cs
@@ -99,7 +99,7 @@ namespace SIPSorcery.SIP
 
             Receive();
 
-            Task.Factory.StartNew(ExpireFailedSends, TaskCreationOptions.LongRunning);
+            Task.Factory.StartNew(ExpireFailedSends, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
 
         public SIPUDPChannel(IPAddress listenAddress, int listenPort) : this(new IPEndPoint(listenAddress, listenPort))

--- a/src/SIPSorcery/core/SIP/SIPTransport.cs
+++ b/src/SIPSorcery/core/SIP/SIPTransport.cs
@@ -279,7 +279,7 @@ namespace SIPSorcery.SIP
                     {
                         // Starts tasks to process queued SIP messages.
                         m_transportThreadStarted = true;
-                        Task.Factory.StartNew(ProcessReceiveQueue, TaskCreationOptions.LongRunning);
+                        Task.Factory.StartNew(ProcessReceiveQueue, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
                     }
                 }
                 else


### PR DESCRIPTION
Avoid long running tasks getting starved on the current conext scheduler. Resolves #1535.