### PR TITLE
added VideoCodecsEnum.AV1

### DIFF
--- a/src/SIPSorceryMedia.Abstractions/Enums/VideoCodecsEnum.cs
+++ b/src/SIPSorceryMedia.Abstractions/Enums/VideoCodecsEnum.cs
@@ -27,6 +27,7 @@ public enum VideoCodecsEnum
     H263,
     VP8,
     VP9,
+    AV1,
     H264,
     H265,
 

--- a/src/SIPSorceryMedia.Abstractions/MediaFormats/VideoFormat.cs
+++ b/src/SIPSorceryMedia.Abstractions/MediaFormats/VideoFormat.cs
@@ -47,7 +47,7 @@ public struct VideoFormat
     /// </summary>
     /// <remarks>
     /// Example, 90000 is the clock rate:
-    /// a=rtpmap:102 H264/90000
+    /// a=rtpmap:102 AV1/90000
     /// </remarks>
     public int ClockRate { get; set; }
 

--- a/test/SIPSorceryMedia.Abstractions.UnitTest/VideoFormatTest.cs
+++ b/test/SIPSorceryMedia.Abstractions.UnitTest/VideoFormatTest.cs
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------------
+// Filename: VideoFormatTest.cs
+//
+// Description: Unit tests for the video format model.
+//
+// Author(s):
+// Aaron Clauson (aaron@sipsorcery.com)
+//
+// History:
+// 28 Mar 2026  OpenAI         Added AV1 coverage.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace SIPSorceryMedia.Abstractions.UnitTest
+{
+    public class VideoFormatTest
+    {
+        [Fact]
+        public void DynamicAv1FormatMapsToAv1CodecUnitTest()
+        {
+            const int formatId = 96;
+            const int clockRate = VideoFormat.DEFAULT_CLOCK_RATE;
+
+            var videoFormat = new VideoFormat(formatId, "AV1", clockRate);
+
+            Assert.Equal(VideoCodecsEnum.AV1, videoFormat.Codec);
+            Assert.Equal(formatId, videoFormat.FormatID);
+            Assert.Equal("AV1", videoFormat.FormatName);
+            Assert.Equal(clockRate, videoFormat.ClockRate);
+        }
+
+        [Fact]
+        public void Av1EnumCreatesRfcAlignedDynamicFormatUnitTest()
+        {
+            const int formatId = 96;
+
+            var videoFormat = new VideoFormat(VideoCodecsEnum.AV1, formatId);
+
+            Assert.Equal(VideoCodecsEnum.AV1, videoFormat.Codec);
+            Assert.Equal(formatId, videoFormat.FormatID);
+            Assert.Equal("AV1", videoFormat.FormatName);
+            Assert.Equal(VideoFormat.DEFAULT_CLOCK_RATE, videoFormat.ClockRate);
+        }
+    }
+}

--- a/test/unit/net/SDP/SDPAudioVideoMediaFormatUnitTest.cs
+++ b/test/unit/net/SDP/SDPAudioVideoMediaFormatUnitTest.cs
@@ -50,5 +50,25 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(8000, audioFormat.ClockRate);
             Assert.Equal("PCMU/8000", pcmu.Rtpmap);
         }
+
+        /// <summary>
+        /// Tests that a dynamic AV1 video format is serialised to SDP and mapped back.
+        /// </summary>
+        [Fact]
+        public void MapDynamicAv1VideoFormatUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var av1 = new VideoFormat(VideoCodecsEnum.AV1, 96);
+            var sdpFormat = new SDPAudioVideoMediaFormat(av1);
+            var roundTrip = sdpFormat.ToVideoFormat();
+
+            Assert.Equal(SDPMediaTypesEnum.video, sdpFormat.Kind);
+            Assert.Equal("AV1/90000", sdpFormat.Rtpmap);
+            Assert.Equal(VideoCodecsEnum.AV1, roundTrip.Codec);
+            Assert.Equal("AV1", roundTrip.FormatName);
+            Assert.Equal(VideoFormat.DEFAULT_CLOCK_RATE, roundTrip.ClockRate);
+        }
     }
 }


### PR DESCRIPTION
I am planning to add full AV1 support over a few separate PRs that depend on each other. If maintainers want, it is possible to review the full set at once: https://github.com/BorgGames/sipsorcery/tree/AV1-FFmpeg

With these changes + AV1 forcing in WebRTCTestPatternServer I am able to see the test pattern in Firefox on Windows using AV1.

The failure seems unrelated