### PR TITLE
SRTP Performance improvements and bugfixes

### DIFF
--- a/src/SIPSorcery/net/DtlsSrtp/DtlsSrtpTransport.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/DtlsSrtpTransport.cs
@@ -71,7 +71,7 @@ namespace SIPSorcery.Net
 
         public bool DoHandshake(out string handshakeError)
         {
-            DtlsTransport transport = _connection.DoHandshake(out handshakeError, this, null, (remoteEndpoint) => this);
+            DtlsTransport transport = _connection.DoHandshake(out handshakeError, this, null);
             Transport = transport;
             return string.IsNullOrEmpty(handshakeError);
         }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/BouncyCastleExtensions.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/BouncyCastleExtensions.cs
@@ -1,0 +1,85 @@
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
+using System;
+using System.Runtime.CompilerServices;
+
+public static class BouncyCastleExtensions
+{
+    extension(KeyParameter)
+    {
+#if NET8_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static KeyParameter Create(ReadOnlyMemory<byte> key)
+        {
+            return new KeyParameter(key.Span);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static KeyParameter Create(ReadOnlySpan<byte> key)
+        {
+            return new KeyParameter(key);
+        }
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static KeyParameter Create(ReadOnlyMemory<byte> memory)
+        {
+            if (System.Runtime.InteropServices.MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment))
+            {
+                return KeyParameter.Create(segment);
+            }
+            // Fallback for non-array-backed memory
+            return new KeyParameter(memory.ToArray());
+        }
+#endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static KeyParameter Create(ArraySegment<byte> key)
+        {
+            return new KeyParameter(key.Array, key.Offset, key.Count);
+        }
+    }
+
+#if !NET8_0_OR_GREATER
+    extension(IBlockCipher engine)
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ProcessBlock(ArraySegment<byte> input, ArraySegment<byte> output)
+        {
+            return engine.ProcessBlock(input.Array, input.Offset, output.Array, output.Offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ProcessBlock(byte[] input, byte[] output)
+        {
+            return engine.ProcessBlock(input, 0, output, 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ProcessBlock(byte[] input, ArraySegment<byte> output)
+        {
+            return engine.ProcessBlock(input, 0, output.Array, output.Offset);
+        }
+    }
+
+    extension(IAeadBlockCipher engine)
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ProcessBytes(ArraySegment<byte> input, ArraySegment<byte> output)
+        {
+            return engine.ProcessBytes(input.Array, input.Offset, input.Count, output.Array, output.Offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ProcessAadBytes(ArraySegment<byte> input)
+        {
+            engine.ProcessAadBytes(input.Array, input.Offset, input.Count);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int DoFinal(ArraySegment<byte> output)
+        {
+            return engine.DoFinal(output.Array, output.Offset);
+        }
+    }
+#endif
+}

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/DtlsCertificateUtils.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/DtlsCertificateUtils.cs
@@ -107,7 +107,9 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
 
             var crypto = new BcTlsCrypto();
             var tlsCertificate = crypto.CreateCertificate(x509Certificate.GetEncoded());
-            var certificate = new Certificate(new TlsCertificate[] { tlsCertificate });
+
+            // certificateRequestContext = TlsUtilities.EmptyBytes for TLS/DTLS 1.3, null for TLS/DTLS 1.2
+            var certificate = new Certificate(null, new[] { new CertificateEntry(tlsCertificate, null) });
 
             return (certificate, privateKey);
         }
@@ -166,7 +168,9 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
 
             var crypto = new BcTlsCrypto();
             var tlsCertificate = crypto.CreateCertificate(x509Certificate.GetEncoded());
-            var certificate = new Certificate(new[] { tlsCertificate });
+
+            // certificateRequestContext = TlsUtilities.EmptyBytes for TLS/DTLS 1.3, null for TLS/DTLS 1.2
+            var certificate = new Certificate(null, new[] { new CertificateEntry(tlsCertificate, null) });
 
             return (certificate, privateKey);
         }
@@ -204,7 +208,7 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
                 // This method has an unfortunate consequence of actually creating the digest, so the call is expensive.
                 digest = DigestUtilities.GetDigest(algStr.ToUpperInvariant());
             }
-            catch(Exception)
+            catch (Exception)
             {
                 return false;
             }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/DtlsClient.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/DtlsClient.cs
@@ -33,8 +33,8 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
 {
     public class DtlsClient : DefaultTlsClient, IDtlsPeer
     {
-        protected DatagramTransport _clientDatagramTransport; // valid only for the current session
-
+        private readonly object _syncRoot = new object();
+        protected DatagramTransport _clientDatagramTransport = null;
         private TlsSession _session;
 
         public bool AutogenerateCertificate { get; set; } = true;
@@ -136,26 +136,28 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
             }
         }
 
-        public virtual DtlsTransport DoHandshake(out string handshakeError, DatagramTransport datagramTransport, Func<string> getRemoteEndpoint = null, Func<string, DatagramTransport> createClientDatagramTransport = null)
+        public virtual DtlsTransport DoHandshake(out string handshakeError, DatagramTransport datagramTransport, DtlsRequest request = null)
         {
-            DtlsTransport transport = null;
-                        
-            try
+            lock (_syncRoot)
             {
-                DtlsClientProtocol clientProtocol = new DtlsClientProtocol();
+                DtlsTransport transport = null;
 
-                _clientDatagramTransport = datagramTransport;
-                transport = clientProtocol.Connect(this, datagramTransport);
-                _clientDatagramTransport = null;
-            }
-            catch (Exception ex)
-            {
-                handshakeError = ex.Message;
-                return null;
-            }
+                try
+                {
+                    DtlsClientProtocol clientProtocol = new DtlsClientProtocol();
+                    _clientDatagramTransport = datagramTransport;
+                    transport = clientProtocol.Connect(this, datagramTransport);
+                    _clientDatagramTransport = null;
+                }
+                catch (Exception ex)
+                {
+                    handshakeError = ex.Message;
+                    return null;
+                }
 
-            handshakeError = null;
-            return transport;
+                handshakeError = null;
+                return transport;
+            }
         }
 
         public override TlsSession GetSessionToResume()

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/DtlsServer.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/DtlsServer.cs
@@ -27,13 +27,13 @@ using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 using Org.BouncyCastle.Utilities.Encoders;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace SIPSorcery.Net.SharpSRTP.DTLS
 {
     public class DtlsServer : DefaultTlsServer, IDtlsPeer
     {
-        protected DatagramTransport _clientDatagramTransport; // valid only for the current session
+        private readonly object _syncRoot = new object();
+        protected DatagramTransport _clientDatagramTransport = null;
 
         public int TimeoutMilliseconds { get; set; } = 20000;
 
@@ -131,81 +131,33 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
             }
         }
 
-        public virtual DtlsTransport DoHandshake(out string handshakeError, DatagramTransport datagramTransport, Func<string> getRemoteEndpoint, Func<string, DatagramTransport> createClientDatagramTransport)
+        public virtual DtlsTransport DoHandshake(out string handshakeError, DatagramTransport datagramTransport, DtlsRequest request = null)
         {
-            if (datagramTransport == null)
+            lock (_syncRoot)
             {
-                throw new ArgumentNullException(nameof(datagramTransport));
-            }
-
-            if (createClientDatagramTransport == null)
-            {
-                throw new ArgumentNullException(nameof(createClientDatagramTransport));
-            }
-
-            DtlsTransport transport = null;
-
-            try
-            {
-                DtlsServerProtocol serverProtocol = new DtlsServerProtocol();
-                DtlsRequest request = null;
-                string remoteEndpoint = null;
-
-                if (getRemoteEndpoint != null)
+                if (datagramTransport == null)
                 {
-                    // Use DtlsVerifier to require a HelloVerifyRequest cookie exchange before accepting
-                    DtlsVerifier verifier = new DtlsVerifier(Crypto);
-                    int receiveLimit = datagramTransport.GetReceiveLimit();
-                    byte[] buf = new byte[receiveLimit];
-                    int receiveAttemptCounter = 0;
-
-                    do
-                    {
-                        const int RECEIVE_TIMEOUT = 100;
-                        int length = datagramTransport.Receive(buf, 0, receiveLimit, RECEIVE_TIMEOUT);
-                        if (length > 0)
-                        {
-                            remoteEndpoint = getRemoteEndpoint();
-                            if (string.IsNullOrEmpty(remoteEndpoint))
-                            {
-                                throw new InvalidOperationException();
-                            }
-
-                            byte[] clientID = Encoding.UTF8.GetBytes(remoteEndpoint);
-                            request = verifier.VerifyRequest(clientID, buf, 0, length, datagramTransport);
-                        }
-                        else
-                        {
-                            receiveAttemptCounter++;
-
-                            if (receiveAttemptCounter * RECEIVE_TIMEOUT >= TimeoutMilliseconds) // 20 seconds so that we don't wait forever
-                            {
-                                handshakeError = "HelloVerifyRequest cookie exchange could not be verified due to a timeout";
-                                return null;
-                            }
-                        }
-                    }
-                    while (request == null);
+                    throw new ArgumentNullException(nameof(datagramTransport));
                 }
 
-                var clientDatagramTransport = createClientDatagramTransport(remoteEndpoint);
+                DtlsTransport transport = null;
 
-                // store the current client datagram transport for this session
-                _clientDatagramTransport = clientDatagramTransport;
+                try
+                {
+                    DtlsServerProtocol serverProtocol = new DtlsServerProtocol();
+                    _clientDatagramTransport = datagramTransport;
+                    transport = serverProtocol.Accept(this, datagramTransport, request);
+                    _clientDatagramTransport = null;
+                }
+                catch (Exception ex)
+                {
+                    handshakeError = ex.Message;
+                    return null;
+                }
 
-                transport = serverProtocol.Accept(this, clientDatagramTransport, request);
-
-                // clear the reference to the transport after handshake is done
-                _clientDatagramTransport = null;
+                handshakeError = null;
+                return transport;
             }
-            catch (Exception ex)
-            {
-                handshakeError = ex.Message;
-                return null;
-            }
-            
-            handshakeError = null;
-            return transport;
         }
 
         public override void NotifyAlertRaised(short alertLevel, short alertDescription, string message, Exception cause)

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/IDtlsPeer.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLS/IDtlsPeer.cs
@@ -123,6 +123,6 @@ namespace SIPSorcery.Net.SharpSRTP.DTLS
         short CertificateHashAlgorithm { get; }
         void SetCertificate(Certificate certificate, AsymmetricKeyParameter privateKey, short signatureAlgorithm, short hashAlgorithm);
 
-        DtlsTransport DoHandshake(out string handshakeError, DatagramTransport datagramTransport, Func<string> getRemoteEndpoint, Func<string, DatagramTransport> createClientDatagramTransport);
+        DtlsTransport DoHandshake(out string handshakeError, DatagramTransport datagramTransport, DtlsRequest request = null);
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpClient.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpClient.cs
@@ -27,7 +27,6 @@ using SIPSorcery.Net.SharpSRTP.DTLS;
 using SIPSorcery.Net.SharpSRTP.SRTP;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 {
@@ -42,11 +41,11 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
            this(new BcTlsCrypto(), certificate, privateKey, certificateSignatureAlgorithm, certificateHashAlgorithm, session)
         { }
 
-        public DtlsSrtpClient(TlsCrypto crypto, Certificate certificate = null, AsymmetricKeyParameter privateKey = null, short certificateSignatureAlgorithm = SignatureAlgorithm.ecdsa, short certificateHashAlgorithm = HashAlgorithm.sha256, TlsSession session = null) : 
+        public DtlsSrtpClient(TlsCrypto crypto, Certificate certificate = null, AsymmetricKeyParameter privateKey = null, short certificateSignatureAlgorithm = SignatureAlgorithm.ecdsa, short certificateHashAlgorithm = HashAlgorithm.sha256, TlsSession session = null) :
             base(crypto, session, certificate, privateKey, certificateSignatureAlgorithm, certificateHashAlgorithm)
         {
             int[] protectionProfiles = GetSupportedProtectionProfiles();
-            
+
             byte[] mki = DtlsSrtpProtocol.GenerateMki(MkiLength);
             this._srtpData = new UseSrtpData(protectionProfiles, mki);
 
@@ -59,10 +58,10 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
             Certificate peerCertificate = e.SecurityParameters.PeerCertificate;
             OnSessionStarted?.Invoke(this, new DtlsSessionStartedEventArgs(context, peerCertificate, base._clientDatagramTransport));
         }
-       
+
         public void SetMKI(byte[] mki)
         {
-            if(mki == null)
+            if (mki == null)
             {
                 MkiLength = 0;
                 mki = new byte[0];
@@ -82,7 +81,7 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 
         protected virtual int[] GetSupportedProtectionProfiles()
         {
-            return new int[] 
+            return new int[]
             {
                 ExtendedSrtpProtectionProfile.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM,
                 ExtendedSrtpProtectionProfile.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM,
@@ -124,13 +123,13 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 
             // verify that the server has selected a profile we support
             int selectedProfile = serverSrtpExtension.ProtectionProfiles[0];
-            if (!clientSupportedProfiles.Contains(selectedProfile))
+            if (Array.IndexOf(clientSupportedProfiles, selectedProfile) < 0)
             {
                 throw new TlsFatalAlert(AlertDescription.internal_error);
             }
 
             // verify the mki sent by the server matches our mki
-            if (_srtpData.Mki != null && serverSrtpExtension.Mki != null && !Enumerable.SequenceEqual(_srtpData.Mki, serverSrtpExtension.Mki))
+            if (_srtpData.Mki != null && serverSrtpExtension.Mki != null && !_srtpData.Mki.AsSpan().SequenceEqual(serverSrtpExtension.Mki))
             {
                 throw new TlsFatalAlert(AlertDescription.illegal_parameter);
             }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpKeys.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpKeys.cs
@@ -27,14 +27,20 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
     public class DtlsSrtpKeys
     {
         public SrtpProtectionProfileConfiguration ProtectionProfile { get; }
-        public byte[] Mki { get; }
+        public ReadOnlyMemory<byte> Mki { get; }
 
-        public byte[] ClientWriteMasterKey { get; }
-        public byte[] ClientWriteMasterSalt { get; }
-        public byte[] ServerWriteMasterKey { get; }
-        public byte[] ServerWriteMasterSalt { get; }
+        public ReadOnlyMemory<byte> ClientWriteMasterKey { get; }
+        public ReadOnlyMemory<byte> ClientWriteMasterSalt { get; }
+        public ReadOnlyMemory<byte> ServerWriteMasterKey { get; }
+        public ReadOnlyMemory<byte> ServerWriteMasterSalt { get; }
 
-        public DtlsSrtpKeys(SrtpProtectionProfileConfiguration protectionProfile, byte[] mki = null)
+        public DtlsSrtpKeys(
+            SrtpProtectionProfileConfiguration protectionProfile,
+            ReadOnlyMemory<byte> clientWriteMasterKey,
+            ReadOnlyMemory<byte> clientWriteMasterSalt,
+            ReadOnlyMemory<byte> serverWriteMasterKey,
+            ReadOnlyMemory<byte> serverWriteMasterSalt,
+            ReadOnlyMemory<byte> mki = default)
         {
             this.ProtectionProfile = protectionProfile ?? throw new ArgumentNullException(nameof(protectionProfile));
             this.Mki = mki;
@@ -42,10 +48,18 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
             int cipherKeyLen = protectionProfile.CipherKeyLength >> 3;
             int cipherSaltLen = protectionProfile.CipherSaltLength >> 3;
 
-            this.ClientWriteMasterKey = new byte[cipherKeyLen];
-            this.ClientWriteMasterSalt = new byte[cipherSaltLen];
-            this.ServerWriteMasterKey = new byte[cipherKeyLen];
-            this.ServerWriteMasterSalt = new byte[cipherSaltLen];
+            if (clientWriteMasterKey.Length != cipherKeyLen
+                || clientWriteMasterSalt.Length != cipherSaltLen
+                || serverWriteMasterKey.Length != cipherKeyLen
+                || serverWriteMasterSalt.Length != cipherSaltLen)
+            {
+                throw new ArgumentException();
+            }
+
+            this.ClientWriteMasterKey = clientWriteMasterKey;
+            this.ClientWriteMasterSalt = clientWriteMasterSalt;
+            this.ServerWriteMasterKey = serverWriteMasterKey;
+            this.ServerWriteMasterSalt = serverWriteMasterSalt;
         }
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpProtocol.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpProtocol.cs
@@ -81,7 +81,7 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
                 // https://datatracker.ietf.org/doc/html/rfc5764#section-9
                 { ExtendedSrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80, new SrtpProtectionProfileConfiguration(SrtpCiphers.AES_128_CM, 128, 112, int.MaxValue, SrtpAuth.HMAC_SHA1, 160, 80) },
                 { ExtendedSrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32, new SrtpProtectionProfileConfiguration(SrtpCiphers.AES_128_CM, 128, 112, int.MaxValue, SrtpAuth.HMAC_SHA1, 160, 32) },
-
+                
                 // for NULL we still need the keys (K_a) for auth, so we use the same key lengths as AES128 CM in order to derive non-zero master keys
                 { ExtendedSrtpProtectionProfile.SRTP_NULL_HMAC_SHA1_80, new SrtpProtectionProfileConfiguration(SrtpCiphers.NULL, 128, 112, int.MaxValue, SrtpAuth.HMAC_SHA1, 160, 80) },
                 { ExtendedSrtpProtectionProfile.SRTP_NULL_HMAC_SHA1_32, new SrtpProtectionProfileConfiguration(SrtpCiphers.NULL, 128, 112, int.MaxValue, SrtpAuth.HMAC_SHA1, 160, 32) },
@@ -120,11 +120,14 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
                SecurityParameters.server_random
                )[length]
              */
+            byte[] prfSeed = GC.AllocateUninitializedArray<byte>(dtlsSecurityParameters.ClientRandom.Length + dtlsSecurityParameters.ServerRandom.Length);
+            Buffer.BlockCopy(dtlsSecurityParameters.ClientRandom, 0, prfSeed, 0, dtlsSecurityParameters.ClientRandom.Length);
+            Buffer.BlockCopy(dtlsSecurityParameters.ServerRandom, 0, prfSeed, dtlsSecurityParameters.ClientRandom.Length, dtlsSecurityParameters.ServerRandom.Length);
             byte[] sharedSecret = TlsUtilities.Prf(
                 dtlsSecurityParameters,
                 dtlsSecurityParameters.MasterSecret,
                 ExporterLabel.dtls_srtp, // The exporter label for this usage is "EXTRACTOR-dtls_srtp"
-                dtlsSecurityParameters.ClientRandom.Concat(dtlsSecurityParameters.ServerRandom).ToArray(),
+                prfSeed,
                 sharedSecretLength
                 ).Extract();
 
@@ -135,42 +138,76 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
         {
             var srtpSecurityParams = DtlsProtectionProfiles[protectionProfile];
 
-            if(sharedSecret == null)
+            if (sharedSecret == null)
             {
                 throw new ArgumentNullException(nameof(sharedSecret));
             }
 
             int sharedSecretLength = (2 * (srtpSecurityParams.CipherKeyLength + srtpSecurityParams.CipherSaltLength)) >> 3;
-            if(sharedSecret.Length < sharedSecretLength)
+            if (sharedSecret.Length < sharedSecretLength)
             {
                 throw new ArgumentException("Invalid shared secret length.", nameof(sharedSecret));
             }
 
-            DtlsSrtpKeys keys = new DtlsSrtpKeys(srtpSecurityParams, mki);
+            var cipherKeyLen = srtpSecurityParams.CipherKeyLength >> 3;
+            var cipherSaltLen = srtpSecurityParams.CipherSaltLength >> 3;
+
+
+            ReadOnlyMemory<byte> clientWriteMasterKey, clientWriteMasterSalt, serverWriteMasterKey, serverWriteMasterSalt;
 
             if (srtpSecurityParams.Cipher >= SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM)
             {
                 // we have to maintain separation of the inner and outer keys according to RFC8723
                 // <inner client key> <inner server key> <inner client salt> <inner server salt> | <outer client key> <outer server key> <outer client salt> <outer server salt>
-                Buffer.BlockCopy(sharedSecret, 0, keys.ClientWriteMasterKey, 0, keys.ClientWriteMasterKey.Length / 2); // inner
-                Buffer.BlockCopy(sharedSecret, sharedSecretLength / 2, keys.ClientWriteMasterKey, keys.ClientWriteMasterKey.Length / 2, keys.ClientWriteMasterKey.Length / 2); // outer
-                Buffer.BlockCopy(sharedSecret, keys.ClientWriteMasterKey.Length / 2, keys.ServerWriteMasterKey, 0, keys.ServerWriteMasterKey.Length / 2); // inner
-                Buffer.BlockCopy(sharedSecret, sharedSecretLength / 2 + keys.ClientWriteMasterKey.Length / 2, keys.ServerWriteMasterKey, keys.ServerWriteMasterKey.Length / 2, keys.ServerWriteMasterKey.Length / 2); // outer
-                Buffer.BlockCopy(sharedSecret, keys.ClientWriteMasterKey.Length / 2 + keys.ServerWriteMasterKey.Length / 2, keys.ClientWriteMasterSalt, 0, keys.ClientWriteMasterSalt.Length / 2); // inner
-                Buffer.BlockCopy(sharedSecret, sharedSecretLength / 2 + keys.ClientWriteMasterKey.Length / 2 + keys.ServerWriteMasterKey.Length / 2, keys.ClientWriteMasterSalt, keys.ClientWriteMasterSalt.Length / 2, keys.ClientWriteMasterSalt.Length / 2); // outer
-                Buffer.BlockCopy(sharedSecret, keys.ClientWriteMasterKey.Length / 2 + keys.ServerWriteMasterKey.Length / 2 + keys.ClientWriteMasterSalt.Length / 2, keys.ServerWriteMasterSalt, 0, keys.ServerWriteMasterSalt.Length / 2); // inner
-                Buffer.BlockCopy(sharedSecret, sharedSecretLength / 2 + keys.ClientWriteMasterKey.Length / 2 + keys.ServerWriteMasterKey.Length / 2 + keys.ClientWriteMasterSalt.Length / 2, keys.ServerWriteMasterSalt, keys.ServerWriteMasterSalt.Length / 2, keys.ServerWriteMasterSalt.Length / 2); // outer
+                int halfKeyLen = cipherKeyLen / 2;
+                int halfSaltLen = cipherSaltLen / 2;
+                int halfSecret = sharedSecretLength / 2;
+
+                // ClientWriteMasterKey: inner + outer
+                var clientKey = new byte[cipherKeyLen];
+                Buffer.BlockCopy(sharedSecret, 0, clientKey, 0, halfKeyLen);
+                Buffer.BlockCopy(sharedSecret, halfSecret, clientKey, halfKeyLen, halfKeyLen);
+                clientWriteMasterKey = clientKey.AsMemory();
+
+                // ServerWriteMasterKey: inner + outer
+                var serverKey = new byte[cipherKeyLen];
+                Buffer.BlockCopy(sharedSecret, halfKeyLen, serverKey, 0, halfKeyLen);
+                Buffer.BlockCopy(sharedSecret, halfSecret + halfKeyLen, serverKey, halfKeyLen, halfKeyLen);
+                serverWriteMasterKey = serverKey.AsMemory();
+
+                // ClientWriteMasterSalt: inner + outer
+                var clientSalt = new byte[cipherSaltLen];
+                Buffer.BlockCopy(sharedSecret, 2 * halfKeyLen, clientSalt, 0, halfSaltLen);
+                Buffer.BlockCopy(sharedSecret, halfSecret + 2 * halfKeyLen, clientSalt, halfSaltLen, halfSaltLen);
+                clientWriteMasterSalt = clientSalt.AsMemory();
+
+                // ServerWriteMasterSalt: inner + outer
+                var serverSalt = new byte[cipherSaltLen];
+                Buffer.BlockCopy(sharedSecret, 2 * halfKeyLen + halfSaltLen, serverSalt, 0, halfSaltLen);
+                Buffer.BlockCopy(sharedSecret, halfSecret + 2 * halfKeyLen + halfSaltLen, serverSalt, halfSaltLen, halfSaltLen);
+                serverWriteMasterSalt = serverSalt.AsMemory();
             }
             else
             {
                 // <client key> <server key> <client salt> <server salt>
-                Buffer.BlockCopy(sharedSecret, 0, keys.ClientWriteMasterKey, 0, keys.ClientWriteMasterKey.Length);
-                Buffer.BlockCopy(sharedSecret, keys.ClientWriteMasterKey.Length, keys.ServerWriteMasterKey, 0, keys.ServerWriteMasterKey.Length);
-                Buffer.BlockCopy(sharedSecret, keys.ClientWriteMasterKey.Length + keys.ServerWriteMasterKey.Length, keys.ClientWriteMasterSalt, 0, keys.ClientWriteMasterSalt.Length);
-                Buffer.BlockCopy(sharedSecret, keys.ClientWriteMasterKey.Length + keys.ServerWriteMasterKey.Length + keys.ClientWriteMasterSalt.Length, keys.ServerWriteMasterSalt, 0, keys.ServerWriteMasterSalt.Length);
+                int offset = 0;
+                clientWriteMasterKey = sharedSecret.AsMemory(offset, cipherKeyLen);
+                offset += cipherKeyLen;
+                serverWriteMasterKey = sharedSecret.AsMemory(offset, cipherKeyLen);
+                offset += cipherKeyLen;
+                clientWriteMasterSalt = sharedSecret.AsMemory(offset, cipherSaltLen);
+                offset += cipherSaltLen;
+                serverWriteMasterSalt = sharedSecret.AsMemory(offset, cipherSaltLen);
             }
 
-            return keys;
+            var k = new DtlsSrtpKeys(
+                srtpSecurityParams,
+                clientWriteMasterKey,
+                clientWriteMasterSalt,
+                serverWriteMasterKey,
+                serverWriteMasterSalt,
+                mki == null ? default : mki.AsMemory());
+            return k;
         }
 
         public static byte[] GenerateMki(int length)

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpServer.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/DTLSSRTP/DtlsSrtpServer.cs
@@ -27,7 +27,6 @@ using SIPSorcery.Net.SharpSRTP.DTLS;
 using SIPSorcery.Net.SharpSRTP.SRTP;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 {
@@ -46,11 +45,11 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 
         public event EventHandler<DtlsSessionStartedEventArgs> OnSessionStarted;
 
-        public DtlsSrtpServer(Certificate certificate = null, AsymmetricKeyParameter privateKey = null, short certificateSignatureAlgorithm = SignatureAlgorithm.ecdsa, short certificateHashAlgorithm = HashAlgorithm.sha256) 
+        public DtlsSrtpServer(Certificate certificate = null, AsymmetricKeyParameter privateKey = null, short certificateSignatureAlgorithm = SignatureAlgorithm.ecdsa, short certificateHashAlgorithm = HashAlgorithm.sha256)
             : this(new BcTlsCrypto(), certificate, privateKey, certificateSignatureAlgorithm, certificateHashAlgorithm)
         { }
 
-        public DtlsSrtpServer(TlsCrypto crypto, Certificate certificate = null, AsymmetricKeyParameter privateKey = null, short certificateSignatureAlgorithm = SignatureAlgorithm.ecdsa, short certificateHashAlgorithm = HashAlgorithm.sha256) 
+        public DtlsSrtpServer(TlsCrypto crypto, Certificate certificate = null, AsymmetricKeyParameter privateKey = null, short certificateSignatureAlgorithm = SignatureAlgorithm.ecdsa, short certificateHashAlgorithm = HashAlgorithm.sha256)
             : base(crypto, certificate, privateKey, certificateSignatureAlgorithm, certificateHashAlgorithm)
         {
             this.OnHandshakeCompleted += DtlsSrtpServer_OnHandshakeCompleted;
@@ -65,7 +64,7 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 
         protected virtual int[] GetSupportedProtectionProfiles()
         {
-            return new int[] 
+            return new int[]
             {
                 ExtendedSrtpProtectionProfile.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM,
                 ExtendedSrtpProtectionProfile.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM,
@@ -77,7 +76,7 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
                 ExtendedSrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80,
                 ExtendedSrtpProtectionProfile.SRTP_ARIA_128_CTR_HMAC_SHA1_80,
                 ExtendedSrtpProtectionProfile.SRTP_ARIA_256_CTR_HMAC_SHA1_32,
-                ExtendedSrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32,                
+                ExtendedSrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32,
                 ExtendedSrtpProtectionProfile.SRTP_ARIA_128_CTR_HMAC_SHA1_32,
 
                 // do not offer NULL profiles to make sure these do not get selected by accident
@@ -97,15 +96,27 @@ namespace SIPSorcery.Net.SharpSRTP.DTLSSRTP
 
             UseSrtpData clientSrtpExtension = TlsSrtpUtilities.GetUseSrtpExtension(clientExtensions);
 
+            // Choose the highest priority profile supported by the server
             int[] serverSupportedProfiles = GetSupportedProtectionProfiles();
-            int[] mutuallySupportedProfiles = clientSrtpExtension.ProtectionProfiles.Where(x => serverSupportedProfiles.Contains(x)).ToArray();
-            if (mutuallySupportedProfiles.Length == 0)
+            bool found = false;
+            int selectedProfile = int.MinValue;
+            int minIndex = int.MaxValue;
+            for (int i = 0; i < clientSrtpExtension.ProtectionProfiles.Length; i++)
+            {
+                int val = clientSrtpExtension.ProtectionProfiles[i];
+                int idx = Array.IndexOf(serverSupportedProfiles, val);
+                if (idx >= 0 && idx < minIndex)
+                {
+                    minIndex = idx;
+                    selectedProfile = val;
+                    found = true;
+                }
+            }
+            if (!found)
             {
                 throw new TlsFatalAlert(AlertDescription.internal_error);
             }
-
-            int selectedProfile = mutuallySupportedProfiles.OrderBy(x => Array.IndexOf(serverSupportedProfiles, x)).First(); // Choose the highest priority profile supported by the server
-            _srtpData = new UseSrtpData(new int[] { selectedProfile }, ForceDisableMKI ? new byte[0] : clientSrtpExtension.Mki); // Server must return only a single selected profile
+            _srtpData = new UseSrtpData(new int[] { selectedProfile }, ForceDisableMKI ? Array.Empty<byte>() : clientSrtpExtension.Mki); // Server must return only a single selected profile
         }
 
         public override IDictionary<int, byte[]> GetServerExtensions()

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/Log.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/Log.cs
@@ -20,20 +20,11 @@
 // SOFTWARE.
 
 using System;
-using Microsoft.Extensions.Logging;
 
 namespace SIPSorcery.Net.SharpSRTP
 {
     public static class Log
     {
-        /// <summary>
-        /// Empty class only meant to be an anchor type for the logger.
-        /// </summary>
-        private class SharpSRTP { }
-
-        // wire up the sipsorcery's logger
-        private static readonly ILogger logger = LogFactory.CreateLogger<SharpSRTP>();
-
         public static bool WarnEnabled { get; set; } = true;
         public static void Warn(string message, Exception ex = null)
         {
@@ -71,10 +62,10 @@ namespace SIPSorcery.Net.SharpSRTP
             SinkInfo(message, ex);
         }
 
-        public static Action<string, Exception> SinkWarn = new Action<string, Exception>((m, ex) => { logger.LogWarning(m); });
-        public static Action<string, Exception> SinkError = new Action<string, Exception>((m, ex) => { logger.LogError(m); });
-        public static Action<string, Exception> SinkTrace = new Action<string, Exception>((m, ex) => { logger.LogTrace(m); });
-        public static Action<string, Exception> SinkDebug = new Action<string, Exception>((m, ex) => { logger.LogDebug(m); });
-        public static Action<string, Exception> SinkInfo = new Action<string, Exception>((m, ex) => { logger.LogInformation(m); });
+        public static Action<string, Exception> SinkWarn = new Action<string, Exception>((m, ex) => { System.Diagnostics.Debug.WriteLine(m); });
+        public static Action<string, Exception> SinkError = new Action<string, Exception>((m, ex) => { System.Diagnostics.Debug.WriteLine(m); });
+        public static Action<string, Exception> SinkTrace = new Action<string, Exception>((m, ex) => { System.Diagnostics.Debug.WriteLine(m); });
+        public static Action<string, Exception> SinkDebug = new Action<string, Exception>((m, ex) => { System.Diagnostics.Debug.WriteLine(m); });
+        public static Action<string, Exception> SinkInfo = new Action<string, Exception>((m, ex) => { System.Diagnostics.Debug.WriteLine(m); });
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/PolyfillExtensions.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/PolyfillExtensions.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+internal static partial class PolyfillExtensions
+{
+#if !NET8_0_OR_GREATER
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocate an array while skipping zero-initialization if possible.
+        /// </summary>
+        /// <typeparam name="T">Specifies the type of the array element.</typeparam>
+        /// <param name="length">Specifies the length of the array.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // forced to ensure no perf drop for small memory buffers (hot path)
+        public static T[] AllocateUninitializedArray<T>(int length) // T[] rather than T?[] to match `new T[length]` behavior
+        {
+            return new T[length];
+        }
+    }
+
+    extension<T>(ArraySegment<T> source)
+    {
+        public int Length => source.Count;
+
+        public T[] ToArray()
+        {
+            var array = new T[source.Count];
+            Array.Copy(source.Array, source.Offset, array, 0, source.Count);
+            return array;
+        }
+
+        public void CopyTo(Span<T> destination)
+        {
+            new ReadOnlySpan<T>(source.Array, source.Offset, source.Count).CopyTo(destination);
+        }
+
+        public ArraySegment<T> Slice(int index)
+        {
+            if (source.Array == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if ((uint)index > (uint)source.Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return new ArraySegment<T>(source.Array, source.Offset + index, source.Count - index);
+        }
+
+        public ArraySegment<T> Slice(int index, int count)
+        {
+            if (source.Array == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if ((uint)index > (uint)source.Count || (uint)count > (uint)(source.Count - index))
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return new ArraySegment<T>(source.Array, source.Offset + index, count);
+        }
+
+        public void CopyTo(T[] destination)
+        {
+            new ReadOnlySpan<T>(source.Array, source.Offset, source.Count).CopyTo(destination);
+        }
+    }
+
+    extension (byte[] bytes)
+    {
+        public void CopyTo(Span<byte> destination)
+        {
+            if (bytes == null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+            if (destination.Length < bytes.Length)
+            {
+                throw new ArgumentException("Destination span is too small.", nameof(destination));
+            }
+            bytes.AsSpan().CopyTo(destination);
+        }
+    }
+#endif
+
+#if NET8_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<T> Slice<T>(this T[] array, int index) => array.AsSpan(index);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<T> Slice<T>(this T[] array, int index, int count) => array.AsSpan(index, count);
+#else
+    public static ArraySegment<T> Slice<T>(this T[] array, int index) => new ArraySegment<T>(array, index, array.Length - index);
+
+    public static ArraySegment<T> Slice<T>(this T[] array, int index, int count) => new ArraySegment<T>(array, index, count);
+#endif
+
+    public static ArraySegment<T> AsArraySegment<T>(this T[] array) => array != null ? new ArraySegment<T>(array) : default(ArraySegment<T>);
+
+    public static ArraySegment<T> AsArraySegment<T>(this T[] array, int count) => array != null ? new ArraySegment<T>(array, array.Length - count, count) : default(ArraySegment<T>);
+
+    public static ArraySegment<T> AsArraySegment<T>(this T[] array, int offset, int count) => array != null ? new ArraySegment<T>(array, offset, count) : default(ArraySegment<T>);
+}

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Authentication/HMAC.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Authentication/HMAC.cs
@@ -20,14 +20,24 @@
 // SOFTWARE.
 
 using Org.BouncyCastle.Crypto.Macs;
+using System;
+#if NET8_0_OR_GREATER
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+#else
+using ReadOnlyBytes = System.ArraySegment<byte>;
+#endif
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP.Authentication
 {
     public static class HMAC
     {
-        public static byte[] GenerateAuthTag(HMac hmac, byte[] payload, int offset, int length)
+        public static byte[] GenerateAuthTag(HMac hmac, ReadOnlyBytes payload)
         {
-            hmac.BlockUpdate(payload, offset, length);
+#if NET8_0_OR_GREATER
+            hmac.BlockUpdate(payload);
+#else
+            hmac.BlockUpdate(payload.Array, payload.Offset, payload.Count);
+#endif
 
             byte[] output = new byte[hmac.GetMacSize()];
             hmac.DoFinal(output, 0);

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/BinaryExtensions.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/BinaryExtensions.cs
@@ -72,9 +72,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
             if (i <= output.Length - 2)
             {
-                BinaryPrimitives.WriteUInt16LittleEndian(output.Slice(i, 2),
-                    (ushort)(BinaryPrimitives.ReadUInt16LittleEndian(a.Slice(i, 2)) ^
-                             BinaryPrimitives.ReadUInt16LittleEndian(b.Slice(i, 2))));
+                BinaryPrimitives.WriteUInt16BigEndian(output.Slice(i, 2),
+                    (ushort)(BinaryPrimitives.ReadUInt16BigEndian(a.Slice(i, 2)) ^
+                             BinaryPrimitives.ReadUInt16BigEndian(b.Slice(i, 2))));
                 i += 2;
             }
 
@@ -124,13 +124,13 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Xor16(Span<byte> data, ReadOnlySpan<byte> other)
         {
-            Xor16(data, BinaryPrimitives.ReadUInt16LittleEndian(other));
+            Xor16(data, BinaryPrimitives.ReadUInt16BigEndian(other));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Xor16(Span<byte> data, ushort other)
         {
-            BinaryPrimitives.WriteUInt16LittleEndian(data, (ushort)(BinaryPrimitives.ReadUInt16LittleEndian(data) ^ other));
+            BinaryPrimitives.WriteUInt16BigEndian(data, (ushort)(BinaryPrimitives.ReadUInt16BigEndian(data) ^ other));
         }
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/BinaryExtensions.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/BinaryExtensions.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+#endif
+
+namespace SIPSorcery.Net.SharpSRTP.SRTP
+{
+    internal static class BinaryExtensions
+    {
+        public static void Xor(Span<byte> data, ReadOnlySpan<byte> other)
+        {
+            Xor(data, other, data);
+        }
+
+        public static void Xor(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b, Span<byte> output)
+        {
+            int i = 0;
+
+#if NET8_0_OR_GREATER
+            ref byte aRef = ref MemoryMarshal.GetReference(a);
+            ref byte bRef = ref MemoryMarshal.GetReference(b);
+            ref byte oRef = ref MemoryMarshal.GetReference(output);
+
+            if (Vector512.IsHardwareAccelerated)
+            {
+                for (; i <= output.Length - 64; i += 64)
+                {
+                    (Vector512.LoadUnsafe(ref Unsafe.Add(ref aRef, i)) ^
+                     Vector512.LoadUnsafe(ref Unsafe.Add(ref bRef, i)))
+                        .StoreUnsafe(ref Unsafe.Add(ref oRef, i));
+                }
+            }
+
+            if (Vector256.IsHardwareAccelerated)
+            {
+                for (; i <= output.Length - 32; i += 32)
+                {
+                    (Vector256.LoadUnsafe(ref Unsafe.Add(ref aRef, i)) ^
+                     Vector256.LoadUnsafe(ref Unsafe.Add(ref bRef, i)))
+                        .StoreUnsafe(ref Unsafe.Add(ref oRef, i));
+                }
+            }
+
+            if (Vector128.IsHardwareAccelerated)
+            {
+                for (; i <= output.Length - 16; i += 16)
+                {
+                    (Vector128.LoadUnsafe(ref Unsafe.Add(ref aRef, i)) ^
+                     Vector128.LoadUnsafe(ref Unsafe.Add(ref bRef, i)))
+                        .StoreUnsafe(ref Unsafe.Add(ref oRef, i));
+                }
+            }
+#endif
+
+            for (; i <= output.Length - 8; i += 8)
+            {
+                BinaryPrimitives.WriteUInt64BigEndian(output.Slice(i, 8),
+                    BinaryPrimitives.ReadUInt64BigEndian(a.Slice(i, 8)) ^
+                    BinaryPrimitives.ReadUInt64BigEndian(b.Slice(i, 8)));
+            }
+
+            if (i <= output.Length - 4)
+            {
+                BinaryPrimitives.WriteUInt32BigEndian(output.Slice(i, 4),
+                    BinaryPrimitives.ReadUInt32BigEndian(a.Slice(i, 4)) ^
+                    BinaryPrimitives.ReadUInt32BigEndian(b.Slice(i, 4)));
+                i += 4;
+            }
+
+            if (i <= output.Length - 2)
+            {
+                BinaryPrimitives.WriteUInt16LittleEndian(output.Slice(i, 2),
+                    (ushort)(BinaryPrimitives.ReadUInt16LittleEndian(a.Slice(i, 2)) ^
+                             BinaryPrimitives.ReadUInt16LittleEndian(b.Slice(i, 2))));
+                i += 2;
+            }
+
+            if (i < output.Length)
+            {
+                output[i] = (byte)(a[i] ^ b[i]);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor128(Span<byte> data, ReadOnlySpan<byte> other)
+        {
+#if NET8_0_OR_GREATER
+            var result = Vector128.LoadUnsafe(ref MemoryMarshal.GetReference(data)) ^
+                         Vector128.LoadUnsafe(ref MemoryMarshal.GetReference(other));
+            result.StoreUnsafe(ref MemoryMarshal.GetReference(data));
+#else
+            Xor64(data, other);
+            Xor64(data.Slice(8), other.Slice(8));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor64(Span<byte> data, ReadOnlySpan<byte> other)
+        {
+            Xor64(data, BinaryPrimitives.ReadUInt64BigEndian(other));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor64(Span<byte> data, ulong other)
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(data, BinaryPrimitives.ReadUInt64BigEndian(data) ^ other);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor32(Span<byte> data, ReadOnlySpan<byte> other)
+        {
+            Xor32(data, BinaryPrimitives.ReadUInt32BigEndian(other));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor32(Span<byte> data, uint other)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(data, BinaryPrimitives.ReadUInt32BigEndian(data) ^ other);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor16(Span<byte> data, ReadOnlySpan<byte> other)
+        {
+            Xor16(data, BinaryPrimitives.ReadUInt16LittleEndian(other));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Xor16(Span<byte> data, ushort other)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(data, (ushort)(BinaryPrimitives.ReadUInt16LittleEndian(data) ^ other));
+        }
+    }
+}

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Encryption/AEAD.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Encryption/AEAD.cs
@@ -22,47 +22,52 @@
 using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
 using System;
+using System.Buffers.Binary;
+#if NET8_0_OR_GREATER
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+using Bytes = System.Span<byte>;
+#else
+using ReadOnlyBytes = System.ArraySegment<byte>;
+using Bytes = System.ArraySegment<byte>;
+#endif
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
 {
     public static class AEAD
     {
-        public static void Encrypt(IAeadBlockCipher engine, bool encrypt, byte[] payload, int offset, int length, byte[] iv, byte[] K_e, int N_tag, byte[] associatedData)
+        public const int BLOCK_SIZE = 12;
+
+        public static void Encrypt(IAeadBlockCipher engine, bool encrypt, ReadOnlyBytes input, Bytes output, byte[] iv, byte[] K_e, int N_tag, ReadOnlyBytes associatedData)
         {
-            int payloadSize = length - offset;
-
-            int expectedLength = engine.GetOutputSize(payloadSize);
-            if (offset + expectedLength > payload.Length)
-            {
-                throw new ArgumentOutOfRangeException("Payload is too small!");
-            }
-
-            var parameters = new AeadParameters(new KeyParameter(K_e), N_tag << 3, iv, associatedData);
-            engine.Init(encrypt, parameters);
-
-            int len = engine.ProcessBytes(payload, offset, payloadSize, payload, offset);
-
-            // throws when the MAC fails to match
-            engine.DoFinal(payload, offset + len);
+            Encrypt(engine, encrypt, input, output, iv, new KeyParameter(K_e), N_tag, associatedData);
         }
 
-        public static byte[] GenerateMessageKeyIV(byte[] k_s, uint ssrc, ulong index)
+        public static void Encrypt(IAeadBlockCipher engine, bool encrypt, ReadOnlyBytes input, Bytes output, byte[] iv, KeyParameter K_e, int N_tag, ReadOnlyBytes associatedData)
         {
-            byte[] iv = new byte[12];
-            Buffer.BlockCopy(k_s, 0, iv, 0, 12);
+            var parameters = new AeadParameters(K_e, N_tag << 3, iv);
+            engine.Init(encrypt, parameters);
 
-            iv[2] ^= (byte)((ssrc >> 24) & 0xFF);
-            iv[3] ^= (byte)((ssrc >> 16) & 0xFF);
-            iv[4] ^= (byte)((ssrc >> 8) & 0xFF);
-            iv[5] ^= (byte)(ssrc & 0xFF);
-            iv[6] ^= (byte)((index >> 40) & 0xFF);
-            iv[7] ^= (byte)((index >> 32) & 0xFF);
-            iv[8] ^= (byte)((index >> 24) & 0xFF);
-            iv[9] ^= (byte)((index >> 16) & 0xFF);
-            iv[10] ^= (byte)((index >> 8) & 0xFF);
-            iv[11] ^= (byte)(index & 0xFF);
+            engine.ProcessAadBytes(associatedData);
 
-            return iv;
+            int len = engine.ProcessBytes(input, output);
+
+            // throws when the MAC fails to match
+            engine.DoFinal(output.Slice(len));
+        }
+
+        public static void GenerateMessageKeyIV(ReadOnlySpan<byte> k_s, uint ssrc, ulong index, Span<byte> iv)
+        {
+            k_s.Slice(0, BLOCK_SIZE).CopyTo(iv);
+
+            // XOR ssrc at offset 2 (3 bytes for 48-bit index)
+            var ssrcSpan = iv.Slice(2, 4);
+            BinaryPrimitives.WriteUInt32BigEndian(ssrcSpan,
+                BinaryPrimitives.ReadUInt32BigEndian(ssrcSpan) ^ ssrc);
+
+            // XOR index at offset 6 (6 bytes for 48-bit index)
+            var indexSpan = iv.Slice(4, 8);
+            BinaryPrimitives.WriteUInt64BigEndian(indexSpan,
+                BinaryPrimitives.ReadUInt64BigEndian(indexSpan) ^ (index & 0x0000_FFFF_FFFF_FFFF));
         }
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Encryption/CTR.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Encryption/CTR.cs
@@ -21,6 +21,16 @@
 
 using Org.BouncyCastle.Crypto;
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
+
+#if NET8_0_OR_GREATER
+using Bytes = System.Span<byte>;
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+#else
+using Bytes = byte[];
+using ReadOnlyBytes = byte[];
+#endif
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
 {
@@ -28,10 +38,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
     {
         public const int BLOCK_SIZE = 16;
 
-        public static byte[] GenerateSessionKeyIV(byte[] masterSalt, ulong index, ulong kdr, byte label)
+        public static void GenerateSessionKeyIV(ReadOnlyMemory<byte> masterSalt, ulong index, ulong kdr, byte label, Span<byte> iv)
         {
-            byte[] iv = new byte[BLOCK_SIZE];
-
             // RFC 3711 - 4.3.1
             // Key derivation SHALL be defined as follows in terms of<label>, an
             // 8 - bit constant(see below), master_salt and key_derivation_rate, as
@@ -39,28 +47,21 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
             // (i.e., the 48 - bit ROC || SEQ for SRTP):
 
             // *Let r = index DIV key_derivation_rate(with DIV as defined above).
-            ulong r = DIV(index, kdr);
+            var r = DIV(index, kdr);
 
             // *Let key_id = < label > || r.
-            ulong keyId = ((ulong)label << 48) | r;
+            var keyId = ((ulong)label << 48) | r;
 
             // *Let x = key_id XOR master_salt, where key_id and master_salt are
             //  aligned so that their least significant bits agree(right-
             //  alignment).
-            Buffer.BlockCopy(masterSalt, 0, iv, 0, masterSalt.Length);
+            masterSalt.Span.CopyTo(iv);
 
-            iv[7] ^= (byte)((keyId >> 48) & 0xFF);
-            iv[8] ^= (byte)((keyId >> 40) & 0xFF);
-            iv[9] ^= (byte)((keyId >> 32) & 0xFF);
-            iv[10] ^= (byte)((keyId >> 24) & 0xFF);
-            iv[11] ^= (byte)((keyId >> 16) & 0xFF);
-            iv[12] ^= (byte)((keyId >> 8) & 0xFF);
-            iv[13] ^= (byte)(keyId & 0xFF);
+            // XOR index at offset 7 (6 bytes for 48-bit index)
+            BinaryExtensions.Xor64(iv.Slice(6, 8), (keyId & 0x00FF_FFFF_FFFF_FFFF));
 
             iv[14] = 0;
             iv[15] = 0;
-
-            return iv;
         }
 
         private static ulong DIV(ulong x, ulong y)
@@ -75,58 +76,53 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
             }
         }
 
-        public static byte[] GenerateMessageKeyIV(byte[] salt, uint ssrc, ulong index)
+        public static void GenerateMessageKeyIV(ReadOnlySpan<byte> salt, uint ssrc, ulong index, Span<byte> iv)
         {
             // RFC 3711 - 4.1.1
             // IV = (k_s * 2 ^ 16) XOR(SSRC * 2 ^ 64) XOR(i * 2 ^ 16)
-            byte[] iv = new byte[16];
+            salt.Slice(0, 14).CopyTo(iv);
 
-            Buffer.BlockCopy(salt, 0, iv, 0, 14);
+            // XOR ssrc at offset 4 (3 bytes for 48-bit index)
+            BinaryExtensions.Xor32(iv.Slice(4, 4), ssrc);
 
-            iv[4] ^= (byte)((ssrc >> 24) & 0xFF);
-            iv[5] ^= (byte)((ssrc >> 16) & 0xFF);
-            iv[6] ^= (byte)((ssrc >> 8) & 0xFF);
-            iv[7] ^= (byte)(ssrc & 0xFF);
-
-            iv[8] ^= (byte)((index >> 40) & 0xFF);
-            iv[9] ^= (byte)((index >> 32) & 0xFF);
-            iv[10] ^= (byte)((index >> 24) & 0xFF);
-            iv[11] ^= (byte)((index >> 16) & 0xFF);
-            iv[12] ^= (byte)((index >> 8) & 0xFF);
-            iv[13] ^= (byte)(index & 0xFF);
+            // XOR index at offset 8 (6 bytes for 48-bit index)
+            BinaryExtensions.Xor64(iv.Slice(6, 8), index & 0x0000_FFFF_FFFF_FFFF);
 
             iv[14] = 0;
             iv[15] = 0;
-
-            return iv;
         }
 
-        public static void Encrypt(IBlockCipher engine, byte[] payload, int offset, int length, byte[] iv)
+        public static void Encrypt(IBlockCipher engine, ReadOnlySpan<byte> input, Span<byte> output, Bytes iv)
         {
-            int payloadSize = length - offset;
-            byte[] cipher = new byte[payloadSize];
+            var payloadSize = input.Length;
+            var cipher = ArrayPool<byte>.Shared.Rent(payloadSize);
 
-            int blockNo = 0;
-            for (int i = 0; i < payloadSize / BLOCK_SIZE; i++)
+            try
             {
-                iv[14] = (byte)((i >> 8) & 0xff);
-                iv[15] = (byte)(i & 0xff);
-                engine.ProcessBlock(iv, 0, cipher, BLOCK_SIZE * blockNo);
-                blockNo++;
+                var blockNo = 0;
+                for (var i = 0; i < payloadSize / BLOCK_SIZE; i++)
+                {
+                    BinaryPrimitives.WriteUInt16BigEndian(iv.Slice(14, 2), (ushort)i);
+                    engine.ProcessBlock(iv, cipher.Slice(BLOCK_SIZE * blockNo, BLOCK_SIZE));
+                    blockNo++;
+                }
+
+                if (payloadSize % BLOCK_SIZE != 0)
+                {
+                    BinaryPrimitives.WriteUInt16BigEndian(iv.Slice(14, 2), (ushort)blockNo);
+                    var lastBlock = GC.AllocateUninitializedArray<byte>(BLOCK_SIZE);
+                    engine.ProcessBlock(iv, lastBlock);
+                    Buffer.BlockCopy(lastBlock, 0, cipher, BLOCK_SIZE * blockNo, payloadSize % BLOCK_SIZE);
+                }
+
+                BinaryExtensions.Xor(
+                    input,
+                    cipher.AsSpan(0, payloadSize),
+                    output);
             }
-
-            if (payloadSize % BLOCK_SIZE != 0)
+            finally
             {
-                iv[14] = (byte)((blockNo >> 8) & 0xff);
-                iv[15] = (byte)(blockNo & 0xff);
-                byte[] lastBlock = new byte[BLOCK_SIZE];
-                engine.ProcessBlock(iv, 0, lastBlock, 0);
-                Buffer.BlockCopy(lastBlock, 0, cipher, BLOCK_SIZE * blockNo, payloadSize % BLOCK_SIZE);
-            }
-
-            for (int i = 0; i < payloadSize; i++)
-            {
-                payload[offset + i] ^= cipher[i];
+                ArrayPool<byte>.Shared.Return(cipher);
             }
         }
     }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Encryption/F8.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Encryption/F8.cs
@@ -20,7 +20,18 @@
 // SOFTWARE.
 
 using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
+#if NET8_0_OR_GREATER
+using Bytes = System.Span<byte>;
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+#else
+using Bytes = byte[];
+using ReadOnlyBytes = byte[];
+#endif
+
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
 {
@@ -28,118 +39,109 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Encryption
     {
         public const int BLOCK_SIZE = 16;
 
-        public static byte[] GenerateRtpMessageKeyIV(IBlockCipher engine, byte[] k_e, byte[] k_s, byte[] rtpPacket, uint ROC)
+        public static void GenerateRtpMessageKeyIV(IBlockCipher engine, byte[] k_e, byte[] k_s, ReadOnlySpan<byte> rtpPacket, uint ROC, Bytes iv)
         {
-            byte[] iv = GenerateRtpIV(rtpPacket, ROC);            
-            byte[] iv2 = GenerateIV2(engine, k_e, k_s, iv);
-            return iv2;
+#if NET8_0_OR_GREATER
+            Span<byte> rtpIV = stackalloc byte[BLOCK_SIZE];
+#else
+            var rtpIV = new byte[BLOCK_SIZE];
+#endif
+            GenerateRtpIV(rtpIV, rtpPacket, ROC);
+
+            GenerateIV2(engine, k_e, k_s, rtpIV, iv);
         }
 
-        private static byte[] GenerateRtpIV(byte[] rtpPacket, uint ROC)
+        private static void GenerateRtpIV(Span<byte> iv, ReadOnlySpan<byte> rtpPacket, uint ROC)
         {
-            byte[] iv = new byte[BLOCK_SIZE];
             iv[0] = 0;
 
             // M + PT + SEQ + TS + SSRC
-            Buffer.BlockCopy(rtpPacket, 1, iv, 1, 11);
-            
-            // ROC
-            iv[12] = (byte)((ROC >> 24) & 0xFF);
-            iv[13] = (byte)((ROC >> 16) & 0xFF);
-            iv[14] = (byte)((ROC >> 8) & 0xFF);
-            iv[15] = (byte)(ROC & 0xFF);
-            return iv;
+            rtpPacket.Slice(1, 11).CopyTo(iv.Slice(1));
+
+            // ROC (big-endian)
+            BinaryPrimitives.WriteUInt32BigEndian(iv.Slice(12, 4), ROC);
         }
 
-        public static byte[] GenerateRtcpMessageKeyIV(IBlockCipher engine, byte[] k_e, byte[] k_s, byte[] rtcpPacket, uint index)
+        public static byte[] GenerateRtcpMessageKeyIV(IBlockCipher engine, byte[] k_e, byte[] k_s, ReadOnlySpan<byte> rtcpPacket, uint index)
         {
-            byte[] iv = GenerateRtcpIV(rtcpPacket, index);
-            byte[] iv2 = GenerateIV2(engine, k_e, k_s, iv);
+#if NET8_0_OR_GREATER
+            Span<byte> iv = stackalloc byte[BLOCK_SIZE];
+#else
+            var iv = new byte[BLOCK_SIZE];
+#endif
+            GenerateRtcpIV(iv, rtcpPacket, index);
+
+            byte[] iv2 = new byte[BLOCK_SIZE];
+
+            GenerateIV2(engine, k_e, k_s, iv, iv2);
+
             return iv2;
         }
 
-        private static byte[] GenerateRtcpIV(byte[] rtcpPacket, uint index)
+        private static void GenerateRtcpIV(Span<byte> iv, ReadOnlySpan<byte> rtcpPacket, uint index)
         {
-            byte[] iv = new byte[BLOCK_SIZE];
-
             // 0..0
-            iv[0] = 0;
-            iv[1] = 0;
-            iv[2] = 0;
-            iv[3] = 0;
+            iv.Slice(0, 4).Clear();
 
             // E + SRTCP index
-            iv[4] = (byte)((index >> 24) & 0xFF);
-            iv[5] = (byte)((index >> 16) & 0xFF);
-            iv[6] = (byte)((index >> 8) & 0xFF);
-            iv[7] = (byte)(index & 0xFF);
+            BinaryPrimitives.WriteUInt32BigEndian(iv.Slice(4, 4), index);
 
             // V + P + RC + PT + L + SSRC
-            Buffer.BlockCopy(rtcpPacket, 0, iv, BLOCK_SIZE - 8, 8);
-            return iv;
+            rtcpPacket.Slice(0, 8).CopyTo(iv.Slice(BLOCK_SIZE - 8, 8));
         }
 
-        private static byte[] GenerateIV2(IBlockCipher engine, byte[] k_e, byte[] k_s, byte[] iv)
+        private static void GenerateIV2(IBlockCipher engine, byte[] k_e, byte[] k_s, ReadOnlyBytes iv, Bytes iv2)
         {
-            byte[] iv2 = new byte[BLOCK_SIZE];
-            
             // IV' = E(k_e XOR m, IV)
-            Buffer.BlockCopy(k_e, 0, iv2, 0, k_e.Length);
+            k_e.CopyTo(iv2);
 
             // m = k_s || 0x555..5
-            for (int i = 0; i < BLOCK_SIZE; i++)
-            {
-                if (i < k_s.Length)
-                {
-                    iv2[i] ^= k_s[i];
-                }
-                else
-                {
-                    iv2[i] ^= 0x55;
-                }
-            }
+            Span<byte> k_s_temp = stackalloc byte[BLOCK_SIZE];
+            k_s_temp.Fill(0x55);
+            k_s.CopyTo(k_s_temp);
 
-            engine.Init(true, new Org.BouncyCastle.Crypto.Parameters.KeyParameter(iv2));
-            engine.ProcessBlock(iv, 0, iv2, 0);
+            BinaryExtensions.Xor128(iv2, k_s_temp);
 
-            return iv2;
+            engine.Init(true, new KeyParameter(iv2));
+            engine.ProcessBlock(iv, iv2);
         }
 
-        public static void Encrypt(IBlockCipher aes, byte[] payload, int offset, int length, byte[] iv)
+        public static void Encrypt(IBlockCipher aes, ReadOnlySpan<byte> input, Span<byte> output, ReadOnlySpan<byte> iv)
         {
-            int payloadSize = length - offset;
-            int blockCount = payloadSize / BLOCK_SIZE + payloadSize % BLOCK_SIZE;
-            byte[] cipher = new byte[blockCount * BLOCK_SIZE];
+            int payloadSize = input.Length;
+            int blockCount = (payloadSize + BLOCK_SIZE - 1) / BLOCK_SIZE;
+            byte[] cipher = ArrayPool<byte>.Shared.Rent(blockCount * BLOCK_SIZE);
 
-            int blockNo = 0;
-            byte[] iv2 = new byte[iv.Length];
-            for (uint j = 0; j < blockCount; j++)
+            try
             {
-                Buffer.BlockCopy(iv, 0, iv2, 0, iv.Length);
-
-                // IV' xor j
-                iv2[12] ^= (byte)((j >> 24) & 0xff);
-                iv2[13] ^= (byte)((j >> 16) & 0xff);
-                iv2[14] ^= (byte)((j >> 8) & 0xff);
-                iv2[15] ^= (byte)(j & 0xff);
-
-                // IV' xor S(-1) xor j
-                if (blockNo > 0)
+                int blockNo = 0;
+                byte[] iv2 = GC.AllocateUninitializedArray<byte>(iv.Length);
+                for (uint j = 0; j < blockCount; j++)
                 {
-                    int previousBlockIndex = BLOCK_SIZE * (blockNo - 1);
-                    for (int i = 0; i < BLOCK_SIZE; i++)
+                    iv.CopyTo(iv2);
+
+                    // IV' xor j
+                    BinaryExtensions.Xor32(iv2.AsSpan(12, 4), j);
+
+                    // IV' xor S(-1) xor j
+                    if (blockNo > 0)
                     {
-                        iv2[i] = (byte)(iv2[i] ^ cipher[previousBlockIndex + i]);
+                        var previousBlockIndex = BLOCK_SIZE * (blockNo - 1);
+                        BinaryExtensions.Xor128(iv2, cipher.AsSpan(previousBlockIndex + 0));
                     }
+
+                    aes.ProcessBlock(iv2, 0, cipher, BLOCK_SIZE * blockNo);
+                    blockNo++;
                 }
 
-                aes.ProcessBlock(iv2, 0, cipher, BLOCK_SIZE * blockNo);
-                blockNo++;
+                BinaryExtensions.Xor(
+                    input,
+                    cipher.AsSpan(0, payloadSize),
+                    output.Slice(0, payloadSize));
             }
-
-            for (int i = 0; i < payloadSize; i++)
+            finally
             {
-                payload[offset + i] ^= cipher[i];
+                ArrayPool<byte>.Shared.Return(cipher);
             }
         }
     }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/ISrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/ISrtpContext.cs
@@ -19,15 +19,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 // SOFTWARE.
 
+#if NET8_0_OR_GREATER
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+using Bytes = System.Span<byte>;
+#else
+using ReadOnlyBytes = System.ArraySegment<byte>;
+using Bytes = byte[];
+#endif
+
 namespace SIPSorcery.Net.SharpSRTP.SRTP
 {
     public interface ISrtpContext
     {
         int CalculateRequiredSrtpPayloadLength(int rtpLen);
-        int ProtectRtp(byte[] payload, int length, out int outputBufferLength);
-        int UnprotectRtp(byte[] payload, int length, out int outputBufferLength);
+        int ProtectRtp(ReadOnlyBytes input, Bytes output, out int outputBufferLength);
+        int UnprotectRtp(ReadOnlyBytes input, Bytes output, out int outputBufferLength);
         int CalculateRequiredSrtcpPayloadLength(int rtpLen);
-        int ProtectRtcp(byte[] payload, int length, out int outputBufferLength);
-        int UnprotectRtcp(byte[] payload, int length, out int outputBufferLength);
+        int ProtectRtcp(ReadOnlyBytes input, Bytes output, out int outputBufferLength);
+        int UnprotectRtcp(ReadOnlyBytes input, Bytes output, out int outputBufferLength);
+    }
+
+    public static class SrtpContextExtensions
+    {
+        public static int ProtectRtp(this ISrtpContext context, Bytes payload, int length, out int outputBufferLength)
+            => context.ProtectRtp(payload.Slice(0, length), payload, out outputBufferLength);
+
+        public static int UnprotectRtp(this ISrtpContext context, Bytes payload, int length, out int outputBufferLength)
+            => context.UnprotectRtp(payload.Slice(0, length), payload, out outputBufferLength);
+
+        public static int ProtectRtcp(this ISrtpContext context, Bytes payload, int length, out int outputBufferLength)
+            => context.ProtectRtcp(payload.Slice(0, length), payload, out outputBufferLength);
+
+        public static int UnprotectRtcp(this ISrtpContext context, Bytes payload, int length, out int outputBufferLength)
+            => context.UnprotectRtcp(payload.Slice(0, length), payload, out outputBufferLength);
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtcpReader.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtcpReader.cs
@@ -19,6 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 // SOFTWARE.
 
+using System;
+using System.Buffers.Binary;
+
 namespace SIPSorcery.Net.SharpSRTP.SRTP.Readers
 {
     public static class RtcpReader
@@ -28,15 +31,15 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Readers
             return 8;
         }
 
-        public static uint ReadSsrc(byte[] rtcpPacket)
+        public static uint ReadSsrc(ReadOnlySpan<byte> rtcpPacket)
         {
-            return (uint)((rtcpPacket[4] << 24) | (rtcpPacket[5] << 16) | (rtcpPacket[6] << 8) | rtcpPacket[7]);
+            return BinaryPrimitives.ReadUInt32BigEndian(rtcpPacket.Slice(4, 4));
         }
 
-        public static uint SrtcpReadIndex(byte[] srtcpPacket, int authTagLen)
+        public static uint SrtcpReadIndex(ReadOnlySpan<byte> srtcpPacket, int authTagLen)
         {
             int index = srtcpPacket.Length - authTagLen - 4;
-            return (uint)((srtcpPacket[index] << 24) | (srtcpPacket[index + 1] << 16) | (srtcpPacket[index + 2] << 8) | srtcpPacket[index + 3]);
+            return BinaryPrimitives.ReadUInt32BigEndian(srtcpPacket.Slice(index, 4));
         }
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtpReader.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtpReader.cs
@@ -19,33 +19,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 // SOFTWARE.
 
-using System.Linq;
+using System;
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP.Readers
 {
     public static class RtpReader
     {
-        public static uint ReadSsrc(byte[] rtpPacket)
+        public static uint ReadSsrc(ReadOnlySpan<byte> rtpPacket)
         {
-            return (uint)((rtpPacket[8] << 24) | (rtpPacket[9] << 16) | (rtpPacket[10] << 8) | rtpPacket[11]);
+            return System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(rtpPacket.Slice(8, 4));
         }
 
-        public static ushort ReadSequenceNumber(byte[] rtpPacket)
+        public static ushort ReadSequenceNumber(ReadOnlySpan<byte> rtpPacket)
         {
-            return (ushort)((rtpPacket[2] << 8) | rtpPacket[3]);
+            return System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(rtpPacket.Slice(2, 2));
         }
 
-        public static int ReadHeaderLen(byte[] payload)
+        public static int ReadHeaderLen(ReadOnlySpan<byte> payload)
         {
             return ReadHeaderLenWithoutExtensions(payload) + ReadExtensionsLength(payload);
         }
 
-        public static int ReadExtensionsLength(byte[] payload)
+        public static int ReadExtensionsLength(ReadOnlySpan<byte> payload)
         {
             int length = ReadHeaderLenWithoutExtensions(payload);
             if ((payload[0] & 0x10) == 0x10)
             {
-                return 4 + (payload[length + 2] << 8) | payload[length + 3];
+                return 4 + System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(payload.Slice(length + 2, 2));
             }
             else
             {
@@ -53,16 +53,16 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Readers
             }
         }
 
-        public static int ReadHeaderLenWithoutExtensions(byte[] payload)
+        public static int ReadHeaderLenWithoutExtensions(ReadOnlySpan<byte> payload)
         {
             return 12 + 4 * (payload[0] & 0xf);
         }
 
-        public static byte[] ReadHeaderExtensions(byte[] payload)
+        public static ReadOnlySpan<byte> ReadHeaderExtensions(ReadOnlySpan<byte> payload)
         {
             int length = ReadHeaderLenWithoutExtensions(payload);
             int extLen = ReadExtensionsLength(payload);
-            return payload.Skip(length).Take(extLen).ToArray();
+            return payload.Slice(length, extLen);
         }
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -151,6 +151,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         public IBlockCipher PayloadF8 { get; private set; }
         public IAeadBlockCipher PayloadAEAD { get; private set; }
 
+        public byte[] Iv12 { get; } = new byte[Encryption.AEAD.BLOCK_SIZE];
+        public byte[] Iv16 { get; } = new byte[Encryption.CTR.BLOCK_SIZE];
+
         public IBlockCipher HeaderCTR { get; private set; }
         public IBlockCipher HeaderF8 { get; private set; }
 
@@ -281,11 +284,11 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
                         var aesKeys = AesUtilities.CreateEngine();
-                        this.K_e = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate);
-                        this.K_a = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate);
-                        this.K_s = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate);
-                        this.K_he = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_e, 6, index, KeyDerivationRate);
-                        this.K_hs = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_s, 7, index, KeyDerivationRate);
+                        this.K_e = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate, Iv16);
+                        this.K_a = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate, Iv16);
+                        this.K_s = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate, Iv16);
+                        this.K_he = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_e, 6, index, KeyDerivationRate, Iv16);
+                        this.K_hs = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_s, 7, index, KeyDerivationRate, Iv16);
 
                         if (Cipher >= SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM)
                         {
@@ -330,11 +333,11 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.AEAD_ARIA_256_GCM:
                     {
                         var ariaKeys = new AriaEngine();
-                        this.K_e = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate);
-                        this.K_a = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate);
-                        this.K_s = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate);
-                        this.K_he = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_e, 6, index, KeyDerivationRate);
-                        this.K_hs = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_s, 7, index, KeyDerivationRate);
+                        this.K_e = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate, Iv16);
+                        this.K_a = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate, Iv16);
+                        this.K_s = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate, Iv16);
+                        this.K_he = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_e, 6, index, KeyDerivationRate, Iv16);
+                        this.K_hs = GenerateSessionKey(ariaKeys, Cipher, MasterKey, MasterSalt, N_s, 7, index, KeyDerivationRate, Iv16);
 
                         var ariaPayload = new AriaEngine();
                         ariaPayload.Init(true, new KeyParameter(K_e));
@@ -356,11 +359,11 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_GCM:
                     {
                         var seedKeys = new SeedEngine();
-                        this.K_e = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate);
-                        this.K_a = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate);
-                        this.K_s = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate);
-                        this.K_he = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_e, 6, index, KeyDerivationRate);
-                        this.K_hs = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_s, 7, index, KeyDerivationRate);
+                        this.K_e = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate, Iv16);
+                        this.K_a = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate, Iv16);
+                        this.K_s = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate, Iv16);
+                        this.K_he = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_e, 6, index, KeyDerivationRate, Iv16);
+                        this.K_hs = GenerateSessionKey(seedKeys, Cipher, MasterKey, MasterSalt, N_s, 7, index, KeyDerivationRate, Iv16);
 
                         var seedPayload = new SeedEngine();
                         seedPayload.Init(true, new KeyParameter(K_e));
@@ -404,7 +407,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             }
         }
 
-        public static byte[] GenerateSessionKey(IBlockCipher engineKeys, SrtpCiphers cipher, ReadOnlyMemory<byte> masterKey, ReadOnlyMemory<byte> masterSalt, int length, int label, ulong index, ulong kdr)
+        public static byte[] GenerateSessionKey(IBlockCipher engineKeys, SrtpCiphers cipher, ReadOnlyMemory<byte> masterKey, ReadOnlyMemory<byte> masterSalt, int length, int label, ulong index, ulong kdr, byte[] iv)
         {
             var key = GC.AllocateUninitializedArray<byte>(length);
             switch (cipher)
@@ -425,11 +428,6 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_GCM:
                     {
                         engineKeys.Init(true, KeyParameter.Create(masterKey));
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[Encryption.CTR.BLOCK_SIZE];
-#else
-                        var iv = new byte[Encryption.CTR.BLOCK_SIZE];
-#endif
                         Encryption.CTR.GenerateSessionKeyIV(masterSalt, index, kdr, (byte)label, iv);
                         Encryption.CTR.Encrypt(engineKeys, key, key, iv);
                     }
@@ -442,26 +440,18 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                         var innerSalt = masterSalt.Slice(0, masterSalt.Length / 2);
                         var innerKey = masterKey.Slice(0, masterKey.Length / 2);
                         engineKeys.Init(true, KeyParameter.Create(masterKey));
-#if NET8_0_OR_GREATER
-                        Span<byte> innerIv = stackalloc byte[Encryption.CTR.BLOCK_SIZE];
-#else
-                        var innerIv = new byte[Encryption.CTR.BLOCK_SIZE];
-#endif
-                        Encryption.CTR.GenerateSessionKeyIV(innerSalt, index, kdr, (byte)label, innerIv);
+
+                        Encryption.CTR.GenerateSessionKeyIV(innerSalt, index, kdr, (byte)label, iv);
                         engineKeys.Init(true, KeyParameter.Create(innerKey));
                         var halfLen = key.Length / 2;
-                        Encryption.CTR.Encrypt(engineKeys, key.AsSpan(0, halfLen), key.AsSpan(0, halfLen), innerIv);
+                        Encryption.CTR.Encrypt(engineKeys, key.AsSpan(0, halfLen), key.AsSpan(0, halfLen), iv);
 
                         var outerSalt = masterSalt.Slice(masterSalt.Length / 2);
                         var outerKey = masterKey.Slice(masterKey.Length / 2);
-#if NET8_0_OR_GREATER
-                        Span<byte> outerIv = stackalloc byte[Encryption.CTR.BLOCK_SIZE];
-#else
-                        var outerIv = new byte[Encryption.CTR.BLOCK_SIZE];
-#endif
-                        Encryption.CTR.GenerateSessionKeyIV(outerSalt, index, kdr, (byte)label, outerIv);
+
+                        Encryption.CTR.GenerateSessionKeyIV(outerSalt, index, kdr, (byte)label, iv);
                         engineKeys.Init(true, KeyParameter.Create(outerKey));
-                        Encryption.CTR.Encrypt(engineKeys, key.AsSpan(halfLen), key.AsSpan(halfLen), outerIv);
+                        Encryption.CTR.Encrypt(engineKeys, key.AsSpan(halfLen), key.AsSpan(halfLen), iv);
                     }
                     break;
 
@@ -538,13 +528,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
                 case SrtpCiphers.AES_128_F8:
                     {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.F8.BLOCK_SIZE];
-#else
-                        var iv = new byte[SRTP.Encryption.F8.BLOCK_SIZE];
-#endif
-                        SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, roc, iv);
-                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
+                        SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, roc, context.Iv16);
+                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), context.Iv16);
                     }
                     break;
 
