### PR TITLE
Fix SctpDataSender lost-wakeup race (60x loopback throughput win)

### DIFF
--- a/src/SIPSorcery/net/SCTP/SctpDataSender.cs
+++ b/src/SIPSorcery/net/SCTP/SctpDataSender.cs
@@ -526,6 +526,19 @@ namespace SIPSorcery.Net
 
             while (!_isClosed)
             {
+                // Reset the sender wake event at the START of each iteration. Resetting
+                // AFTER the send work introduces a lost-wakeup race with SACK arrival:
+                // a SACK that fires _senderMre.Set() between the last chunk sent and
+                // the Reset() gets its signal wiped by Reset(), and the thread then
+                // blocks in _senderMre.Wait() for the full BURST_PERIOD_MILLISECONDS
+                // even though more work is ready to go. On loopback where SACKs
+                // round-trip in microseconds this window is hit almost every burst,
+                // capping throughput at the RFC4960 §7.2.2 steady-state of roughly
+                // MAX_BURST * MTU / BURST_PERIOD (~104 KB/s for MTU=1300, period=50ms).
+                // Resetting first preserves any Set() that happens during send work so
+                // Wait() returns immediately on the next iteration.
+                _senderMre.Reset();
+
                 var outstandingBytes = _outstandingBytes;
                 // DateTime.Now calls have been a tiny bit expensive in the past so get a small saving by only
                 // calling once per loop.
@@ -614,8 +627,6 @@ namespace SIPSorcery.Net
                         chunksSent++;
                     }
                 }
-
-                _senderMre.Reset();
 
                 int wait = GetSendWaitMilliseconds();
                 //logger.LogTrace($"SCTP sender wait period {wait}ms, arwnd {_receiverWindow}, cwnd {_congestionWindow} " +

--- a/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
@@ -15,7 +15,9 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
@@ -88,6 +90,75 @@ namespace SIPSorcery.Net.UnitTests
             await Task.Delay(100);
 
             Assert.True(sender._congestionWindow < sender._outstandingBytes);
+        }
+
+        /// <summary>
+        /// Regression test for the DoSend Reset-race (producer-consumer lost-wakeup).
+        /// Before the fix, <c>_senderMre.Reset()</c> ran AFTER the send work, so any
+        /// <c>Set()</c> fired by an incoming SACK in the window between the last chunk
+        /// sent and the Reset was wiped, and the thread blocked for the full
+        /// <see cref="SctpDataSender.BURST_PERIOD_MILLISECONDS"/> (50 ms) before noticing
+        /// more cwnd was available. This capped throughput at
+        /// <c>MAX_BURST * MTU / BURST_PERIOD = 4 * 1300 / 50 ms = 104 KB/s</c> even on
+        /// localhost loopback where SACKs round-trip in microseconds.
+        ///
+        /// With the fix (Reset moved to the TOP of the loop, preserving Set-during-send
+        /// for the next Wait), 500 KB ships in well under 500 ms on any reasonable
+        /// machine - the bottleneck becomes the ManualResetEventSlim wake latency
+        /// (sub-millisecond), not the 50 ms burst period.
+        ///
+        /// Pre-fix expected: 500 KB / 104 KB/s = ~4800 ms + slow-start ramp = ~5+ seconds.
+        /// Post-fix expected: under 500 ms.
+        /// Threshold set at 2000 ms to leave slack for CI jitter while still proving
+        /// we're not on the broken 100-KB/s ceiling.
+        /// </summary>
+        [Fact]
+        public async Task Throughput_FastSackWake_ExceedsBurstCeiling()
+        {
+            uint arwnd = SctpAssociation.DEFAULT_ADVERTISED_RECEIVE_WINDOW;
+            ushort mtu = 1400;
+            uint initialTSN = 0;
+
+            SctpDataReceiver receiver = new SctpDataReceiver(arwnd, mtu, initialTSN);
+            SctpDataSender sender = new SctpDataSender("throughput-probe", null, mtu, initialTSN, arwnd);
+
+            // Deliver data + SACK synchronously on the sender's own DoSend thread - the
+            // worst case for the Reset race, because the SACK's Set() fires BEFORE the
+            // Reset that wiped it pre-fix.
+            Action<SctpDataChunk> doSend = (chunk) =>
+            {
+                receiver.OnDataChunk(chunk);
+                sender.GotSack(receiver.GetSackChunk());
+            };
+            sender._sendDataChunk = doSend;
+            sender.StartSending();
+
+            // 360 chunks of 1400 bytes = 504 KB. Large enough to exit slow-start and
+            // enter the steady-state where the race would dominate, small enough that
+            // a fast machine finishes in milliseconds.
+            const int chunksToSend = 360;
+            var buffer = new byte[mtu];
+
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < chunksToSend; i++)
+            {
+                sender.SendData(0, 0, buffer);
+            }
+
+            // Wait for all chunks to be acknowledged by the receiver.
+            uint expectedAckTSN = (uint)(chunksToSend - 1);
+            while (receiver.CumulativeAckTSN != expectedAckTSN && sw.ElapsedMilliseconds < 10000)
+            {
+                await Task.Delay(5);
+            }
+            sw.Stop();
+
+            Assert.Equal(expectedAckTSN, receiver.CumulativeAckTSN);
+            Assert.True(sw.ElapsedMilliseconds < 2000,
+                $"Throughput regression: {chunksToSend * mtu} bytes took {sw.ElapsedMilliseconds} ms " +
+                $"(effective {(double)(chunksToSend * mtu) / sw.ElapsedMilliseconds:F1} KB/s). " +
+                $"Expected under 2000 ms with SACK-wake race fix. Pre-fix throughput is " +
+                $"capped at ~104 KB/s by the Reset race, giving ~{chunksToSend * mtu / 104} ms.");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`SctpDataSender.DoSend` had a producer-consumer lost-wakeup race. `_senderMre.Reset()` was called AFTER the send work and BEFORE `Wait(burstPeriod)`. A SACK arriving on a different thread between the last chunk sent and the Reset would fire `_senderMre.Set()`, which Reset then wiped, and the sender thread blocked for the full `BURST_PERIOD_MILLISECONDS` (50 ms default) even though more cwnd was available.

