### PR TITLE
VP8 encoder foundation: quantizer table builder (PR 5 of N)

### DIFF
--- a/src/VP8.Net/quantizer_init.cs
+++ b/src/VP8.Net/quantizer_init.cs
@@ -1,0 +1,187 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: quantizer_init.cs
+//
+// Description: Quantizer-table builder for the VP8 encoder. Port of the
+// inner loop of libvpx vp8cx_init_quantizer (vp8/encoder/vp8_quantize.c)
+// + the supporting invert_quant helper. Given a base Q index in [0..127]
+// (and optional dc/ac quantizer deltas), produces the six 16-element
+// per-block-type tables (zbin, round, quant, quant_shift, dequant,
+// zrun_zbin_boost) the encoder needs for Y1, Y2, and UV transforms.
+//
+// libvpx caches the build for all 128 Q indices at once; this port
+// builds a single Q's tables on demand. The numerical output is
+// bit-exactly the same as libvpx's improved-quant path (the default).
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 25 Apr 2026  Claude          Ported from libvpx vp8/encoder/vp8_quantize.c.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+/*
+ *  Copyright (c) 2010 The WebM project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+using System;
+
+namespace Vpx.Net
+{
+    /// <summary>
+    /// One block-type's quantizer arrays (16 elements each, raster order).
+    /// Mirrors the per-Q slice of libvpx's Y1quant/Y1zbin/etc. table.
+    /// </summary>
+    public sealed class QuantizerTables
+    {
+        public short[] zbin = new short[16];
+        public short[] round = new short[16];
+        public short[] quant = new short[16];
+        public short[] quant_shift = new short[16];
+        public short[] dequant = new short[16];
+        public short[] zrun_zbin_boost = new short[16];
+    }
+
+    /// <summary>
+    /// All three block-type quantizer-table sets for a given Q index.
+    /// </summary>
+    public sealed class FrameQuantizer
+    {
+        public QuantizerTables Y1;
+        public QuantizerTables Y2;
+        public QuantizerTables UV;
+    }
+
+    public static class quantizer_init
+    {
+        // -- Constants from libvpx/vp8/encoder/vp8_quantize.c ---------------
+
+        // Per-zig-zag-position zbin boost: when no non-zero coefficient has
+        // been seen yet within a zero-run, the threshold for the next
+        // coefficient is bumped by zbin_boost[run_length] * dequant[1] >> 7.
+        // Identical for Y1/Y2/UV.
+        private static readonly int[] s_zbinBoost = {
+            0, 0, 8, 10, 12, 14, 16, 20, 24, 28, 32, 36, 40, 44, 44, 44,
+        };
+
+        // qrounding_factors / qzbin_factors (libvpx). 129 entries; the
+        // encoder only ever uses indices 0..127. The Y2 variants are
+        // identical in libvpx so they're shared here.
+        private static readonly int[] s_qroundingFactors = MakeFlat129(48);
+
+        private static readonly int[] s_qzbinFactors = MakeQzbinFactors();
+
+        private static int[] MakeFlat129(int v)
+        {
+            var a = new int[129];
+            for (int i = 0; i < 129; i++) a[i] = v;
+            return a;
+        }
+
+        private static int[] MakeQzbinFactors()
+        {
+            // 84 for QIndex < 48, 80 for QIndex >= 48 (extends to 128).
+            var a = new int[129];
+            for (int i = 0; i < 48; i++) a[i] = 84;
+            for (int i = 48; i < 129; i++) a[i] = 80;
+            return a;
+        }
+
+        // -- invert_quant -------------------------------------------------
+
+        /// <summary>
+        /// Bit-exact port of libvpx invert_quant in its "improved_quant"
+        /// branch (the default). For dequant value <paramref name="d"/>,
+        /// produces a (quant, shift) pair such that
+        ///     y = (((x * quant) >> 16) + x) * shift) >> 16
+        /// computes the same x/d division libvpx's regular_quantize_b uses.
+        /// </summary>
+        public static void InvertQuant(short d, out short quant, out short shift)
+        {
+            int t = d;
+            int l;
+            for (l = 0; t > 1; l++) t >>= 1;
+            int m = 1 + (1 << (16 + l)) / d;
+            quant = (short)(m - (1 << 16));
+            shift = (short)(1 << (16 - l));
+        }
+
+        // -- Per-block-type build ----------------------------------------
+
+        /// <summary>
+        /// Build a single block-type's quantizer arrays for the given Q
+        /// index, using the supplied DC and AC dequant lookups.
+        /// </summary>
+        private static QuantizerTables BuildOne(int Q, int dcDelta, int acDelta,
+            Func<int, int, int> dcLookup, Func<int, int, int> acLookup)
+        {
+            var t = new QuantizerTables();
+
+            // Position 0 is the DC coefficient.
+            int qval = dcLookup(Q, dcDelta);
+            InvertQuant((short)qval, out t.quant[0], out t.quant_shift[0]);
+            t.zbin[0] = (short)(((s_qzbinFactors[Q] * qval) + 64) >> 7);
+            t.round[0] = (short)((s_qroundingFactors[Q] * qval) >> 7);
+            t.dequant[0] = (short)qval;
+            t.zrun_zbin_boost[0] = (short)((qval * s_zbinBoost[0]) >> 7);
+
+            // Position 1 is the first AC coefficient. Positions 2..15
+            // share the same quant/shift/zbin/round/dequant as position 1
+            // but get their own zrun_zbin_boost.
+            qval = acLookup(Q, acDelta);
+            InvertQuant((short)qval, out t.quant[1], out t.quant_shift[1]);
+            t.zbin[1] = (short)(((s_qzbinFactors[Q] * qval) + 64) >> 7);
+            t.round[1] = (short)((s_qroundingFactors[Q] * qval) >> 7);
+            t.dequant[1] = (short)qval;
+            t.zrun_zbin_boost[1] = (short)((qval * s_zbinBoost[1]) >> 7);
+
+            for (int i = 2; i < 16; i++)
+            {
+                t.quant[i] = t.quant[1];
+                t.quant_shift[i] = t.quant_shift[1];
+                t.zbin[i] = t.zbin[1];
+                t.round[i] = t.round[1];
+                t.dequant[i] = t.dequant[1];
+                t.zrun_zbin_boost[i] = (short)((t.dequant[1] * s_zbinBoost[i]) >> 7);
+            }
+            return t;
+        }
+
+        /// <summary>
+        /// Build the full Y1/Y2/UV quantizer-table set for the given Q
+        /// index and quantizer deltas. Use deltas of 0 for the simple
+        /// keyframe-only encoder; the deltas are written into the
+        /// compressed frame header by bitstream.StartKeyframeHeader.
+        /// </summary>
+        public static FrameQuantizer BuildForQIndex(
+            int qIndex,
+            int y1dcDelta = 0,
+            int y2dcDelta = 0, int y2acDelta = 0,
+            int uvdcDelta = 0, int uvacDelta = 0)
+        {
+            if (qIndex < 0 || qIndex > 127)
+                throw new ArgumentOutOfRangeException(nameof(qIndex), qIndex, "Q index must be 0..127.");
+
+            return new FrameQuantizer
+            {
+                Y1 = BuildOne(qIndex, y1dcDelta, 0,
+                    quant_common.vp8_dc_quant,
+                    (q, _) => quant_common.vp8_ac_yquant(q)),
+                Y2 = BuildOne(qIndex, y2dcDelta, y2acDelta,
+                    quant_common.vp8_dc2quant,
+                    quant_common.vp8_ac2quant),
+                UV = BuildOne(qIndex, uvdcDelta, uvacDelta,
+                    quant_common.vp8_dc_uv_quant,
+                    quant_common.vp8_ac_uv_quant),
+            };
+        }
+    }
+}

--- a/test/VP8.Net.UnitTest/quantizer_init_unittest.cs
+++ b/test/VP8.Net.UnitTest/quantizer_init_unittest.cs
@@ -1,0 +1,196 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: quantizer_init_unittest.cs
+//
+// Description: Unit tests for the VP8 quantizer-table builder (encoder side,
+// quantizer_init.cs). Cross-checks each of the six 16-element tables
+// (zbin, round, quant, quant_shift, dequant, zrun_zbin_boost) bit-exactly
+// against libvpx's vp8cx_init_quantizer for every block type (Y1, Y2, UV).
+//
+// Reference output captured from a standalone build of libvpx's
+// vp8cx_init_quantizer + invert_quant for two representative Q indices
+// (32 = mid quality, 100 = low quality). Any divergence indicates a bug
+// in the C# port.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 25 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public class quantizer_init_unittest
+    {
+        // ------- libvpx reference values for QIndex = 32, all deltas = 0 -------
+
+        private static readonly short[] s_q32_y1_zbin   = { 19,24,24,24,24,24,24,24, 24,24,24,24,24,24,24,24 };
+        private static readonly short[] s_q32_y1_round  = { 10,13,13,13,13,13,13,13, 13,13,13,13,13,13,13,13 };
+        private static readonly short[] s_q32_y1_quant  = { -29378,-7281,-7281,-7281,-7281,-7281,-7281,-7281, -7281,-7281,-7281,-7281,-7281,-7281,-7281,-7281 };
+        private static readonly short[] s_q32_y1_qshift = { 4096,2048,2048,2048,2048,2048,2048,2048, 2048,2048,2048,2048,2048,2048,2048,2048 };
+        private static readonly short[] s_q32_y1_dequant= { 29,36,36,36,36,36,36,36, 36,36,36,36,36,36,36,36 };
+        private static readonly short[] s_q32_y1_zrun   = { 0,0,2,2,3,3,4,5, 6,7,9,10,11,12,12,12 };
+
+        private static readonly short[] s_q32_y2_zbin   = { 38,36,36,36,36,36,36,36, 36,36,36,36,36,36,36,36 };
+        private static readonly short[] s_q32_y2_round  = { 21,20,20,20,20,20,20,20, 20,20,20,20,20,20,20,20 };
+        private static readonly short[] s_q32_y2_quant  = { -29378,-27405,-27405,-27405,-27405,-27405,-27405,-27405, -27405,-27405,-27405,-27405,-27405,-27405,-27405,-27405 };
+        private static readonly short[] s_q32_y2_qshift = { 2048,2048,2048,2048,2048,2048,2048,2048, 2048,2048,2048,2048,2048,2048,2048,2048 };
+        private static readonly short[] s_q32_y2_dequant= { 58,55,55,55,55,55,55,55, 55,55,55,55,55,55,55,55 };
+        private static readonly short[] s_q32_y2_zrun   = { 0,0,3,4,5,6,6,8, 10,12,13,15,17,18,18,18 };
+
+        private static readonly short[] s_q32_uv_zbin   = { 19,24,24,24,24,24,24,24, 24,24,24,24,24,24,24,24 };
+        private static readonly short[] s_q32_uv_round  = { 10,13,13,13,13,13,13,13, 13,13,13,13,13,13,13,13 };
+        private static readonly short[] s_q32_uv_quant  = { -29378,-7281,-7281,-7281,-7281,-7281,-7281,-7281, -7281,-7281,-7281,-7281,-7281,-7281,-7281,-7281 };
+        private static readonly short[] s_q32_uv_qshift = { 4096,2048,2048,2048,2048,2048,2048,2048, 2048,2048,2048,2048,2048,2048,2048,2048 };
+        private static readonly short[] s_q32_uv_dequant= { 29,36,36,36,36,36,36,36, 36,36,36,36,36,36,36,36 };
+        private static readonly short[] s_q32_uv_zrun   = { 0,0,2,2,3,3,4,5, 6,7,9,10,11,12,12,12 };
+
+        // ------- libvpx reference values for QIndex = 100, all deltas = 0 -------
+
+        private static readonly short[] s_q100_y1_zbin   = { 61,104,104,104,104,104,104,104, 104,104,104,104,104,104,104,104 };
+        private static readonly short[] s_q100_y1_round  = { 36,62,62,62,62,62,62,62, 62,62,62,62,62,62,62,62 };
+        private static readonly short[] s_q100_y1_quant  = { -22736,-15304,-15304,-15304,-15304,-15304,-15304,-15304, -15304,-15304,-15304,-15304,-15304,-15304,-15304,-15304 };
+        private static readonly short[] s_q100_y1_qshift = { 1024,512,512,512,512,512,512,512, 512,512,512,512,512,512,512,512 };
+        private static readonly short[] s_q100_y1_dequant= { 98,167,167,167,167,167,167,167, 167,167,167,167,167,167,167,167 };
+        private static readonly short[] s_q100_y1_zrun   = { 0,0,10,13,15,18,20,26, 31,36,41,46,52,57,57,57 };
+
+        private static readonly short[] s_q100_y2_zbin   = { 123,161,161,161,161,161,161,161, 161,161,161,161,161,161,161,161 };
+        private static readonly short[] s_q100_y2_round  = { 73,96,96,96,96,96,96,96, 96,96,96,96,96,96,96,96 };
+        private static readonly short[] s_q100_y2_quant  = { -22736,-508,-508,-508,-508,-508,-508,-508, -508,-508,-508,-508,-508,-508,-508,-508 };
+        private static readonly short[] s_q100_y2_qshift = { 512,256,256,256,256,256,256,256, 256,256,256,256,256,256,256,256 };
+        private static readonly short[] s_q100_y2_dequant= { 196,258,258,258,258,258,258,258, 258,258,258,258,258,258,258,258 };
+        private static readonly short[] s_q100_y2_zrun   = { 0,0,16,20,24,28,32,40, 48,56,64,72,80,88,88,88 };
+
+        private static readonly short[] s_q100_uv_zbin   = { 61,104,104,104,104,104,104,104, 104,104,104,104,104,104,104,104 };
+        private static readonly short[] s_q100_uv_round  = { 36,62,62,62,62,62,62,62, 62,62,62,62,62,62,62,62 };
+        private static readonly short[] s_q100_uv_quant  = { -22736,-15304,-15304,-15304,-15304,-15304,-15304,-15304, -15304,-15304,-15304,-15304,-15304,-15304,-15304,-15304 };
+        private static readonly short[] s_q100_uv_qshift = { 1024,512,512,512,512,512,512,512, 512,512,512,512,512,512,512,512 };
+        private static readonly short[] s_q100_uv_dequant= { 98,167,167,167,167,167,167,167, 167,167,167,167,167,167,167,167 };
+        private static readonly short[] s_q100_uv_zrun   = { 0,0,10,13,15,18,20,26, 31,36,41,46,52,57,57,57 };
+
+        // ---------- bit-exact reference checks ----------
+
+        [Fact]
+        public void BuildForQIndex_32_Y1_MatchesLibvpxReference()
+        {
+            var q = quantizer_init.BuildForQIndex(32);
+            AssertTablesMatch("Y1@Q32", q.Y1, s_q32_y1_zbin, s_q32_y1_round, s_q32_y1_quant, s_q32_y1_qshift, s_q32_y1_dequant, s_q32_y1_zrun);
+        }
+
+        [Fact]
+        public void BuildForQIndex_32_Y2_MatchesLibvpxReference()
+        {
+            var q = quantizer_init.BuildForQIndex(32);
+            AssertTablesMatch("Y2@Q32", q.Y2, s_q32_y2_zbin, s_q32_y2_round, s_q32_y2_quant, s_q32_y2_qshift, s_q32_y2_dequant, s_q32_y2_zrun);
+        }
+
+        [Fact]
+        public void BuildForQIndex_32_UV_MatchesLibvpxReference()
+        {
+            var q = quantizer_init.BuildForQIndex(32);
+            AssertTablesMatch("UV@Q32", q.UV, s_q32_uv_zbin, s_q32_uv_round, s_q32_uv_quant, s_q32_uv_qshift, s_q32_uv_dequant, s_q32_uv_zrun);
+        }
+
+        [Fact]
+        public void BuildForQIndex_100_Y1_MatchesLibvpxReference()
+        {
+            var q = quantizer_init.BuildForQIndex(100);
+            AssertTablesMatch("Y1@Q100", q.Y1, s_q100_y1_zbin, s_q100_y1_round, s_q100_y1_quant, s_q100_y1_qshift, s_q100_y1_dequant, s_q100_y1_zrun);
+        }
+
+        [Fact]
+        public void BuildForQIndex_100_Y2_MatchesLibvpxReference()
+        {
+            var q = quantizer_init.BuildForQIndex(100);
+            AssertTablesMatch("Y2@Q100", q.Y2, s_q100_y2_zbin, s_q100_y2_round, s_q100_y2_quant, s_q100_y2_qshift, s_q100_y2_dequant, s_q100_y2_zrun);
+        }
+
+        [Fact]
+        public void BuildForQIndex_100_UV_MatchesLibvpxReference()
+        {
+            var q = quantizer_init.BuildForQIndex(100);
+            AssertTablesMatch("UV@Q100", q.UV, s_q100_uv_zbin, s_q100_uv_round, s_q100_uv_quant, s_q100_uv_qshift, s_q100_uv_dequant, s_q100_uv_zrun);
+        }
+
+        // ---------- integration check: produced tables drive the existing quantize ----------
+
+        /// <summary>
+        /// The whole point of these tables is that they feed
+        /// quantize.vp8_regular_quantize_b_arrays. This test verifies that
+        /// when we plug the tables built for Q=32 into the quantizer with a
+        /// known coefficient block, the output qcoeff and dqcoeff are
+        /// numerically consistent (every dqcoeff[i] = qcoeff[i] * dequant[i],
+        /// and the quantize-then-dequantize round-trip is bounded by the
+        /// quantization step).
+        /// </summary>
+        [Fact]
+        public unsafe void Tables_DriveQuantizerCorrectly_ForKnownCoeffBlock()
+        {
+            var q = quantizer_init.BuildForQIndex(32);
+            // Use Y1 for an AC-style block.
+            var t = q.Y1;
+
+            // A representative coefficient block (results of an fdct).
+            short[] coeff = { 256, 1, 0, 0,  18, 0, -32, 0,  0, 0, 0, 0,  0, 0, 0, 0 };
+            short[] qcoeff = new short[16];
+            short[] dqcoeff = new short[16];
+
+            int eob;
+            fixed (short* coefP = coeff)
+            fixed (short* zbinP = t.zbin)
+            fixed (short* zboostP = t.zrun_zbin_boost)
+            fixed (short* roundP = t.round)
+            fixed (short* quantP = t.quant)
+            fixed (short* quantShiftP = t.quant_shift)
+            fixed (short* dequantP = t.dequant)
+            fixed (short* qcoeffP = qcoeff)
+            fixed (short* dqcoeffP = dqcoeff)
+            {
+                eob = quantize.vp8_regular_quantize_b_arrays(
+                    coefP, zbinP, zboostP, roundP, quantP, quantShiftP, dequantP,
+                    qcoeffP, dqcoeffP, zbin_extra: 0);
+            }
+
+            // Internal consistency: every dqcoeff[i] must equal qcoeff[i] * dequant[i].
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Equal(qcoeff[i] * t.dequant[i], dqcoeff[i]);
+            }
+
+            // The DC coefficient (256) is well above zbin[0] (=19) so it
+            // must round-trip to within one dequantizer step.
+            Assert.True(System.Math.Abs(dqcoeff[0] - coeff[0]) <= t.dequant[0],
+                "DC reconstruction exceeded one quantizer step");
+            // Block must have at least one non-zero coefficient.
+            Assert.True(eob > 0);
+        }
+
+        // ---------- helper ----------
+
+        private static void AssertTablesMatch(string label, QuantizerTables t,
+            short[] zbin, short[] round, short[] quant, short[] qshift, short[] dequant, short[] zrun)
+        {
+            AssertArr(label + ".zbin", zbin, t.zbin);
+            AssertArr(label + ".round", round, t.round);
+            AssertArr(label + ".quant", quant, t.quant);
+            AssertArr(label + ".quant_shift", qshift, t.quant_shift);
+            AssertArr(label + ".dequant", dequant, t.dequant);
+            AssertArr(label + ".zrun_zbin_boost", zrun, t.zrun_zbin_boost);
+        }
+
+        private static void AssertArr(string name, short[] expected, short[] actual)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.True(expected[i] == actual[i],
+                    name + "[" + i + "]: expected " + expected[i] + " got " + actual[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## VP8 encoder foundation (PR 5 of N): quantizer table builder

Continues the encoder series. This PR adds `quantizer_init.BuildForQIndex` — the function that turns a base Q index in [0..127] into the per-block-type quantizer arrays the encoder needs. With this in place, the per-MB encode pipeline (PR 6) and the frame orchestration (PR 7) have all the table data they need.

### What's in this PR

`src/VP8.Net/quantizer_init.cs`:

- **`InvertQuant(short d, out short quant, out short shift)`** — bit-exact port of libvpx's `invert_quant` improved-quant branch (the default). Produces the (quant, shift) pair the multiplicative quantizer uses to compute `x / d`.
- **`QuantizerTables`** — one block-type's 16-element arrays: `zbin`, `round`, `quant`, `quant_shift`, `dequant`, `zrun_zbin_boost`. Mirrors a per-Q slice of libvpx's `Y1quant`/`Y1zbin`/etc.
- **`FrameQuantizer`** — the `{ Y1, Y2, UV }` triple a single frame uses.
- **`BuildForQIndex(qIndex, …deltas…)`** — the main entry point: ports the inner loop of `vp8cx_init_quantizer`, building the three table sets on demand for one Q index instead of caching all 128.

The lookups (`vp8_dc_quant`, `vp8_ac_yquant`, `vp8_dc2quant`, `vp8_ac2quant`, `vp8_dc_uv_quant`, `vp8_ac_uv_quant`, `dc_qlookup`, `ac_qlookup`) were already shipped on the decoder side as `quant_common.cs` and are reused as-is.

### Tests

**7 new tests, all passing on first run:**

- **6 bit-exact reference checks** against libvpx `vp8cx_init_quantizer` output for `{ Y1, Y2, UV } × { Q=32, Q=100 }`. Every entry of every table (`zbin`, `round`, `quant`, `quant_shift`, `dequant`, `zrun_zbin_boost`) must match. Reference captured by compiling `vp8cx_init_quantizer + invert_quant` standalone in the sandbox.
- **1 integration check** that the produced `Y1@Q=32` tables drive the existing `quantize.vp8_regular_quantize_b_arrays` correctly: `dqcoeff[i] = qcoeff[i] * dequant[i]` for every `i`, and the DC coefficient reconstructs within one quantizer step.

### What's NOT in this PR

- Per-MB encode pipeline (intra DC_PRED + transform + quantize + tokenize) — **PR 6**.
- Frame orchestration + `VP8Codec.EncodeVideo` wire-up + round-trip test — **PR 7**.

### Verification

- `dotnet build` clean.
- All 7 new tests green.
- Pre-existing GDI+/Bitmap failures in `VP8CodecUnitTest`/`vpx_decoder_unittest` are Windows-only and unrelated to this PR.

### Author attribution

New files credit Claude (model: `claude-opus-4-7`) per the convention from #1562.