@@ -555,13 +540,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.ARIA_256_CTR:
                 case SrtpCiphers.SEED_128_CTR:
                     {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#else
-                        var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#endif
-                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
-                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
+                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index, context.Iv16);
+                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), context.Iv16);
                     }
                     break;
 
@@ -572,9 +552,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, output.Slice(0, offset));
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index, context.Iv12);
+                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), context.Iv12, context.K_e, context.N_tag, output.Slice(0, offset));
                         length += context.N_tag;
                     }
                     break;
@@ -602,9 +581,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                             // apply inner cryptographic algorithm
                             var innerK_e = KeyParameter.Create(context.K_e.Slice(0, context.K_e.Length / 2));
                             var innerK_s = context.K_s.AsSpan(0, context.K_s.Length / 2);
-                            var innerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, ssrc, index, innerIv);
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, syntheticRtpPacket.Slice(rtpHeaderLength, length - rtpExtensionsLength - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), innerIv, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, ssrc, index, context.Iv12);
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, syntheticRtpPacket.Slice(rtpHeaderLength, length - rtpExtensionsLength - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), context.Iv12, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
 
                             // copy the protected payload back to the output buffer
                             syntheticRtpPacket.AsSpan(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength).CopyTo(output.Slice(offset, syntheticRtpPacketLen - rtpHeaderLength));