On localhost loopback this capped throughput at roughly `MAX_BURST * MTU / BURST_PERIOD` (~104 KB/s for MTU=1300, period=50 ms) instead of the much higher rate the link could sustain.

## Fix

One-line conceptual change: move `_senderMre.Reset()` to the TOP of the loop so any `Set()` fired during send work is preserved through to the next `Wait()`. RFC 4960 §7.2.2 defaults (MAX_BURST, BURST_PERIOD_MILLISECONDS) unchanged.

## Measurement

New regression test `SctpDataSenderUnitTest.Throughput_FastSackWake_ExceedsBurstCeiling` sends 360 × 1400-byte chunks (504 KB) with synchronous SACK delivery on the sender thread and asserts completion under 2 s:

| | Time | Throughput |
|---|---|---|
| Pre-fix | 5613 ms | 89.8 KB/s |
| Post-fix | 94 ms | 5.4 MB/s |

**~60× speedup.** Pre-fix test fails at the 2000 ms threshold; post-fix passes with ~20× headroom.

Verified by reverting the fix temporarily, running the new test (fails as predicted at the theoretical ceiling), and re-applying (passes). The failure numbers line up exactly with `MAX_BURST * MTU / BURST_PERIOD = 4 * 1300 / 50ms ≈ 104 KB/s`, confirming the race window dominates on fast-SACK paths.

## Scope + compatibility

- Touches only `src/SIPSorcery/net/SCTP/SctpDataSender.cs` (Reset moved) and `test/unit/net/SCTP/SctpDataSenderUnitTest.cs` (regression test added).
- No behavior change on long-haul or lossy links where the `MAX_BURST * MTU / RTT` bound already dominates.
- Existing `SctpData*` tests still pass (53/55; the 2 skips are pre-existing CI-flake skips unrelated to this change).
- `_senderMre.Reset()` at loop-top briefly has a tiny race vs Set firing between Wait return and Reset, but that's unavoidable with MRE and only costs one extra work iteration (which was going to happen anyway) — strict improvement over the original race which cost a full 50 ms timeout.

## Context

This issue was discovered while stress-testing SipSorcery-backed WebRTC data channels inside [SpawnDev.ILGPU.P2P](https://github.com/LostBeard/SpawnDev.ILGPU) (a distributed-GPU-compute project). Throughput over a local-loopback 10 MB tensor transfer was capped at ~77 KB/s before this fix lands at ~5 MB/s after. Diagnostic credit to Geordi (one of the crew AI agents on the LostBeard team) who traced the ceiling to `SctpDataSender.cs` line by line before handing it off. Fix authored and verified by LostBeard with AI-assisted code review from Riker (another crew AI agent).