### PR TITLE
Fix RTP header extension length calculation (RFC 3550 compliance)

### DIFF
--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtpReader.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtpReader.cs
@@ -45,8 +45,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Readers
             int length = ReadHeaderLenWithoutExtensions(payload);
             if ((payload[0] & 0x10) == 0x10)
             {
-                var extensionsCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(payload.Slice(length + 2, 2));
-                return 4 + (extensionsCount * 4);
+                var extensionLengthWords = System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(payload.Slice(length + 2, 2));
+                return 4 + (extensionLengthWords * 4);
             }
             return 0;
         }

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtpReader.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/Readers/RtpReader.cs
@@ -45,12 +45,10 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP.Readers
             int length = ReadHeaderLenWithoutExtensions(payload);
             if ((payload[0] & 0x10) == 0x10)
             {
-                return 4 + System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(payload.Slice(length + 2, 2));
+                var extensionsCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(payload.Slice(length + 2, 2));
+                return 4 + (extensionsCount * 4);
             }
-            else
-            {
-                return 0;
-            }
+            return 0;
         }
 
         public static int ReadHeaderLenWithoutExtensions(ReadOnlySpan<byte> payload)


### PR DESCRIPTION
- The extension length field specifies the number of 32-bit words, not bytes
- Multiply the length field by 4 to convert from 32-bit words to bytes

https://datatracker.ietf.org/doc/html/rfc3550#section-5.3.1