@@ -618,10 +596,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                             // apply outer cryptographic algorithm
                             var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
                             var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
-                            var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index, outerIv);
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index, context.Iv12);
 
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, output.Slice(offset, length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, output.Slice(0, offset));
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, output.Slice(offset, length - offset), output.Slice(offset), context.Iv12, outerK_e, context.N_tag / 2, output.Slice(0, offset));
                             length += context.N_tag / 2;
                         }
                         finally
@@ -686,13 +663,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
                     case SrtpCiphers.AES_128_F8:
                         {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.F8.BLOCK_SIZE];
-#else
-                            var iv = new byte[SRTP.Encryption.F8.BLOCK_SIZE];
-#endif
-                            SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.HeaderF8, context.K_he, context.K_hs, payload, roc, iv);
-                            SRTP.Encryption.F8.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), iv);
+                            SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.HeaderF8, context.K_he, context.K_hs, payload, roc, context.Iv16);
+                            SRTP.Encryption.F8.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), context.Iv16);
                         }
                         break;
 
@@ -709,13 +681,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.SEED_128_CCM:
                     case SrtpCiphers.SEED_128_GCM:
                         {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#else
-                            var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#endif
-                            SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_hs, ssrc, index, iv);
-                            SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), iv);
+                            SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_hs, ssrc, index, context.Iv16);
+                            SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), context.Iv16);
                         }
                         break;
 
