### PR TITLE
Handle early media SDP in any provisional response (101-199), not only 183

### DIFF
--- a/src/SIPSorcery/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/SIPSorcery/app/SIPUserAgents/SIPUserAgent.cs
@@ -1690,7 +1690,8 @@ namespace SIPSorcery.SIP.App
         {
             try
             {
-                if (sipResponse.Status == SIPResponseStatusCodesEnum.SessionProgress &&
+                if (sipResponse.StatusCode > 100 &&
+                    sipResponse.StatusCode < 200 &&
                     sipResponse.Body != null)
                 {
                     var setDescriptionResult = MediaSession.SetRemoteDescription(SdpType.answer, SDP.ParseSDPDescription(sipResponse.Body));


### PR DESCRIPTION
Closes #1547 

## Summary

  - `ClientCallRingingHandler` previously only started early media when the provisional response was `183 Session Progress`. A `180 Ringing` (or any other 1xx) carrying an SDP answer was ignored.
  - The condition is relaxed to match any provisional response in the range 101–199 that includes an SDP body, per RFC 3261 §13.2.1 and §21.1.
  - The existing `IsAudioStarted` guard in `ClientCallAnsweredHandler` already handles the case where the `200 OK` arrives without a body after early media is established, so no further changes are needed.

  ## RFC basis

  RFC 3261 §13.2.1:
  > "That same exact answer MAY also be placed in **any provisional responses** sent prior to the answer."

  RFC 3261 §21.1:
  > "Provisional (1xx) responses MAY contain message bodies, including session descriptions."

  100 Trying is excluded because it is hop-by-hop and cannot be sent reliably
  (RFC 3262 §3: "A UAS MUST NOT attempt to send a 100 (Trying) response
  reliably").