### PR TITLE
Fix SortMediaCapability offerer-priority track inversion

### DIFF
--- a/src/SIPSorcery/net/RTP/RTPSession.cs
+++ b/src/SIPSorcery/net/RTP/RTPSession.cs
@@ -1218,8 +1218,10 @@ namespace SIPSorcery.Net
                         capabilities = SDPAudioVideoMediaFormat.GetCompatibleFormats(currentMediaStream.RemoteTrack?.Capabilities, currentMediaStream.LocalTrack?.Capabilities);
 
                         // The offerer gets to set the codec priority.
+                        // When receiving an offer: the REMOTE party is the offerer, so their Capabilities are the priority key.
+                        // When receiving an answer: LOCAL is the offerer (we sent the offer), so our Capabilities are the priority key.
                         SDPAudioVideoMediaFormat.SortMediaCapability(capabilities,
-                            sdpType == SdpType.offer ? currentMediaStream.LocalTrack?.Capabilities : currentMediaStream.RemoteTrack?.Capabilities);
+                            sdpType == SdpType.offer ? currentMediaStream.RemoteTrack?.Capabilities : currentMediaStream.LocalTrack?.Capabilities);
 
                         currentMediaStream.LocalTrack.Capabilities = capabilities;
                         currentMediaStream.RemoteTrack.Capabilities = capabilities;


### PR DESCRIPTION
## Summary

The ternary in `RTPSession.SetRemoteDescription` passing the priority-order key to `SDPAudioVideoMediaFormat.SortMediaCapability` is flipped relative to the comment above it (`// The offerer gets to set the codec priority.`). The current code picks the answerer's track on both branches:

- Receiving offer: uses `LocalTrack` (receiver is local; offerer is REMOTE)
- Receiving answer: uses `RemoteTrack` (answerer is remote; offerer is LOCAL)

Flipping the branches makes the behavior match the comment.

## Repro

Two `RTCPeerConnection` peers with identical audio Capabilities `[Opus, PCMU, PCMA, G722]` (Opus first). Standard offer -> setRemote -> answer -> setRemote. `OnAudioFormatsNegotiated` before this fix reports `PCMU 8 kHz mono` on the offerer and `OPUS 48 kHz stereo` on the answerer from the same negotiation. After the fix both report `OPUS 48 kHz stereo`.

Found while wiring a local Opus audio source into a desktop WebRTC app; any consumer that binds an encoder to a codec-specific sample rate (Opus 48 kHz vs PCMU 8 kHz) ends up dropping frames on the offerer side when the two peers disagree.

Happy to add a cross-peer-consistency test under `test/unit/` in a follow-up commit if you'd like - point me at the closest existing pattern.

Debugged with Claude (Anthropic) as pair-programming assist. Credits: LostBeard (Todd Tanner) + Claude Opus 4.7.