@@ -723,13 +690,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                         {
                             var outerK_hs = context.K_hs.AsSpan(context.K_hs.Length / 2);
-#if NET8_0_OR_GREATER
-                        Span<byte> outerIv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#else
-                            var outerIv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#endif
-                            SRTP.Encryption.CTR.GenerateMessageKeyIV(outerK_hs, ssrc, index, outerIv);
-                            SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), outerIv);
+                            SRTP.Encryption.CTR.GenerateMessageKeyIV(outerK_hs, ssrc, index, context.Iv16);
+                            SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), context.Iv16);
                         }
                         break;
 
@@ -846,15 +808,10 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
                 case SrtpCiphers.AES_128_F8:
                     {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.F8.BLOCK_SIZE];
-#else
-                        var iv = new byte[SRTP.Encryption.F8.BLOCK_SIZE];
-#endif
-                        SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, roc, iv);
+                        SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, roc, context.Iv16);
                         var decLen = length - mki.Length - context.N_tag;
                         input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), context.Iv16);
                         outputBufferLength = decLen;
                     }
                     break;
@@ -866,15 +823,10 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.ARIA_256_CTR:
                 case SrtpCiphers.SEED_128_CTR:
                     {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#else
-                        var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#endif
-                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
+                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index, context.Iv16);
                         var decLen = length - mki.Length - context.N_tag;
                         input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), context.Iv16);
                         outputBufferLength = decLen;
                     }
                     break;
@@ -886,10 +838,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index, context.Iv12);
                         input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - mki.Length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, input.Slice(0, offset));
+                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - mki.Length - offset), output.Slice(offset), context.Iv12, context.K_e, context.N_tag, input.Slice(0, offset));
                         outputBufferLength = length - mki.Length - context.N_tag;
                     }
                     break;
@@ -900,9 +851,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                         // apply outer cryptographic algorithm
                         var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
                         var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
-                        var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index, outerIv);
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - mki.Length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, input.Slice(0, offset));
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index, context.Iv12);
+                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - mki.Length - offset), output.Slice(offset), context.Iv12, outerK_e, context.N_tag / 2, input.Slice(0, offset));
 
                         // copy header from input to output
                         input.Slice(0, offset).CopyTo(output.Slice(0, offset));
@@ -961,9 +911,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                             // apply inner cryptographic algorithm
                             var innerK_e = KeyParameter.Create(context.K_e.Slice(0, context.K_e.Length / 2));
                             var innerK_s = context.K_s.AsSpan(0, context.K_s.Length / 2);
-                            var innerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, innerSsrc, innerIndex, innerIv);
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), innerIv, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, innerSsrc, innerIndex, context.Iv16);
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), context.Iv16, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
 
                             // copy the unprotected payload back to the output buffer
                             syntheticRtpPacket.AsSpan(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2).CopyTo(output.Slice(offset, syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2));
@@ -1074,14 +1023,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.ARIA_256_CTR:
                 case SrtpCiphers.SEED_128_CTR:
                     {
-#if NET8_0_OR_GREATER
-                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#else
-                        var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#endif
-                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, context.Iv16);
                         input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
+                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), context.Iv16);
                     }
                     break;
 
@@ -1092,15 +1036,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, context.Iv12);
                         var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
                         try
                         {
                             input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
                             BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), index);
                             input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, associatedDataRented.Slice(0, offset + 4));
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), context.Iv12, context.K_e, context.N_tag, associatedDataRented.Slice(0, offset + 4));
                             length += context.N_tag;
                         }
                         finally
@@ -1116,15 +1059,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                         // RTCP under Double AEAD is protected only with the outer layer
                         var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
                         var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
-                        var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l, outerIv);
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l, context.Iv12);
                         var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
                         try
                         {
                             input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
                             BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), index);
                             input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, associatedDataRented.Slice(0, offset + 4));
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), context.Iv12, outerK_e, context.N_tag / 2, associatedDataRented.Slice(0, offset + 4));
                             length += context.N_tag / 2;
                         }
                         finally
@@ -1263,14 +1205,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.SEED_128_CTR:
                         {
                             var decLen = length - 4 - context.N_tag - mki.Length;
-#if NET8_0_OR_GREATER
-                            Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#else
-                            var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
-#endif
-                            SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                            SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, context.Iv16);
                             input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                            SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                            SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), context.Iv16);
                             outputBufferLength = decLen;
                         }
                         break;
@@ -1282,15 +1219,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.SEED_128_CCM:
                     case SrtpCiphers.SEED_128_GCM:
                         {
-                            var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, context.Iv12);
                             var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
                             try
                             {
                                 input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
                                 BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), originalIndex);
                                 input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                                SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - 4 - mki.Length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, associatedDataRented.Slice(0, offset + 4));
+                                SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - 4 - mki.Length - offset), output.Slice(offset), context.Iv12, context.K_e, context.N_tag, associatedDataRented.Slice(0, offset + 4));
                                 outputBufferLength = length - 4 - context.N_tag - mki.Length;
                             }
                             finally
@@ -1306,15 +1242,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                             // RTCP under Double AEAD is protected only with the outer layer
                             var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
                             var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
-                            var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
-                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l, outerIv);
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l, context.Iv12);
                             var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
                             try
                             {
                                 input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
                                 BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), originalIndex);
                                 input.Slice(0, offset).CopyTo(output.Slice(0, offset));
-                                SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - 4 - mki.Length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, associatedDataRented.Slice(0, offset + 4));
+                                SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - 4 - mki.Length - offset), output.Slice(offset), context.Iv12, outerK_e, context.N_tag / 2, associatedDataRented.Slice(0, offset + 4));
                                 outputBufferLength = length - 4 - context.N_tag / 2 - mki.Length;
                             }
                             finally

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -911,8 +911,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                             // apply inner cryptographic algorithm
                             var innerK_e = KeyParameter.Create(context.K_e.Slice(0, context.K_e.Length / 2));
                             var innerK_s = context.K_s.AsSpan(0, context.K_s.Length / 2);
-                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, innerSsrc, innerIndex, context.Iv16);
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), context.Iv16, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, innerSsrc, innerIndex, context.Iv12);
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), context.Iv12, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
 
                             // copy the unprotected payload back to the output buffer
                             syntheticRtpPacket.AsSpan(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2).CopyTo(output.Slice(offset, syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2));

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -436,10 +436,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM:
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
-
                         var innerSalt = masterSalt.Slice(0, masterSalt.Length / 2);
                         var innerKey = masterKey.Slice(0, masterKey.Length / 2);
-                        engineKeys.Init(true, KeyParameter.Create(masterKey));
 
                         Encryption.CTR.GenerateSessionKeyIV(innerSalt, index, kdr, (byte)label, iv);
                         engineKeys.Init(true, KeyParameter.Create(innerKey));

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -27,9 +27,17 @@ using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
 using SIPSorcery.Net.SharpSRTP.SRTP.Readers;
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
+#if NET8_0_OR_GREATER
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+using Bytes = System.Span<byte>;
+#else
+using ReadOnlyBytes = System.ArraySegment<byte>;
+using Bytes = byte[];
+#endif
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP
 {
@@ -64,7 +72,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
             if (sequenceNumber == 0)
             {
-                if(!S_l_set)
+                if (!S_l_set)
                 {
                     S_l_set = true;
                     return true; /* first is good */
@@ -150,8 +158,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         public SrtpCiphers Cipher { get; set; }
         public SrtpAuth Auth { get; set; }
 
-        public byte[] MasterKey { get; set; }
-        public byte[] MasterSalt { get; set; }
+        public ReadOnlyMemory<byte> MasterKey { get; set; }
+        public ReadOnlyMemory<byte> MasterSalt { get; set; }
 
         /// <summary>
         /// Rollover counter.
@@ -179,7 +187,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         /// <summary>
         /// Master Key Identifier.
         /// </summary>
-        public byte[] Mki { get; private set; }
+        public ReadOnlyMemory<byte> Mki { get; private set; }
 
         /// <summary>
         /// The byte-length of the session keys for encryption.
@@ -237,13 +245,13 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         /// </summary>
         public int SRTP_PREFIX_LENGTH { get; set; } = 0;
 
-        public SrtpContext(SrtpContextType contextType, SrtpProtectionProfileConfiguration protectionProfile, byte[] masterKey, byte[] masterSalt, byte[] mki = null)
+        public SrtpContext(SrtpContextType contextType, SrtpProtectionProfileConfiguration protectionProfile, ReadOnlyMemory<byte> masterKey, ReadOnlyMemory<byte> masterSalt, ReadOnlyMemory<byte> mki = default)
         {
             this._contextType = contextType;
             this.ProtectionProfile = protectionProfile ?? throw new ArgumentNullException(nameof(protectionProfile));
-            this.MasterKey = masterKey ?? throw new ArgumentNullException(nameof(masterKey));
-            this.MasterSalt = masterSalt ?? throw new ArgumentNullException(nameof(masterSalt));
-            this.Mki = mki ?? new byte[0];
+            this.MasterKey = masterKey;
+            this.MasterSalt = masterSalt;
+            this.Mki = mki;
 
             Cipher = protectionProfile.Cipher;
             Auth = protectionProfile.Auth;
@@ -258,7 +266,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
         public virtual void DeriveSessionKeys(ulong index = 0)
         {
-            int labelBaseValue = _contextType == SrtpContextType.RTP ? 0 : 3;
+            var labelBaseValue = _contextType == SrtpContextType.RTP ? 0 : 3;
 
             switch (Cipher)
             {
@@ -272,7 +280,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM:
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
-                        var aesKeys = new AesEngine();
+                        var aesKeys = AesUtilities.CreateEngine();
                         this.K_e = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_e, labelBaseValue + 0, index, KeyDerivationRate);
                         this.K_a = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_a, labelBaseValue + 1, index, KeyDerivationRate);
                         this.K_s = GenerateSessionKey(aesKeys, Cipher, MasterKey, MasterSalt, N_s, labelBaseValue + 2, index, KeyDerivationRate);
@@ -281,40 +289,37 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
                         if (Cipher >= SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM)
                         {
-                            byte[] outerK_e = K_e.Skip(K_e.Length / 2).ToArray();
-                            byte[] outerK_he = K_he.Skip(K_he.Length / 2).ToArray();
-
-                            var aesPayload = new AesEngine();
-                            aesPayload.Init(true, new KeyParameter(outerK_e));
+                            var aesPayload = AesUtilities.CreateEngine();
+                            aesPayload.Init(true, new KeyParameter(K_e, K_e.Length / 2, K_e.Length / 2));
                             this.PayloadCTR = aesPayload;
 
-                            var aesHeader = new AesEngine();
-                            aesHeader.Init(true, new KeyParameter(outerK_he));
+                            var aesHeader = AesUtilities.CreateEngine();
+                            aesHeader.Init(true, new KeyParameter(K_he, K_he.Length / 2, K_he.Length / 2));
                             this.HeaderCTR = aesHeader;
                         }
                         else
                         {
-                            var aesPayload = new AesEngine();
+                            var aesPayload = AesUtilities.CreateEngine();
                             aesPayload.Init(true, new KeyParameter(K_e));
                             this.PayloadCTR = aesPayload;
 
-                            var aesHeader = new AesEngine();
+                            var aesHeader = AesUtilities.CreateEngine();
                             aesHeader.Init(true, new KeyParameter(K_he));
                             this.HeaderCTR = aesHeader;
                         }
 
                         if (Cipher == SrtpCiphers.AES_128_F8)
                         {
-                            this.PayloadF8 = new AesEngine();
-                            this.HeaderF8 = new AesEngine();
+                            this.PayloadF8 = AesUtilities.CreateEngine();
+                            this.HeaderF8 = AesUtilities.CreateEngine();
                         }
                         else if (Cipher == SrtpCiphers.AEAD_AES_128_GCM || Cipher == SrtpCiphers.AEAD_AES_256_GCM)
                         {
-                            this.PayloadAEAD = new GcmBlockCipher(new AesEngine());
+                            this.PayloadAEAD = new GcmBlockCipher(AesUtilities.CreateEngine());
                         }
                         else if (Cipher == SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM || Cipher == SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM)
                         {
-                            this.PayloadAEAD = new GcmBlockCipher(new AesEngine());
+                            this.PayloadAEAD = new GcmBlockCipher(AesUtilities.CreateEngine());
                         }
                     }
                     break;
@@ -399,9 +404,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             }
         }
 
-        public static byte[] GenerateSessionKey(IBlockCipher engineKeys, SrtpCiphers cipher, byte[] masterKey, byte[] masterSalt, int length, int label, ulong index, ulong kdr)
+        public static byte[] GenerateSessionKey(IBlockCipher engineKeys, SrtpCiphers cipher, ReadOnlyMemory<byte> masterKey, ReadOnlyMemory<byte> masterSalt, int length, int label, ulong index, ulong kdr)
         {
-            byte[] key = new byte[length];
+            var key = GC.AllocateUninitializedArray<byte>(length);
             switch (cipher)
             {
                 case SrtpCiphers.NULL:
@@ -419,9 +424,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        engineKeys.Init(true, new KeyParameter(masterKey));
-                        byte[] iv = Encryption.CTR.GenerateSessionKeyIV(masterSalt, index, kdr, (byte)label);
-                        Encryption.CTR.Encrypt(engineKeys, key, 0, length, iv);
+                        engineKeys.Init(true, KeyParameter.Create(masterKey));
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[Encryption.CTR.BLOCK_SIZE];
+#else
+                        var iv = new byte[Encryption.CTR.BLOCK_SIZE];
+#endif
+                        Encryption.CTR.GenerateSessionKeyIV(masterSalt, index, kdr, (byte)label, iv);
+                        Encryption.CTR.Encrypt(engineKeys, key, key, iv);
                     }
                     break;
 
@@ -429,17 +439,29 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
 
-                        byte[] innerSalt = masterSalt.Take(masterSalt.Length / 2).ToArray();
-                        byte[] innerKey = masterKey.Take(masterKey.Length / 2).ToArray();
-                        byte[] innerIv = Encryption.CTR.GenerateSessionKeyIV(innerSalt, index, kdr, (byte)label);
-                        engineKeys.Init(true, new KeyParameter(innerKey));
-                        Encryption.CTR.Encrypt(engineKeys, key, 0, key.Length / 2, innerIv);
+                        var innerSalt = masterSalt.Slice(0, masterSalt.Length / 2);
+                        var innerKey = masterKey.Slice(0, masterKey.Length / 2);
+                        engineKeys.Init(true, KeyParameter.Create(masterKey));
+#if NET8_0_OR_GREATER
+                        Span<byte> innerIv = stackalloc byte[Encryption.CTR.BLOCK_SIZE];
+#else
+                        var innerIv = new byte[Encryption.CTR.BLOCK_SIZE];
+#endif
+                        Encryption.CTR.GenerateSessionKeyIV(innerSalt, index, kdr, (byte)label, innerIv);
+                        engineKeys.Init(true, KeyParameter.Create(innerKey));
+                        var halfLen = key.Length / 2;
+                        Encryption.CTR.Encrypt(engineKeys, key.AsSpan(0, halfLen), key.AsSpan(0, halfLen), innerIv);
 
-                        byte[] outerSalt = masterSalt.Skip(masterSalt.Length / 2).ToArray();
-                        byte[] outerKey = masterKey.Skip(masterKey.Length / 2).ToArray();
-                        byte[] outerIv = Encryption.CTR.GenerateSessionKeyIV(outerSalt, index, kdr, (byte)label);
-                        engineKeys.Init(true, new KeyParameter(outerKey));
-                        Encryption.CTR.Encrypt(engineKeys, key, key.Length / 2, key.Length, outerIv);
+                        var outerSalt = masterSalt.Slice(masterSalt.Length / 2);
+                        var outerKey = masterKey.Slice(masterKey.Length / 2);
+#if NET8_0_OR_GREATER
+                        Span<byte> outerIv = stackalloc byte[Encryption.CTR.BLOCK_SIZE];
+#else
+                        var outerIv = new byte[Encryption.CTR.BLOCK_SIZE];
+#endif
+                        Encryption.CTR.GenerateSessionKeyIV(outerSalt, index, kdr, (byte)label, outerIv);
+                        engineKeys.Init(true, KeyParameter.Create(outerKey));
+                        Encryption.CTR.Encrypt(engineKeys, key.AsSpan(halfLen), key.AsSpan(halfLen), outerIv);
                     }
                     break;
 
@@ -453,22 +475,25 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         public virtual int CalculateRequiredSrtpPayloadLength(int rtpLen)
         {
             var context = this;
-            byte[] mki = context.Mki;
+            var mki = context.Mki;
             return rtpLen + mki.Length + context.N_tag + (Cipher >= SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM ? 1 : 0);
         }
 
-        public virtual int ProtectRtp(byte[] payload, int length, out int outputBufferLength)
+        public virtual int ProtectRtp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
             var context = this;
+            var length = input.Length;
 
-            if (payload == null)
+#if !NET8_0_OR_GREATER
+            if (output == null)
             {
-                throw new ArgumentNullException(nameof(payload));
+                throw new ArgumentNullException(nameof(output));
             }
+#endif
 
-            if (payload.Length < CalculateRequiredSrtpPayloadLength(length))
+            if (output.Length < CalculateRequiredSrtpPayloadLength(length))
             {
-                throw new ArgumentOutOfRangeException($"{nameof(ProtectRtp)} failed, {nameof(payload)} buffer is too small!");
+                throw new ArgumentOutOfRangeException($"{nameof(ProtectRtp)} failed, {nameof(output)} buffer is too small!");
             }
 
             if (!context.IncrementMasterKeyUseCounter())
@@ -477,42 +502,49 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 return ERROR_MASTER_KEY_ROTATION_REQUIRED;
             }
 
-            uint ssrc = RtpReader.ReadSsrc(payload);
-            ushort sequenceNumber = RtpReader.ReadSequenceNumber(payload);
-            int offset = RtpReader.ReadHeaderLen(payload);
-            uint roc = context.Roc;
-            ulong index = SrtpContext.GenerateRtpIndex(roc, sequenceNumber);
+            var ssrc = RtpReader.ReadSsrc(input);
+            var sequenceNumber = RtpReader.ReadSequenceNumber(input);
+            var offset = RtpReader.ReadHeaderLen(input);
+            var roc = context.Roc;
+            var index = SrtpContext.GenerateRtpIndex(roc, sequenceNumber);
+
+            // copy header from input to output
+            input.Slice(0, offset).CopyTo(output.Slice(0, offset));
 
             // RFC6904
-            byte[] rtpExtensionsMask = RtpHeaderExtensionsEncryptionMask;
+            var rtpExtensionsMask = RtpHeaderExtensionsEncryptionMask;
             if (rtpExtensionsMask != null && rtpExtensionsMask.Length > 0)
             {
-                int rtpExtensionsOffset = RtpReader.ReadHeaderLenWithoutExtensions(payload) + 4; // 4 bytes of "defined by profile" and "length" fields
-                if (RtpReader.ReadExtensionsLength(payload) <= 0)
+                int extLen = RtpReader.ReadExtensionsLength(input);
+                if (extLen <= 0)
                 {
                     throw new InvalidOperationException("RTP header extensions encryption mask is set, but the RTP packet does not contain any header extensions!");
                 }
 
-                byte[] rtpExtensions = RtpReader.ReadHeaderExtensions(payload);
-                int ret = ProtectUnprotectRtpHeaderExtensions(payload, rtpExtensions, rtpExtensionsMask, ssrc, roc, index);
+                var rtpExtensionsOffset = RtpReader.ReadHeaderLenWithoutExtensions(input) + 4; // 4 bytes of "defined by profile" and "length" fields
+                var ret = ProtectUnprotectRtpHeaderExtensions(input, output.Slice(rtpExtensionsOffset, extLen), rtpExtensionsMask, ssrc, roc, index);
                 if (ret != 0)
                 {
                     outputBufferLength = 0;
                     return ret;
                 }
-
-                Buffer.BlockCopy(rtpExtensions, 0, payload, rtpExtensionsOffset, rtpExtensions.Length);
             }
 
             switch (context.Cipher)
             {
                 case SrtpCiphers.NULL:
+                    input.Slice(offset, length - offset).CopyTo(output.Slice(offset, length - offset));
                     break;
 
                 case SrtpCiphers.AES_128_F8:
                     {
-                        byte[] iv = SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, payload, roc);
-                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, payload, offset, length, iv);
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.F8.BLOCK_SIZE];
+#else
+                        var iv = new byte[SRTP.Encryption.F8.BLOCK_SIZE];
+#endif
+                        SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, roc, iv);
+                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
                     }
                     break;
 
@@ -523,8 +555,13 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.ARIA_256_CTR:
                 case SrtpCiphers.SEED_128_CTR:
                     {
-                        byte[] iv = SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index);
-                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, payload, offset, length, iv);
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#else
+                        var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#endif
+                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
+                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
                     }
                     break;
 
@@ -535,9 +572,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        byte[] iv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index);
-                        byte[] associatedData = payload.Take(offset).ToArray();
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, payload, offset, length, iv, context.K_e, context.N_tag, associatedData);
+                        var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
+                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, output.Slice(0, offset));
                         length += context.N_tag;
                     }
                     break;
@@ -546,43 +583,51 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
                         // form a synthetic RTP packet
-                        int rtpHeaderLength = RtpReader.ReadHeaderLenWithoutExtensions(payload);
-                        int rtpExtensionsLength = RtpReader.ReadExtensionsLength(payload);
-                        byte[] syntheticRtpPacket = new byte[length - rtpExtensionsLength + (context.N_tag / 2)];
+                        var rtpHeaderLength = RtpReader.ReadHeaderLenWithoutExtensions(input);
+                        var rtpExtensionsLength = RtpReader.ReadExtensionsLength(input);
+                        var syntheticRtpPacketLen = length - rtpExtensionsLength + (context.N_tag / 2);
+                        var syntheticRtpPacket = ArrayPool<byte>.Shared.Rent(syntheticRtpPacketLen);
 
-                        // copy header without extensions
-                        Buffer.BlockCopy(payload, 0, syntheticRtpPacket, 0, rtpHeaderLength);
+                        try
+                        {
+                            // copy header without extensions
+                            input.Slice(0, rtpHeaderLength).CopyTo(syntheticRtpPacket.AsSpan(0, rtpHeaderLength));
 
-                        // set X bit to 0
-                        syntheticRtpPacket[0] &= 0xEF;
+                            // set X bit to 0
+                            syntheticRtpPacket[0] &= 0xEF;
 
-                        // copy the original payload
-                        Buffer.BlockCopy(payload, offset, syntheticRtpPacket, rtpHeaderLength, length - offset);
+                            // copy the original payload
+                            input.Slice(offset, length - offset).CopyTo(syntheticRtpPacket.AsSpan(rtpHeaderLength, length - offset));
 
-                        // apply inner cryptographic algorithm
-                        byte[] innerK_e = context.K_e.Take(context.K_e.Length / 2).ToArray();
-                        byte[] innerK_s = context.K_s.Take(context.K_s.Length / 2).ToArray();
-                        byte[] innerIv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, ssrc, index);
-                        byte[] innerAssociatedData = syntheticRtpPacket.Take(rtpHeaderLength).ToArray();
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, syntheticRtpPacket, rtpHeaderLength, length - rtpExtensionsLength, innerIv, innerK_e, context.N_tag / 2, innerAssociatedData);
+                            // apply inner cryptographic algorithm
+                            var innerK_e = KeyParameter.Create(context.K_e.Slice(0, context.K_e.Length / 2));
+                            var innerK_s = context.K_s.AsSpan(0, context.K_s.Length / 2);
+                            var innerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, ssrc, index, innerIv);
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, syntheticRtpPacket.Slice(rtpHeaderLength, length - rtpExtensionsLength - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), innerIv, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
 
-                        // copy the protected payload back to the original payload buffer
-                        Buffer.BlockCopy(syntheticRtpPacket, rtpHeaderLength, payload, offset, syntheticRtpPacket.Length - rtpHeaderLength);
-                        length += context.N_tag / 2;
+                            // copy the protected payload back to the output buffer
+                            syntheticRtpPacket.AsSpan(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength).CopyTo(output.Slice(offset, syntheticRtpPacketLen - rtpHeaderLength));
+                            length += context.N_tag / 2;
 
-                        // append OHB
-                        payload[length] = 0; // all empty OHB
+                            // append OHB
+                            output[length] = 0; // all empty OHB
 
-                        length += 1;
+                            length += 1;
 
-                        // apply outer cryptographic algorithm
-                        byte[] outerK_e = context.K_e.Skip(context.K_e.Length / 2).ToArray();
-                        byte[] outerK_s = context.K_s.Skip(context.K_s.Length / 2).ToArray();
-                        byte[] outerIv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index);
-                        byte[] outerAssociatedData = payload.Take(offset).ToArray();
+                            // apply outer cryptographic algorithm
+                            var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
+                            var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
+                            var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index, outerIv);
 
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, payload, offset, length, outerIv, outerK_e, context.N_tag / 2, outerAssociatedData);
-                        length += context.N_tag / 2;
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, output.Slice(offset, length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, output.Slice(0, offset));
+                            length += context.N_tag / 2;
+                        }
+                        finally
+                        {
+                            ArrayPool<byte>.Shared.Return(syntheticRtpPacket);
+                        }
                     }
                     break;
 
@@ -596,24 +641,21 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             byte[] auth = null;
             if (context.Auth != SrtpAuth.NONE)
             {
-                payload[length + 0] = (byte)(roc >> 24);
-                payload[length + 1] = (byte)(roc >> 16);
-                payload[length + 2] = (byte)(roc >> 8);
-                payload[length + 3] = (byte)roc;
+                BinaryPrimitives.WriteUInt32BigEndian(output.Slice(length, 4), roc);
 
-                auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, payload, 0, length + 4);
+                auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, output.Slice(0, length + 4));
             }
 
-            byte[] mki = context.Mki;
+            var mki = context.Mki;
             if (mki.Length > 0)
             {
-                Buffer.BlockCopy(mki, 0, payload, length, mki.Length);
+                mki.Span.CopyTo(output.Slice(length, mki.Length));
                 length += mki.Length;
             }
 
             if (auth != null)
             {
-                System.Buffer.BlockCopy(auth, 0, payload, length, context.N_tag); // we don't append ROC in SRTP
+                auth.AsSpan(0, context.N_tag).CopyTo(output.Slice(length, context.N_tag)); // we don't append ROC in SRTP
                 length += context.N_tag;
             }
 
@@ -628,79 +670,106 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             return 0;
         }
 
-        public int ProtectUnprotectRtpHeaderExtensions(byte[] payload, byte[] rtpExtensions, byte[] rtpExtensionsMask, uint ssrc, uint roc, ulong index)
+        public int ProtectUnprotectRtpHeaderExtensions(ReadOnlySpan<byte> payload, Span<byte> rtpExtensions, ReadOnlySpan<byte> rtpExtensionsMask, uint ssrc, uint roc, ulong index)
         {
             var context = this;
 
-            byte[] rtpExtensionsEncrypted = rtpExtensions.ToArray();
+            var rtpExtensionsEncrypted = ArrayPool<byte>.Shared.Rent(rtpExtensions.Length);
 
-            // in case of Double AEAD, this should use the outer cryptographic key
-            switch (context.Cipher)
+            try
             {
-                case SrtpCiphers.NULL:
-                    return 0;
+                // in case of Double AEAD, this should use the outer cryptographic key
+                switch (context.Cipher)
+                {
+                    case SrtpCiphers.NULL:
+                        return 0;
 
-                case SrtpCiphers.AES_128_F8:
-                    {
-                        byte[] iv = SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.HeaderF8, context.K_he, context.K_hs, payload, roc);
-                        SRTP.Encryption.F8.Encrypt(context.HeaderCTR, rtpExtensionsEncrypted, 0, rtpExtensionsEncrypted.Length, iv);
-                    }
-                    break;
+                    case SrtpCiphers.AES_128_F8:
+                        {
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.F8.BLOCK_SIZE];
+#else
+                            var iv = new byte[SRTP.Encryption.F8.BLOCK_SIZE];
+#endif
+                            SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.HeaderF8, context.K_he, context.K_hs, payload, roc, iv);
+                            SRTP.Encryption.F8.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), iv);
+                        }
+                        break;
 
-                case SrtpCiphers.AES_128_CM:
-                case SrtpCiphers.AES_192_CM:
-                case SrtpCiphers.AES_256_CM:
-                case SrtpCiphers.ARIA_128_CTR:
-                case SrtpCiphers.ARIA_256_CTR:
-                case SrtpCiphers.SEED_128_CTR:
-                case SrtpCiphers.AEAD_AES_128_GCM:
-                case SrtpCiphers.AEAD_AES_256_GCM:
-                case SrtpCiphers.AEAD_ARIA_128_GCM:
-                case SrtpCiphers.AEAD_ARIA_256_GCM:
-                case SrtpCiphers.SEED_128_CCM:
-                case SrtpCiphers.SEED_128_GCM:
-                    {
-                        byte[] iv = SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_hs, ssrc, index);
-                        SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensionsEncrypted, 0, rtpExtensionsEncrypted.Length, iv);
-                    }
-                    break;
+                    case SrtpCiphers.AES_128_CM:
+                    case SrtpCiphers.AES_192_CM:
+                    case SrtpCiphers.AES_256_CM:
+                    case SrtpCiphers.ARIA_128_CTR:
+                    case SrtpCiphers.ARIA_256_CTR:
+                    case SrtpCiphers.SEED_128_CTR:
+                    case SrtpCiphers.AEAD_AES_128_GCM:
+                    case SrtpCiphers.AEAD_AES_256_GCM:
+                    case SrtpCiphers.AEAD_ARIA_128_GCM:
+                    case SrtpCiphers.AEAD_ARIA_256_GCM:
+                    case SrtpCiphers.SEED_128_CCM:
+                    case SrtpCiphers.SEED_128_GCM:
+                        {
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#else
+                            var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#endif
+                            SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_hs, ssrc, index, iv);
+                            SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), iv);
+                        }
+                        break;
 
-                case SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM:
-                case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
-                    {
-                        byte[] outerK_hs = context.K_hs.Skip(context.K_hs.Length / 2).ToArray();
-                        byte[] outerIv = SRTP.Encryption.CTR.GenerateMessageKeyIV(outerK_hs, ssrc, index);
-                        SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensionsEncrypted, 0, rtpExtensionsEncrypted.Length, outerIv);
-                    }
-                    break;
+                    case SrtpCiphers.DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM:
+                    case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
+                        {
+                            var outerK_hs = context.K_hs.AsSpan(context.K_hs.Length / 2);
+#if NET8_0_OR_GREATER
+                        Span<byte> outerIv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#else
+                            var outerIv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#endif
+                            SRTP.Encryption.CTR.GenerateMessageKeyIV(outerK_hs, ssrc, index, outerIv);
+                            SRTP.Encryption.CTR.Encrypt(context.HeaderCTR, rtpExtensions, rtpExtensionsEncrypted.AsSpan(0, rtpExtensions.Length), outerIv);
+                        }
+                        break;
 
-                default:
-                    return ERROR_UNSUPPORTED_CIPHER;
+                    default:
+                        return ERROR_UNSUPPORTED_CIPHER;
+                }
+
+                for (var i = 0; i < rtpExtensions.Length; i++)
+                {
+                    // EncryptedHeader = (Encrypt(Key, Plaintext) AND MASK) OR (Plaintext AND (NOT MASK))
+                    rtpExtensions[i] = unchecked((byte)((rtpExtensionsEncrypted[i] & rtpExtensionsMask[i]) | (rtpExtensions[i] & ~rtpExtensionsMask[i])));
+                }
             }
-
-            for (int i = 0; i < rtpExtensions.Length; i++)
+            finally
             {
-                // EncryptedHeader = (Encrypt(Key, Plaintext) AND MASK) OR (Plaintext AND (NOT MASK))
-                rtpExtensions[i] = unchecked((byte)((rtpExtensionsEncrypted[i] & rtpExtensionsMask[i]) | (rtpExtensions[i] & ~rtpExtensionsMask[i])));
+                ArrayPool<byte>.Shared.Return(rtpExtensionsEncrypted);
             }
 
             return 0;
         }
 
-        public virtual int UnprotectRtp(byte[] payload, int length, out int outputBufferLength)
+        public virtual int UnprotectRtp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
             var context = this;
+            var length = input.Length;
 
-            if (payload == null)
+#if !NET8_0_OR_GREATER
+            if (output == null)
             {
-                throw new ArgumentNullException(nameof(payload));
+                throw new ArgumentNullException(nameof(output));
             }
+#endif
 
-            byte[] mki = context.Mki;
+            ReadOnlySpan<byte> inputSpan = input;
+            var mki = context.Mki;
 
-            for (int i = 0; i < mki.Length; i++)
+            var mkiSpan = mki.Span;
+            for (var i = 0; i < mki.Length; i++)
             {
-                if (payload[length - mki.Length - context.N_tag + i] != mki[i])
+                if (inputSpan[length - mki.Length - context.N_tag + i] != mkiSpan[i])
                 {
                     outputBufferLength = 0;
                     return ERROR_MKI_CHECK_FAILED;
@@ -713,8 +782,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 return ERROR_MASTER_KEY_ROTATION_REQUIRED;
             }
 
-            uint ssrc = RtpReader.ReadSsrc(payload);
-            ushort sequenceNumber = RtpReader.ReadSequenceNumber(payload);
+            var ssrc = RtpReader.ReadSsrc(input);
+            var sequenceNumber = RtpReader.ReadSequenceNumber(input);
 
             SsrcSrtpContext ssrcContext;
             if (context.ReplayProtection.TryGetValue(ssrc, out ssrcContext) == false)
@@ -726,37 +795,38 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             ssrcContext.SetInitialSequence(sequenceNumber);
 
             // Derive ROC/index for this packet from the last accepted index.
-            uint lastIndex = ssrcContext.S_l;
-            ushort lastSeq = (ushort)(lastIndex & 0xFFFF);
-            uint lastRoc = lastIndex >> 16;
-            uint index = SrtpContext.DetermineRtpIndex(lastSeq, sequenceNumber, lastRoc);
-            uint roc = index >> 16;
+            var lastIndex = ssrcContext.S_l;
+            var lastSeq = (ushort)(lastIndex & 0xFFFF);
+            var lastRoc = lastIndex >> 16;
+            var index = SrtpContext.DetermineRtpIndex(lastSeq, sequenceNumber, lastRoc);
+            var roc = index >> 16;
 
             if (context.Auth != SrtpAuth.NONE)
             {
-                // TODO: optimize memory allocation - we could preallocate 4 byte array and add another GenerateAuthTag overload that processes 2 blocks
-                int authenticatedLen = length - mki.Length - context.N_tag;
-                byte[] msgAuth = new byte[authenticatedLen + 4];
-                Buffer.BlockCopy(payload, 0, msgAuth, 0, authenticatedLen);
-                msgAuth[authenticatedLen + 0] = (byte)(roc >> 24);
-                msgAuth[authenticatedLen + 1] = (byte)(roc >> 16);
-                msgAuth[authenticatedLen + 2] = (byte)(roc >> 8);
-                msgAuth[authenticatedLen + 3] = (byte)(roc);
-
-                byte[] auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, msgAuth, 0, authenticatedLen + 4);
-                for (int i = 0; i < context.N_tag; i++)
+                var authenticatedLen = length - mki.Length - context.N_tag;
+                var msgAuth = ArrayPool<byte>.Shared.Rent(authenticatedLen + 4);
+                try
                 {
-                    if (payload[authenticatedLen + mki.Length + i] != auth[i])
+                    input.Slice(0, authenticatedLen).CopyTo(msgAuth.AsSpan(0, authenticatedLen));
+                    BinaryPrimitives.WriteUInt32BigEndian(msgAuth.AsSpan(authenticatedLen, 4), roc);
+
+                    var auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, msgAuth.Slice(0, authenticatedLen + 4));
+                    for (var i = 0; i < context.N_tag; i++)
                     {
-                        outputBufferLength = 0;
-                        return ERROR_HMAC_CHECK_FAILED;
+                        if (inputSpan[authenticatedLen + mki.Length + i] != auth[i])
+                        {
+                            outputBufferLength = 0;
+                            return ERROR_HMAC_CHECK_FAILED;
+                        }
                     }
                 }
-
-                msgAuth = null;
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(msgAuth);
+                }
             }
 
-            int offset = RtpReader.ReadHeaderLen(payload);
+            var offset = RtpReader.ReadHeaderLen(input);
 
             if (!ssrcContext.CheckAndUpdateReplayWindow(index))
             {
@@ -768,15 +838,24 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             {
                 case SrtpCiphers.NULL:
                     {
-                        outputBufferLength = length - mki.Length - context.N_tag;
+                        var dataLen = length - mki.Length - context.N_tag;
+                        input.Slice(0, dataLen).CopyTo(output.Slice(0, dataLen));
+                        outputBufferLength = dataLen;
                     }
                     break;
 
                 case SrtpCiphers.AES_128_F8:
                     {
-                        byte[] iv = SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, payload, roc);
-                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, payload, offset, length - mki.Length - context.N_tag, iv);
-                        outputBufferLength = length - mki.Length - context.N_tag;
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.F8.BLOCK_SIZE];
+#else
+                        var iv = new byte[SRTP.Encryption.F8.BLOCK_SIZE];
+#endif
+                        SRTP.Encryption.F8.GenerateRtpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, roc, iv);
+                        var decLen = length - mki.Length - context.N_tag;
+                        input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                        outputBufferLength = decLen;
                     }
                     break;
 
@@ -787,9 +866,16 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.ARIA_256_CTR:
                 case SrtpCiphers.SEED_128_CTR:
                     {
-                        byte[] iv = SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index);
-                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, payload, offset, length - mki.Length - context.N_tag, iv);
-                        outputBufferLength = length - mki.Length - context.N_tag;
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#else
+                        var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#endif
+                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
+                        var decLen = length - mki.Length - context.N_tag;
+                        input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                        outputBufferLength = decLen;
                     }
                     break;
 
@@ -800,9 +886,10 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        byte[] iv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index);
-                        byte[] associatedData = payload.Take(offset).ToArray();
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, payload, offset, length - mki.Length, iv, context.K_e, context.N_tag, associatedData);
+                        var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, index, iv);
+                        input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - mki.Length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, input.Slice(0, offset));
                         outputBufferLength = length - mki.Length - context.N_tag;
                     }
                     break;
@@ -811,16 +898,19 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
                         // apply outer cryptographic algorithm
-                        byte[] outerK_e = context.K_e.Skip(context.K_e.Length / 2).ToArray();
-                        byte[] outerK_s = context.K_s.Skip(context.K_s.Length / 2).ToArray();
-                        byte[] outerIv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index);
-                        byte[] outerAssociatedData = payload.Take(offset).ToArray();
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, payload, offset, length - mki.Length, outerIv, outerK_e, context.N_tag / 2, outerAssociatedData);
+                        var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
+                        var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
+                        var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, index, outerIv);
+                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - mki.Length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, input.Slice(0, offset));
+
+                        // copy header from input to output
+                        input.Slice(0, offset).CopyTo(output.Slice(0, offset));
 
                         // calculate OHB size - it can now be larger than 1 byte if it was modified
-                        int lastOhbByteIndex = length - mki.Length - context.N_tag / 2 - 1;
-                        byte ohbConfig = payload[lastOhbByteIndex];
-                        int ohbLength = 1;
+                        var lastOhbByteIndex = length - mki.Length - context.N_tag / 2 - 1;
+                        var ohbConfig = output[lastOhbByteIndex];
+                        var ohbLength = 1;
                         if ((ohbConfig & 0x01) == 0x01)
                         {
                             ohbLength += 2;
@@ -831,55 +921,63 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                         }
 
                         // form a synthetic RTP packet
-                        int rtpHeaderLength = RtpReader.ReadHeaderLenWithoutExtensions(payload);
-                        int rtpExtensionsLength = RtpReader.ReadExtensionsLength(payload);
-                        byte[] syntheticRtpPacket = new byte[length - rtpExtensionsLength - (context.N_tag / 2) - ohbLength];
+                        var rtpHeaderLength = RtpReader.ReadHeaderLenWithoutExtensions(output);
+                        var rtpExtensionsLength = RtpReader.ReadExtensionsLength(output);
+                        var syntheticRtpPacketLen = length - rtpExtensionsLength - (context.N_tag / 2) - ohbLength;
+                        var syntheticRtpPacket = ArrayPool<byte>.Shared.Rent(syntheticRtpPacketLen);
 
-                        // copy header without extensions
-                        Buffer.BlockCopy(payload, 0, syntheticRtpPacket, 0, rtpHeaderLength);
-
-                        // set X bit to 0
-                        syntheticRtpPacket[0] &= 0xEF;
-
-                        // restore original header values from the OHB
-                        if ((ohbConfig & 0x01) == 0x01)
+                        try
                         {
-                            syntheticRtpPacket[2] = payload[lastOhbByteIndex - ohbLength - 1];
-                            syntheticRtpPacket[3] = payload[lastOhbByteIndex - ohbLength];
+                            // copy header without extensions
+                            output.Slice(0, rtpHeaderLength).CopyTo(syntheticRtpPacket.AsSpan(0, rtpHeaderLength));
+
+                            // set X bit to 0
+                            syntheticRtpPacket[0] &= 0xEF;
+
+                            // restore original header values from the OHB
+                            if ((ohbConfig & 0x01) == 0x01)
+                            {
+                                syntheticRtpPacket[2] = output[lastOhbByteIndex - ohbLength - 1];
+                                syntheticRtpPacket[3] = output[lastOhbByteIndex - ohbLength];
+                            }
+                            if ((ohbConfig & 0x02) == 0x02)
+                            {
+                                var pt = output[lastOhbByteIndex - ohbLength];
+                                syntheticRtpPacket[1] = (byte)((syntheticRtpPacket[1] & 0x80) | (pt & 0x7F));
+                            }
+                            if ((ohbConfig & 0x04) == 0x04)
+                            {
+                                var markerBit = (ohbConfig & 0x08) == 0x08;
+                                syntheticRtpPacket[1] = (byte)((markerBit ? 0x80 : 0x00) | (syntheticRtpPacket[1] & 0x7F));
+                            }
+
+                            // copy the payload including the inner authentication tag
+                            output.Slice(offset, length - offset - mki.Length - context.N_tag / 2 - ohbLength).CopyTo(syntheticRtpPacket.AsSpan(rtpHeaderLength, length - offset - mki.Length - context.N_tag / 2 - ohbLength));
+
+                            var innerSsrc = RtpReader.ReadSsrc(syntheticRtpPacket);
+                            var innerSequenceNumber = RtpReader.ReadSequenceNumber(syntheticRtpPacket);
+                            var innerIndex = SrtpContext.DetermineRtpIndex(lastSeq, innerSequenceNumber, lastRoc);
+
+                            // apply inner cryptographic algorithm
+                            var innerK_e = KeyParameter.Create(context.K_e.Slice(0, context.K_e.Length / 2));
+                            var innerK_s = context.K_s.AsSpan(0, context.K_s.Length / 2);
+                            var innerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, innerSsrc, innerIndex, innerIv);
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), syntheticRtpPacket.Slice(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength), innerIv, innerK_e, context.N_tag / 2, syntheticRtpPacket.Slice(0, rtpHeaderLength));
+
+                            // copy the unprotected payload back to the output buffer
+                            syntheticRtpPacket.AsSpan(rtpHeaderLength, syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2).CopyTo(output.Slice(offset, syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2));
+
+                            // copy the synthetic header back to the output buffer
+                            syntheticRtpPacket.AsSpan(0, rtpHeaderLength).CopyTo(output.Slice(0, rtpHeaderLength));
+
+                            // update the output buffer length
+                            outputBufferLength = offset + syntheticRtpPacketLen - rtpHeaderLength - context.N_tag / 2;
                         }
-                        if ((ohbConfig & 0x02) == 0x02)
+                        finally
                         {
-                            byte pt = payload[lastOhbByteIndex - ohbLength];
-                            syntheticRtpPacket[1] = (byte)((syntheticRtpPacket[1] & 0x80) | (pt & 0x7F));
+                            ArrayPool<byte>.Shared.Return(syntheticRtpPacket);
                         }
-                        if ((ohbConfig & 0x04) == 0x04)
-                        {
-                            bool markerBit = (ohbConfig & 0x08) == 0x08;
-                            syntheticRtpPacket[1] = (byte)((markerBit ? 0x80 : 0x00) | (syntheticRtpPacket[1] & 0x7F));
-                        }
-
-                        // copy the payload including the inner authentication tag
-                        Buffer.BlockCopy(payload, offset, syntheticRtpPacket, rtpHeaderLength, length - offset - mki.Length - context.N_tag / 2 - ohbLength);
-
-                        uint innerSsrc = RtpReader.ReadSsrc(syntheticRtpPacket);
-                        ushort innerSequenceNumber = RtpReader.ReadSequenceNumber(syntheticRtpPacket);
-                        uint innerIndex = SrtpContext.DetermineRtpIndex(lastSeq, innerSequenceNumber, lastRoc);
-
-                        // apply inner cryptographic algorithm
-                        byte[] innerK_e = context.K_e.Take(context.K_e.Length / 2).ToArray();
-                        byte[] innerK_s = context.K_s.Take(context.K_s.Length / 2).ToArray();
-                        byte[] innerIv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(innerK_s, innerSsrc, innerIndex);
-                        byte[] innerAssociatedData = syntheticRtpPacket.Take(rtpHeaderLength).ToArray();
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, syntheticRtpPacket, rtpHeaderLength, syntheticRtpPacket.Length, innerIv, innerK_e, context.N_tag / 2, innerAssociatedData);
-
-                        // copy the unprotected payload back to the original payload buffer
-                        Buffer.BlockCopy(syntheticRtpPacket, rtpHeaderLength, payload, offset, syntheticRtpPacket.Length - rtpHeaderLength - context.N_tag / 2);
-
-                        // copy the synthetic header back to the original payload buffer
-                        Buffer.BlockCopy(syntheticRtpPacket, 0, payload, 0, rtpHeaderLength);
-
-                        // update the output buffer length
-                        outputBufferLength = offset + syntheticRtpPacket.Length - rtpHeaderLength - context.N_tag / 2;
                     }
                     break;
 
@@ -892,24 +990,22 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
             // because of CCM/GCM, RTP headers must be unprotected only after the payload is unprotected and HMAC is verified
             // RFC6904
-            byte[] rtpExtensionsMask = RtpHeaderExtensionsEncryptionMask;
+            var rtpExtensionsMask = RtpHeaderExtensionsEncryptionMask;
             if (rtpExtensionsMask != null && rtpExtensionsMask.Length > 0)
             {
-                int rtpExtensionsOffset = RtpReader.ReadHeaderLenWithoutExtensions(payload) + 4; // 4 bytes of "defined by profile" and "length" fields
-                if (RtpReader.ReadExtensionsLength(payload) <= 0)
+                int extLen = RtpReader.ReadExtensionsLength(output);
+                if (extLen <= 0)
                 {
                     throw new InvalidOperationException("RTP header extensions encryption mask is set, but the RTP packet does not contain any header extensions!");
                 }
 
-                byte[] rtpExtensions = RtpReader.ReadHeaderExtensions(payload);
-                int ret = ProtectUnprotectRtpHeaderExtensions(payload, rtpExtensions, rtpExtensionsMask, ssrc, roc, index);
+                var rtpExtensionsOffset = RtpReader.ReadHeaderLenWithoutExtensions(output) + 4; // 4 bytes of "defined by profile" and "length" fields
+                var ret = ProtectUnprotectRtpHeaderExtensions(output, output.Slice(rtpExtensionsOffset, extLen), rtpExtensionsMask, ssrc, roc, index);
                 if (ret != 0)
                 {
                     outputBufferLength = 0;
                     return ret;
                 }
-
-                Buffer.BlockCopy(rtpExtensions, 0, payload, rtpExtensionsOffset, rtpExtensions.Length);
             }
 
             return 0;
@@ -918,22 +1014,25 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         public virtual int CalculateRequiredSrtcpPayloadLength(int rtcpLen)
         {
             var context = this;
-            byte[] mki = context.Mki;
+            var mki = context.Mki;
             return rtcpLen + 4 + mki.Length + context.N_tag;
         }
 
-        public int ProtectRtcp(byte[] payload, int length, out int outputBufferLength)
+        public int ProtectRtcp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
             var context = this;
+            var length = input.Length;
 
-            if (payload == null)
+#if !NET8_0_OR_GREATER
+            if (output == null)
             {
-                throw new ArgumentNullException(nameof(payload));
+                throw new ArgumentNullException(nameof(output));
             }
+#endif
 
-            if (payload.Length < CalculateRequiredSrtcpPayloadLength(length))
+            if (output.Length < CalculateRequiredSrtcpPayloadLength(length))
             {
-                throw new ArgumentOutOfRangeException($"{nameof(ProtectRtcp)} failed, {nameof(payload)} buffer is too small!");
+                throw new ArgumentOutOfRangeException($"{nameof(ProtectRtcp)} failed, {nameof(output)} buffer is too small!");
             }
 
             if (!context.IncrementMasterKeyUseCounter())
@@ -942,8 +1041,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 return ERROR_MASTER_KEY_ROTATION_REQUIRED;
             }
 
-            uint ssrc = RtcpReader.ReadSsrc(payload);
-            int offset = RtcpReader.GetHeaderLen();
+            var ssrc = RtcpReader.ReadSsrc(input);
+            var offset = RtcpReader.GetHeaderLen();
 
             SsrcSrtpContext ssrcContext;
             if (context.ReplayProtection.TryGetValue(ssrc, out ssrcContext) == false)
@@ -952,17 +1051,19 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 context.ReplayProtection.Add(ssrc, ssrcContext);
             }
 
-            uint index = ssrcContext.S_l | E_FLAG;
+            var index = ssrcContext.S_l | E_FLAG;
 
             switch (context.Cipher)
             {
                 case SrtpCiphers.NULL:
+                    input.Slice(0, length).CopyTo(output.Slice(0, length));
                     break;
 
                 case SrtpCiphers.AES_128_F8:
                     {
-                        byte[] iv = SRTP.Encryption.F8.GenerateRtcpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, payload, index);
-                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, payload, offset, length, iv);
+                        var iv = SRTP.Encryption.F8.GenerateRtcpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, index);
+                        input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                        SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
                     }
                     break;
 
@@ -973,8 +1074,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.ARIA_256_CTR:
                 case SrtpCiphers.SEED_128_CTR:
                     {
-                        byte[] iv = SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l);
-                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, payload, offset, length, iv);
+#if NET8_0_OR_GREATER
+                        Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#else
+                        var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#endif
+                        SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                        input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                        SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, length - offset), output.Slice(offset, length - offset), iv);
                     }
                     break;
 
@@ -985,10 +1092,21 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.SEED_128_CCM:
                 case SrtpCiphers.SEED_128_GCM:
                     {
-                        byte[] iv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l);
-                        byte[] associatedData = payload.Take(offset).Concat(new byte[] { (byte)(index >> 24), (byte)(index >> 16), (byte)(index >> 8), (byte)index }).ToArray(); // associatedData include also index
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, payload, offset, length, iv, context.K_e, context.N_tag, associatedData);
-                        length += context.N_tag;
+                        var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                        var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
+                        try
+                        {
+                            input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
+                            BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), index);
+                            input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, associatedDataRented.Slice(0, offset + 4));
+                            length += context.N_tag;
+                        }
+                        finally
+                        {
+                            ArrayPool<byte>.Shared.Return(associatedDataRented);
+                        }
                     }
                     break;
 
@@ -996,12 +1114,23 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                     {
                         // RTCP under Double AEAD is protected only with the outer layer
-                        byte[] outerK_e = context.K_e.Skip(context.K_e.Length / 2).ToArray();
-                        byte[] outerK_s = context.K_s.Skip(context.K_s.Length / 2).ToArray();
-                        byte[] outerIv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l);
-                        byte[] associatedData = payload.Take(offset).Concat(new byte[] { (byte)(index >> 24), (byte)(index >> 16), (byte)(index >> 8), (byte)index }).ToArray();
-                        SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, payload, offset, length, outerIv, outerK_e, context.N_tag / 2, associatedData);
-                        length += context.N_tag / 2;
+                        var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
+                        var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
+                        var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                        SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l, outerIv);
+                        var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
+                        try
+                        {
+                            input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
+                            BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), index);
+                            input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, true, input.Slice(offset, length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, associatedDataRented.Slice(0, offset + 4));
+                            length += context.N_tag / 2;
+                        }
+                        finally
+                        {
+                            ArrayPool<byte>.Shared.Return(associatedDataRented);
+                        }
                     }
                     break;
 
@@ -1012,23 +1141,20 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     }
             }
 
-            payload[length + 0] = (byte)(index >> 24);
-            payload[length + 1] = (byte)(index >> 16);
-            payload[length + 2] = (byte)(index >> 8);
-            payload[length + 3] = (byte)index;
+            BinaryPrimitives.WriteUInt32BigEndian(output.Slice(length, 4), index);
             length += 4;
 
-            byte[] mki = context.Mki;
+            var mki = context.Mki;
             if (mki.Length > 0)
             {
-                Buffer.BlockCopy(mki, 0, payload, length, mki.Length);
+                mki.Span.CopyTo(output.Slice(length, mki.Length));
                 length += mki.Length;
             }
 
             if (context.Auth != SrtpAuth.NONE)
             {
-                byte[] auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, payload, 0, length);
-                System.Buffer.BlockCopy(auth, 0, payload, length, context.N_tag);
+                var auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, output.Slice(0, length));
+                auth.AsSpan(0, context.N_tag).CopyTo(output.Slice(length, context.N_tag));
                 length += context.N_tag;
             }
 
@@ -1038,20 +1164,24 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             return 0;
         }
 
-        public virtual int UnprotectRtcp(byte[] payload, int length, out int outputBufferLength)
+        public virtual int UnprotectRtcp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
             var context = this;
+            var length = input.Length;
 
-            if (payload == null)
+#if !NET8_0_OR_GREATER
+            if (output == null)
             {
-                throw new ArgumentNullException(nameof(payload));
+                throw new ArgumentNullException(nameof(output));
             }
+#endif
 
-            byte[] mki = context.Mki;
+            ReadOnlySpan<byte> inputSpan = input;
+            var mki = context.Mki;
 
-            for (int i = 0; i < mki.Length; i++)
+            for (var i = 0; i < mki.Length; i++)
             {
-                if (payload[length - context.N_tag - mki.Length + i] != mki[i])
+                if (inputSpan[length - context.N_tag - mki.Length + i] != mki.Span[i])
                 {
                     outputBufferLength = 0;
                     return ERROR_MKI_CHECK_FAILED;
@@ -1064,8 +1194,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 return ERROR_MASTER_KEY_ROTATION_REQUIRED;
             }
 
-            uint ssrc = RtcpReader.ReadSsrc(payload);
-            int offset = RtcpReader.GetHeaderLen();
+            var ssrc = RtcpReader.ReadSsrc(input);
+            var offset = RtcpReader.GetHeaderLen();
 
             SsrcSrtpContext ssrcContext;
             if (context.ReplayProtection.TryGetValue(ssrc, out ssrcContext) == false)
@@ -1074,8 +1204,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 context.ReplayProtection.Add(ssrc, ssrcContext);
             }
 
-            uint index = RtcpReader.SrtcpReadIndex(payload, context.N_a > 0 ? (context.N_tag + mki.Length) : 0);
-            bool isEncrypted = false;
+            var originalIndex = RtcpReader.SrtcpReadIndex(input, context.N_a > 0 ? (context.N_tag + mki.Length) : 0);
+            var index = originalIndex;
+            var isEncrypted = false;
 
             if ((index & E_FLAG) == E_FLAG)
             {
@@ -1085,10 +1216,10 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
 
             if (context.Auth != SrtpAuth.NONE)
             {
-                byte[] auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, payload, 0, length - context.N_tag - mki.Length);
-                for (int i = 0; i < context.N_tag; i++)
+                var auth = SRTP.Authentication.HMAC.GenerateAuthTag(context.HMAC, input.Slice(0, length - context.N_tag - mki.Length));
+                for (var i = 0; i < context.N_tag; i++)
                 {
-                    if (payload[length - context.N_tag + i] != auth[i])
+                    if (inputSpan[length - context.N_tag + i] != auth[i])
                     {
                         outputBufferLength = 0;
                         return ERROR_HMAC_CHECK_FAILED;
@@ -1108,15 +1239,19 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 {
                     case SrtpCiphers.NULL:
                         {
-                            outputBufferLength = length - 4 - context.N_tag - mki.Length;
+                            var dataLen = length - 4 - context.N_tag - mki.Length;
+                            input.Slice(0, dataLen).CopyTo(output.Slice(0, dataLen));
+                            outputBufferLength = dataLen;
                         }
                         break;
 
                     case SrtpCiphers.AES_128_F8:
                         {
-                            byte[] iv = SRTP.Encryption.F8.GenerateRtcpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, payload, index);
-                            SRTP.Encryption.F8.Encrypt(context.PayloadCTR, payload, offset, length - 4 - context.N_tag - mki.Length, iv);
-                            outputBufferLength = length - 4 - context.N_tag - mki.Length;
+                            var decLen = length - 4 - context.N_tag - mki.Length;
+                            var iv = SRTP.Encryption.F8.GenerateRtcpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, index);
+                            input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                            SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                            outputBufferLength = decLen;
                         }
                         break;
 
@@ -1127,9 +1262,16 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.ARIA_256_CTR:
                     case SrtpCiphers.SEED_128_CTR:
                         {
-                            byte[] iv = SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l);
-                            SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, payload, offset, length - 4 - context.N_tag - mki.Length, iv);
-                            outputBufferLength = length - 4 - context.N_tag - mki.Length;
+                            var decLen = length - 4 - context.N_tag - mki.Length;
+#if NET8_0_OR_GREATER
+                            Span<byte> iv = stackalloc byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#else
+                            var iv = new byte[SRTP.Encryption.CTR.BLOCK_SIZE];
+#endif
+                            SRTP.Encryption.CTR.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                            input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                            SRTP.Encryption.CTR.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
+                            outputBufferLength = decLen;
                         }
                         break;
 
@@ -1140,10 +1282,21 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.SEED_128_CCM:
                     case SrtpCiphers.SEED_128_GCM:
                         {
-                            byte[] iv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l);
-                            byte[] associatedData = payload.Take(offset).Concat(payload.Skip(length - 4).Take(4)).ToArray(); // associatedData include also index
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, payload, offset, length - 4 - mki.Length, iv, context.K_e, context.N_tag, associatedData);
-                            outputBufferLength = length - 4 - context.N_tag - mki.Length;
+                            var iv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(context.K_s, ssrc, ssrcContext.S_l, iv);
+                            var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
+                            try
+                            {
+                                input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
+                                BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), originalIndex);
+                                input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                                SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - 4 - mki.Length - offset), output.Slice(offset), iv, context.K_e, context.N_tag, associatedDataRented.Slice(0, offset + 4));
+                                outputBufferLength = length - 4 - context.N_tag - mki.Length;
+                            }
+                            finally
+                            {
+                                ArrayPool<byte>.Shared.Return(associatedDataRented);
+                            }
                         }
                         break;
 
@@ -1151,12 +1304,23 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
                         {
                             // RTCP under Double AEAD is protected only with the outer layer
-                            byte[] outerK_e = context.K_e.Skip(context.K_e.Length / 2).ToArray();
-                            byte[] outerK_s = context.K_s.Skip(context.K_s.Length / 2).ToArray();
-                            byte[] outerIv = SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l);
-                            byte[] associatedData = payload.Take(offset).Concat(payload.Skip(length - 4).Take(4)).ToArray(); // associatedData include also index
-                            SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, payload, offset, length - 4 - mki.Length, outerIv, outerK_e, context.N_tag / 2, associatedData);
-                            outputBufferLength = length - 4 - context.N_tag / 2 - mki.Length;
+                            var outerK_e = KeyParameter.Create(context.K_e.Slice(context.K_e.Length / 2));
+                            var outerK_s = context.K_s.AsSpan(context.K_s.Length / 2);
+                            var outerIv = new byte[SRTP.Encryption.AEAD.BLOCK_SIZE];
+                            SRTP.Encryption.AEAD.GenerateMessageKeyIV(outerK_s, ssrc, ssrcContext.S_l, outerIv);
+                            var associatedDataRented = ArrayPool<byte>.Shared.Rent(offset + 4);
+                            try
+                            {
+                                input.Slice(0, offset).CopyTo(associatedDataRented.AsSpan(0, offset));
+                                BinaryPrimitives.WriteUInt32BigEndian(associatedDataRented.AsSpan(offset, 4), originalIndex);
+                                input.Slice(0, offset).CopyTo(output.Slice(0, offset));
+                                SRTP.Encryption.AEAD.Encrypt(context.PayloadAEAD, false, input.Slice(offset, length - 4 - mki.Length - offset), output.Slice(offset), outerIv, outerK_e, context.N_tag / 2, associatedDataRented.Slice(0, offset + 4));
+                                outputBufferLength = length - 4 - context.N_tag / 2 - mki.Length;
+                            }
+                            finally
+                            {
+                                ArrayPool<byte>.Shared.Return(associatedDataRented);
+                            }
                         }
                         break;
 
@@ -1169,7 +1333,9 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             }
             else
             {
-                outputBufferLength = length;
+                var dataLen = length - 4 - context.N_tag - mki.Length;
+                input.Slice(0, dataLen).CopyTo(output.Slice(0, dataLen));
+                outputBufferLength = dataLen;
             }
 
             return 0;
@@ -1216,8 +1382,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         /// </summary>
         public virtual bool IncrementMasterKeyUseCounter()
         {
-            long currentValue = Interlocked.Increment(ref _masterKeySentCounter);
-            long maxAllowedValue = _contextType == SrtpContextType.RTP ? 281474976710656L : 2147483648L;
+            var currentValue = Interlocked.Increment(ref _masterKeySentCounter);
+            var maxAllowedValue = _contextType == SrtpContextType.RTP ? 281474976710656L : 2147483648L;
             if (currentValue >= maxAllowedValue)
             {
                 OnRekeyingRequested?.Invoke(this, new EventArgs());

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -1248,7 +1248,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                     case SrtpCiphers.AES_128_F8:
                         {
                             var decLen = length - 4 - context.N_tag - mki.Length;
-                            var iv = SRTP.Encryption.F8.GenerateRtcpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, index);
+                            var iv = SRTP.Encryption.F8.GenerateRtcpMessageKeyIV(context.PayloadF8, context.K_e, context.K_s, input, originalIndex);
                             input.Slice(0, offset).CopyTo(output.Slice(0, offset));
                             SRTP.Encryption.F8.Encrypt(context.PayloadCTR, input.Slice(offset, decLen - offset), output.Slice(offset, decLen - offset), iv);
                             outputBufferLength = decLen;

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpKeys.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpKeys.cs
@@ -20,27 +20,41 @@
 // SOFTWARE.
 
 using System;
-using System.Linq;
 
 namespace SIPSorcery.Net.SharpSRTP.SRTP
 {
     public class SrtpKeys
     {
         public SrtpProtectionProfileConfiguration ProtectionProfile { get; }
-        public byte[] Mki { get; }
+        public ReadOnlyMemory<byte> Mki { get; }
 
-        public byte[] MasterKey { get { return MasterKeySalt.Take(ProtectionProfile.CipherKeyLength >> 3).ToArray(); } }
-        public byte[] MasterSalt { get { return MasterKeySalt.Skip(ProtectionProfile.CipherKeyLength >> 3).ToArray(); } }
-        public byte[] MasterKeySalt { get; }
+        public ReadOnlyMemory<byte> MasterKey { get; }
+        public ReadOnlyMemory<byte> MasterSalt { get; }
+        public ReadOnlyMemory<byte> MasterKeySalt { get; }
 
-        public SrtpKeys(SrtpProtectionProfileConfiguration protectionProfile, byte[] mki = null)
+        public SrtpKeys(SrtpProtectionProfileConfiguration protectionProfile, byte[] masterKeySalt, byte[] mki = default)
         {
-            this.ProtectionProfile = protectionProfile ?? throw new ArgumentNullException(nameof(protectionProfile));
-            this.Mki = mki;
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(protectionProfile);
+            this.ProtectionProfile = protectionProfile;
 
-            int cipherKeyLen = protectionProfile.CipherKeyLength >> 3;
-            int cipherSaltLen = protectionProfile.CipherSaltLength >> 3;
-            this.MasterKeySalt = new byte[cipherKeyLen + cipherSaltLen];
+            ArgumentNullException.ThrowIfNull(masterKeySalt);
+            this.MasterKeySalt = masterKeySalt.AsMemory();
+#else
+            this.ProtectionProfile = protectionProfile ?? throw new ArgumentNullException(nameof(protectionProfile));
+
+            this.MasterKeySalt = (masterKeySalt ?? throw new ArgumentNullException(nameof(masterKeySalt))).AsMemory();
+#endif
+
+            if (masterKeySalt.Length != (protectionProfile.CipherKeyLength + protectionProfile.CipherSaltLength) >> 3)
+            {
+                throw new ArgumentException($"'{masterKeySalt}' length does not match profile requirements", nameof(masterKeySalt));
+            }
+
+            MasterKey = MasterKeySalt.Slice(0, ProtectionProfile.CipherKeyLength >> 3);
+            MasterSalt = MasterKeySalt.Slice(ProtectionProfile.CipherKeyLength >> 3);
+
+            this.Mki = (mki ?? Array.Empty<byte>()).AsMemory();
         }
     }
 }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpProtocol.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpProtocol.cs
@@ -98,7 +98,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             if (useMasterKeySalt == null)
             {
                 // derive the master key + master salt to be sent in SDP crypto: attribute as per RFC 4568
-                masterKeySalt = new byte[masterKeyLen + masterSaltLen];
+                masterKeySalt = GC.AllocateUninitializedArray<byte>(masterKeyLen + masterSaltLen);
                 _rand.NextBytes(masterKeySalt);
             }
             else
@@ -106,8 +106,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 masterKeySalt = useMasterKeySalt;
             }
 
-            SrtpKeys keys = new SrtpKeys(srtpSecurityParams, mki);
-            Buffer.BlockCopy(masterKeySalt, 0, keys.MasterKeySalt, 0, masterKeySalt.Length);
+            SrtpKeys keys = new SrtpKeys(srtpSecurityParams, masterKeySalt, mki);
 
             return keys;
         }
@@ -119,7 +118,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 throw new ArgumentOutOfRangeException(nameof(length));
             }    
 
-            byte[] MKI = new byte[length];
+            byte[] MKI = GC.AllocateUninitializedArray<byte>(length);
             if (length > 0)
             {
                 // ensure positive value of the generated BigInteger

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpSessionContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpSessionContext.cs
@@ -19,6 +19,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 // SOFTWARE.
 
+#if NET8_0_OR_GREATER
+using ReadOnlyBytes = System.ReadOnlySpan<byte>;
+using Bytes = System.Span<byte>;
+#else
+using ReadOnlyBytes = System.ArraySegment<byte>;
+using Bytes = byte[];
+#endif
+
 namespace SIPSorcery.Net.SharpSRTP.SRTP
 {
     public class SrtpSessionContext : ISrtpContext
@@ -40,15 +48,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         {
             return EncodeRtpContext.CalculateRequiredSrtpPayloadLength(rtpLen);
         }
-
-        public int ProtectRtp(byte[] payload, int length, out int outputBufferLength)
+        public int ProtectRtp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
-            return EncodeRtpContext.ProtectRtp(payload, length, out outputBufferLength);
+            return EncodeRtpContext.ProtectRtp(input, output, out outputBufferLength);
         }
 
-        public int UnprotectRtp(byte[] payload, int length, out int outputBufferLength)
+        public int UnprotectRtp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
-            return DecodeRtpContext.UnprotectRtp(payload, length, out outputBufferLength);
+            return DecodeRtpContext.UnprotectRtp(input, output, out outputBufferLength);
         }
 
         public int CalculateRequiredSrtcpPayloadLength(int rtpLen)
@@ -56,14 +63,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             return EncodeRtcpContext.CalculateRequiredSrtcpPayloadLength(rtpLen);
         }
 
-        public int ProtectRtcp(byte[] payload, int length, out int outputBufferLength)
+        public int ProtectRtcp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
-            return EncodeRtcpContext.ProtectRtcp(payload, length, out outputBufferLength);
+            return EncodeRtcpContext.ProtectRtcp(input, output, out outputBufferLength);
         }
 
-        public int UnprotectRtcp(byte[] payload, int length, out int outputBufferLength)
+        public int UnprotectRtcp(ReadOnlyBytes input, Bytes output, out int outputBufferLength)
         {
-            return DecodeRtcpContext.UnprotectRtcp(payload, length, out outputBufferLength);
+            return DecodeRtcpContext.UnprotectRtcp(input, output, out outputBufferLength);
         }
     }
 }


### PR DESCRIPTION
Contains performance enhancements from SharpSRTP done by @paulomorgado and bugfixes:
[Add performance optimizations and benchmarking infrastructure](https://github.com/jimm98y/SharpSRTP/pull/4)
[Use AesUtilities.CreateEngine() instead of new AesEngine()](https://github.com/jimm98y/SharpSRTP/pull/5)
[perf: SIMD XOR vectorization and fix F8 block count bug](https://github.com/jimm98y/SharpSRTP/pull/6)
[perf: Separate input/output buffers, zero-copy optimizations, and pooled memory](https://github.com/jimm98y/SharpSRTP/pull/7)
[perf: Shared IV](https://github.com/jimm98y/SharpSRTP/pull/8)