### PR TITLE
VP8 encoder foundation: per-macroblock encode pipeline (PR 6 of N)

### DIFF
--- a/src/VP8.Net/mb_encoder.cs
+++ b/src/VP8.Net/mb_encoder.cs
@@ -1,0 +1,420 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: mb_encoder.cs
+//
+// Description: Per-macroblock encode pipeline for an intra-only DC_PRED
+// VP8 keyframe. This is the orchestrator that ties together everything
+// the previous PRs in the foundation series shipped:
+//
+//   - DC_PRED prediction (port of vp8/common/reconintra.c, just the
+//     16x16 and 8x8 DC paths — written here for clarity rather than
+//     pulling in the decoder's intraped.cs which wraps a fuller mode
+//     dispatcher).
+//   - Forward DCT + Walsh                 (PR 1, dct.cs)
+//   - Quantize (regular_quantize_b)       (PR 1, quantize.cs)
+//   - Coefficient tokenizer               (PR 3, tokenize.cs)
+//   - Reconstruction (dequantize + idct)  (existing dequantize.cs +
+//     idctllm.cs from the decoder side)
+//
+// What's implemented here is one function: EncodeMacroblockDcPred. It
+// consumes a 16x16 source luma plane + two 8x8 source chroma planes
+// for one macroblock, plus the 1-row-above-and-1-column-left context
+// bytes, and produces:
+//   - A 25-element TOKENEXTRA list[] (1 Y2 + 16 Y + 4 U + 4 V).
+//   - A reconstructed copy of the macroblock (the bytes the decoder
+//     would produce given the same bitstream).
+//
+// The function does NOT write any bits — that's PR 7's job. It also
+// does NOT perform mode picking; the choice of DC_PRED is fixed.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 25 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+/*
+ *  Copyright (c) 2010 The WebM project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Vpx.Net
+{
+    /// <summary>
+    /// Single-macroblock encode result: token streams (one list per of the
+    /// 25 transformed blocks the decoder reconstructs) plus the
+    /// reconstructed macroblock pixels.
+    ///
+    /// Block ordering matches libvpx's MACROBLOCK.block[] layout:
+    ///   - YBlocks[0..15]: 16 Y blocks (raster order, 4 per row).
+    ///   - UBlocks[0..3] : 4 U blocks (raster order).
+    ///   - VBlocks[0..3] : 4 V blocks (raster order).
+    ///   - Y2Block       : the second-order Walsh-coded DC block.
+    /// </summary>
+    public sealed class MbEncodeResult
+    {
+        public List<TOKENEXTRA>[] YBlocks  = new List<TOKENEXTRA>[16];
+        public List<TOKENEXTRA>[] UBlocks  = new List<TOKENEXTRA>[4];
+        public List<TOKENEXTRA>[] VBlocks  = new List<TOKENEXTRA>[4];
+        public List<TOKENEXTRA>  Y2Block  = new List<TOKENEXTRA>();
+
+        /// <summary>Reconstructed 16x16 luma pixels, raster order.</summary>
+        public byte[] ReconY = new byte[16 * 16];
+
+        /// <summary>Reconstructed 8x8 U pixels, raster order.</summary>
+        public byte[] ReconU = new byte[8 * 8];
+
+        /// <summary>Reconstructed 8x8 V pixels, raster order.</summary>
+        public byte[] ReconV = new byte[8 * 8];
+    }
+
+    public static class mb_encoder
+    {
+        /// <summary>
+        /// Encode one 16x16 macroblock as keyframe-only, DC_PRED-only intra.
+        ///
+        /// Inputs:
+        ///   srcY:   16*16 luma source bytes, raster order (row major).
+        ///   srcU:   8*8 chroma U, raster order.
+        ///   srcV:   8*8 chroma V, raster order.
+        ///   aboveY: 16 luma bytes from the row immediately above this MB,
+        ///           or null if this is the top row of the frame.
+        ///   leftY:  16 luma bytes from the column immediately left of this
+        ///           MB, or null if this is the left column.
+        ///   aboveU/leftU/aboveV/leftV: the 8-byte chroma equivalents.
+        ///   fq:     quantizer tables built by quantizer_init.BuildForQIndex.
+        /// </summary>
+        public static MbEncodeResult EncodeMacroblockDcPred(
+            byte[] srcY, byte[] srcU, byte[] srcV,
+            byte[] aboveY, byte[] leftY,
+            byte[] aboveU, byte[] leftU,
+            byte[] aboveV, byte[] leftV,
+            FrameQuantizer fq)
+        {
+            if (srcY == null || srcY.Length != 256) throw new ArgumentException("srcY must be 16*16");
+            if (srcU == null || srcU.Length != 64)  throw new ArgumentException("srcU must be 8*8");
+            if (srcV == null || srcV.Length != 64)  throw new ArgumentException("srcV must be 8*8");
+            if (fq == null) throw new ArgumentNullException(nameof(fq));
+
+            var result = new MbEncodeResult();
+
+            // ---- Step 1: DC predictions ----
+            byte yPred = DcPred16x16(aboveY, leftY);
+            byte uPred = DcPred8x8(aboveU, leftU);
+            byte vPred = DcPred8x8(aboveV, leftV);
+
+            // ---- Step 2: residual = source - prediction ----
+            short[] residY = SubtractFlat(srcY, yPred);
+            short[] residU = SubtractFlat(srcU, uPred);
+            short[] residV = SubtractFlat(srcV, vPred);
+
+            // ---- Step 3: forward DCT for each 4x4 block ----
+            // Y: 16 blocks of 4x4 carved out of the 16x16 plane.
+            short[][] yCoef = new short[16][];
+            for (int by = 0; by < 4; by++)
+            for (int bx = 0; bx < 4; bx++)
+            {
+                int blkIdx = by * 4 + bx;
+                yCoef[blkIdx] = Fdct4x4FromPlane(residY, srcStride: 16,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+            }
+            // U / V: 4 blocks of 4x4 each.
+            short[][] uCoef = new short[4][];
+            short[][] vCoef = new short[4][];
+            for (int by = 0; by < 2; by++)
+            for (int bx = 0; bx < 2; bx++)
+            {
+                int blkIdx = by * 2 + bx;
+                uCoef[blkIdx] = Fdct4x4FromPlane(residU, srcStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                vCoef[blkIdx] = Fdct4x4FromPlane(residV, srcStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+            }
+
+            // ---- Step 4: build Y2 block from the 16 Y DCs and Walsh-transform ----
+            // For 16x16 intra modes (DC_PRED, V_PRED, H_PRED, TM_PRED) the
+            // 16 Y DC coefficients are themselves transformed by a 4x4 Walsh
+            // and then quantized as a "Y2" second-order block. The 16 Y AC
+            // blocks then drop their DC (zero out coef[0]).
+            short[] y2In = new short[16];
+            for (int i = 0; i < 16; i++) y2In[i] = yCoef[i][0];
+            short[] y2Coef = Walsh4x4(y2In);
+
+            // Zero out the DC of each Y AC block.
+            for (int i = 0; i < 16; i++) yCoef[i][0] = 0;
+
+            // ---- Step 5: quantize ----
+            short[][] yQ = new short[16][], yDQ = new short[16][];
+            int[] yEob = new int[16];
+            for (int i = 0; i < 16; i++)
+            {
+                yQ[i] = new short[16]; yDQ[i] = new short[16];
+                yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i]);
+            }
+
+            short[] y2Q = new short[16], y2DQ = new short[16];
+            int y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ);
+
+            short[][] uQ = new short[4][], uDQ = new short[4][];
+            short[][] vQ = new short[4][], vDQ = new short[4][];
+            int[] uEob = new int[4], vEob = new int[4];
+            for (int i = 0; i < 4; i++)
+            {
+                uQ[i] = new short[16]; uDQ[i] = new short[16];
+                uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i]);
+                vQ[i] = new short[16]; vDQ[i] = new short[16];
+                vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i]);
+            }
+
+            // ---- Step 6: tokenize ----
+            // Block types per libvpx:
+            //   type 0 = Y AC (first coefficient index = 1; DC went to Y2)
+            //   type 1 = Y2
+            //   type 2 = UV
+            //   type 3 = Y with DC (used when no Y2 block — not our case)
+            for (int i = 0; i < 16; i++)
+            {
+                result.YBlocks[i] = new List<TOKENEXTRA>();
+                tokenize.vp8_tokenize_block(yQ[i],
+                    firstCoeffIndex: 1, eob: yEob[i],
+                    blockType: 0, initialContext: 0,
+                    coefProbs: default_coef_probs_c.default_coef_probs,
+                    output: result.YBlocks[i]);
+            }
+            tokenize.vp8_tokenize_block(y2Q,
+                firstCoeffIndex: 0, eob: y2Eob,
+                blockType: 1, initialContext: 0,
+                coefProbs: default_coef_probs_c.default_coef_probs,
+                output: result.Y2Block);
+            for (int i = 0; i < 4; i++)
+            {
+                result.UBlocks[i] = new List<TOKENEXTRA>();
+                tokenize.vp8_tokenize_block(uQ[i],
+                    firstCoeffIndex: 0, eob: uEob[i],
+                    blockType: 2, initialContext: 0,
+                    coefProbs: default_coef_probs_c.default_coef_probs,
+                    output: result.UBlocks[i]);
+                result.VBlocks[i] = new List<TOKENEXTRA>();
+                tokenize.vp8_tokenize_block(vQ[i],
+                    firstCoeffIndex: 0, eob: vEob[i],
+                    blockType: 2, initialContext: 0,
+                    coefProbs: default_coef_probs_c.default_coef_probs,
+                    output: result.VBlocks[i]);
+            }
+
+            // ---- Step 7: reconstruct ----
+            // Inverse Walsh on the Y2 block to recover the (quantized) DC of
+            // each Y block. libvpx's inverse Walsh writes the per-block DC
+            // into mb_dqcoeff[i*16].
+            short[] y2InvOut = InverseWalsh4x4(y2DQ);
+            for (int i = 0; i < 16; i++)
+            {
+                yDQ[i][0] = y2InvOut[i];
+            }
+
+            // For each Y block: idct(dq) + prediction -> reconstructed.
+            for (int by = 0; by < 4; by++)
+            for (int bx = 0; bx < 4; bx++)
+            {
+                int blkIdx = by * 4 + bx;
+                IdctAndAddToPlane(yDQ[blkIdx], yPred, result.ReconY,
+                    dstStride: 16, blockOffsetX: bx * 4, blockOffsetY: by * 4);
+            }
+            for (int by = 0; by < 2; by++)
+            for (int bx = 0; bx < 2; bx++)
+            {
+                int blkIdx = by * 2 + bx;
+                IdctAndAddToPlane(uDQ[blkIdx], uPred, result.ReconU,
+                    dstStride: 8, blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                IdctAndAddToPlane(vDQ[blkIdx], vPred, result.ReconV,
+                    dstStride: 8, blockOffsetX: bx * 4, blockOffsetY: by * 4);
+            }
+
+            return result;
+        }
+
+        // ---------- helpers ----------
+
+        /// <summary>
+        /// 16x16 DC_PRED. RFC 6386 §10.2: when both above and left are
+        /// available, the prediction is the mean of the 32 boundary
+        /// samples; when only one is available, just that 16; when neither,
+        /// 128. The averages are rounded to nearest with the libvpx-style
+        /// "+= half" rounding.
+        /// </summary>
+        private static byte DcPred16x16(byte[] above, byte[] left)
+        {
+            int avgAbove = 0, avgLeft = 0;
+            int count = 0;
+            if (above != null) { for (int i = 0; i < 16; i++) avgAbove += above[i]; count += 16; }
+            if (left  != null) { for (int i = 0; i < 16; i++) avgLeft  += left[i];  count += 16; }
+            if (count == 0) return 128;
+            int sum = avgAbove + avgLeft;
+            return (byte)((sum + count / 2) / count);
+        }
+
+        /// <summary>8x8 DC_PRED — same rules as the 16x16 case.</summary>
+        private static byte DcPred8x8(byte[] above, byte[] left)
+        {
+            int avgAbove = 0, avgLeft = 0;
+            int count = 0;
+            if (above != null) { for (int i = 0; i < 8; i++) avgAbove += above[i]; count += 8; }
+            if (left  != null) { for (int i = 0; i < 8; i++) avgLeft  += left[i];  count += 8; }
+            if (count == 0) return 128;
+            int sum = avgAbove + avgLeft;
+            return (byte)((sum + count / 2) / count);
+        }
+
+        /// <summary>Subtracts a flat prediction value from each source byte.</summary>
+        private static short[] SubtractFlat(byte[] src, byte pred)
+        {
+            var r = new short[src.Length];
+            for (int i = 0; i < src.Length; i++) r[i] = (short)(src[i] - pred);
+            return r;
+        }
+
+        /// <summary>
+        /// Extract a 4x4 sub-block from <paramref name="plane"/> (raster order
+        /// at <paramref name="srcStride"/>) into a contiguous 16-short
+        /// buffer, then forward-DCT it.
+        /// </summary>
+        private static unsafe short[] Fdct4x4FromPlane(short[] plane, int srcStride, int blockOffsetX, int blockOffsetY)
+        {
+            short[] block = new short[16];
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+                block[r * 4 + c] = plane[(blockOffsetY + r) * srcStride + (blockOffsetX + c)];
+
+            short[] coef = new short[16];
+            fixed (short* inP = block)
+            fixed (short* outP = coef)
+            {
+                dct.vp8_short_fdct4x4_c(inP, outP, pitch: 8);
+            }
+            return coef;
+        }
+
+        /// <summary>4x4 Walsh-Hadamard on a 16-element input.</summary>
+        private static unsafe short[] Walsh4x4(short[] input)
+        {
+            short[] outBuf = new short[16];
+            fixed (short* inP = input)
+            fixed (short* outP = outBuf)
+            {
+                dct.vp8_short_walsh4x4_c(inP, outP, pitch: 8);
+            }
+            return outBuf;
+        }
+
+        /// <summary>
+        /// Quantize a 16-coefficient block using the supplied tables, with
+        /// zbin_extra = 0. Returns the EOB.
+        /// </summary>
+        private static unsafe int QuantizeBlock(short[] coef, QuantizerTables t, short[] qcoeff, short[] dqcoeff)
+        {
+            fixed (short* coefP = coef)
+            fixed (short* zbinP = t.zbin)
+            fixed (short* zboostP = t.zrun_zbin_boost)
+            fixed (short* roundP = t.round)
+            fixed (short* quantP = t.quant)
+            fixed (short* qshiftP = t.quant_shift)
+            fixed (short* dequantP = t.dequant)
+            fixed (short* qP = qcoeff)
+            fixed (short* dqP = dqcoeff)
+            {
+                return quantize.vp8_regular_quantize_b_arrays(
+                    coefP, zbinP, zboostP, roundP, quantP, qshiftP, dequantP,
+                    qP, dqP, zbin_extra: 0);
+            }
+        }
+
+        /// <summary>
+        /// Bit-exact port of libvpx's vp8_short_inv_walsh4x4_c for 16 inputs
+        /// (the second-order inverse Walsh used in 16x16 intra modes).
+        /// libvpx writes into an MB-wide dqcoeff buffer; we return a flat
+        /// 16-element array of "DC values per Y block" instead, since the
+        /// caller decides where to install them.
+        /// </summary>
+        private static short[] InverseWalsh4x4(short[] input)
+        {
+            // Adapted from idctllm.cs vp8_short_inv_walsh4x4_c — one buffer
+            // pass that puts the recovered DC of each Y block into the
+            // returned 16-element array (one per Y block).
+            int[] tmp = new int[16];
+            int a1, b1, c1, d1, a2, b2, c2, d2;
+
+            // Stage 1 — rows.
+            for (int i = 0; i < 4; i++)
+            {
+                a1 = input[i * 4 + 0] + input[i * 4 + 3];
+                b1 = input[i * 4 + 1] + input[i * 4 + 2];
+                c1 = input[i * 4 + 1] - input[i * 4 + 2];
+                d1 = input[i * 4 + 0] - input[i * 4 + 3];
+
+                tmp[i * 4 + 0] = a1 + b1;
+                tmp[i * 4 + 1] = c1 + d1;
+                tmp[i * 4 + 2] = a1 - b1;
+                tmp[i * 4 + 3] = d1 - c1;
+            }
+
+            // Stage 2 — columns.
+            short[] outBuf = new short[16];
+            for (int i = 0; i < 4; i++)
+            {
+                a1 = tmp[0 * 4 + i] + tmp[3 * 4 + i];
+                b1 = tmp[1 * 4 + i] + tmp[2 * 4 + i];
+                c1 = tmp[1 * 4 + i] - tmp[2 * 4 + i];
+                d1 = tmp[0 * 4 + i] - tmp[3 * 4 + i];
+
+                a2 = a1 + b1;
+                b2 = c1 + d1;
+                c2 = a1 - b1;
+                d2 = d1 - c1;
+
+                outBuf[0 * 4 + i] = (short)((a2 + 3) >> 3);
+                outBuf[1 * 4 + i] = (short)((b2 + 3) >> 3);
+                outBuf[2 * 4 + i] = (short)((c2 + 3) >> 3);
+                outBuf[3 * 4 + i] = (short)((d2 + 3) >> 3);
+            }
+            return outBuf;
+        }
+
+        /// <summary>
+        /// Inverse-DCT a 16-element block, add a flat prediction, write the
+        /// resulting bytes to a 4x4 sub-block of <paramref name="dstPlane"/>.
+        /// Reuses the existing decoder-side idctllm.vp8_short_idct4x4llm_c.
+        /// </summary>
+        private static unsafe void IdctAndAddToPlane(short[] dqcoeff, byte pred,
+            byte[] dstPlane, int dstStride, int blockOffsetX, int blockOffsetY)
+        {
+            // The decoder's idct adds to a prediction buffer and clamps to
+            // [0, 255]. Build a 4x4 prediction buffer (all = pred), call
+            // idct, then copy back to the destination plane.
+            byte[] predBuf = new byte[16];
+            for (int i = 0; i < 16; i++) predBuf[i] = pred;
+            byte[] dstBuf = new byte[16];
+
+            fixed (short* coefP = dqcoeff)
+            fixed (byte* predP = predBuf)
+            fixed (byte* dstP = dstBuf)
+            {
+                idctllm.vp8_short_idct4x4llm_c(coefP, predP, 4, dstP, 4);
+            }
+
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+                dstPlane[(blockOffsetY + r) * dstStride + (blockOffsetX + c)] = dstBuf[r * 4 + c];
+        }
+    }
+}

--- a/test/VP8.Net.UnitTest/mb_encoder_unittest.cs
+++ b/test/VP8.Net.UnitTest/mb_encoder_unittest.cs
@@ -1,0 +1,203 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: mb_encoder_unittest.cs
+//
+// Description: Unit tests for the per-macroblock encode pipeline
+// (mb_encoder.EncodeMacroblockDcPred). Covers the trivial uniform-input
+// case (every transformed block must collapse to a single EOB token, and
+// reconstruction must equal the prediction), and a non-trivial case
+// (random-but-deterministic source pixels) where reconstruction must
+// match the source within the quantizer's tolerance — which is the right
+// invariant for an intra encoder, since a perfect round-trip is only
+// possible for fully-zero residuals.
+//
+// These tests don't compare against a libvpx C reference for the produced
+// token streams: that would require running the full libvpx encoder,
+// which is too heavy for a unit test. Instead they verify the
+// orchestration's two top-level invariants — flat input -> EOB-only
+// output, and reconstruction equals source within quant noise — with the
+// underlying primitives (DCT, quantize, tokenize, idct) already
+// individually bit-exact-verified against libvpx in earlier PRs.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 25 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public class mb_encoder_unittest
+    {
+        // ---------- uniform input: trivial outputs ----------
+
+        /// <summary>
+        /// Uniform-grey input with no neighbour context: prediction = 128
+        /// (default), residual = 0 everywhere, every transformed block
+        /// quantizes to all zeros, every block tokenizes to a single EOB.
+        /// Reconstruction must equal the prediction (128).
+        /// </summary>
+        [Fact]
+        public void EncodeMacroblock_UniformGrey_NoNeighbours_ProducesEobOnlyAndReconstructsToPred()
+        {
+            byte[] srcY = FlatBytes(256, 128);
+            byte[] srcU = FlatBytes(64, 128);
+            byte[] srcV = FlatBytes(64, 128);
+
+            var fq = quantizer_init.BuildForQIndex(32);
+            var r = mb_encoder.EncodeMacroblockDcPred(
+                srcY, srcU, srcV,
+                aboveY: null, leftY: null,
+                aboveU: null, leftU: null,
+                aboveV: null, leftV: null,
+                fq: fq);
+
+            // Each of the 25 blocks must be exactly one EOB token.
+            Assert.Single(r.Y2Block);
+            Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.Y2Block[0].Token);
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Single(r.YBlocks[i]);
+                Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.YBlocks[i][0].Token);
+            }
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.Single(r.UBlocks[i]);
+                Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.UBlocks[i][0].Token);
+                Assert.Single(r.VBlocks[i]);
+                Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.VBlocks[i][0].Token);
+            }
+
+            // Reconstruction equals the prediction.
+            for (int i = 0; i < 256; i++) Assert.Equal((byte)128, r.ReconY[i]);
+            for (int i = 0; i < 64; i++)
+            {
+                Assert.Equal((byte)128, r.ReconU[i]);
+                Assert.Equal((byte)128, r.ReconV[i]);
+            }
+        }
+
+        /// <summary>
+        /// Uniform-grey input WITH non-default neighbour context — DC_PRED
+        /// computes from the actual neighbours, not 128. Residual is still
+        /// zero (input == DC of input == prediction), reconstruction must
+        /// match the source.
+        /// </summary>
+        [Fact]
+        public void EncodeMacroblock_UniformContext_PredictionMatchesNeighbours()
+        {
+            byte[] srcY = FlatBytes(256, 200);
+            byte[] srcU = FlatBytes(64, 100);
+            byte[] srcV = FlatBytes(64, 50);
+            byte[] aboveY = FlatBytes(16, 200), leftY = FlatBytes(16, 200);
+            byte[] aboveU = FlatBytes(8, 100),  leftU = FlatBytes(8, 100);
+            byte[] aboveV = FlatBytes(8, 50),   leftV = FlatBytes(8, 50);
+
+            var fq = quantizer_init.BuildForQIndex(32);
+            var r = mb_encoder.EncodeMacroblockDcPred(
+                srcY, srcU, srcV,
+                aboveY, leftY, aboveU, leftU, aboveV, leftV,
+                fq);
+
+            // All blocks still EOB-only because residual is zero.
+            Assert.Single(r.Y2Block);
+            Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.Y2Block[0].Token);
+
+            // Reconstruction matches the source.
+            for (int i = 0; i < 256; i++) Assert.Equal((byte)200, r.ReconY[i]);
+            for (int i = 0; i < 64; i++)
+            {
+                Assert.Equal((byte)100, r.ReconU[i]);
+                Assert.Equal((byte)50, r.ReconV[i]);
+            }
+        }
+
+        // ---------- non-trivial input: round-trip within quantizer tolerance ----------
+
+        /// <summary>
+        /// Deterministic pseudo-random source pixels with no neighbour
+        /// context. The encoder produces some non-EOB tokens for at least
+        /// some blocks (otherwise the test data is too smooth), and
+        /// reconstruction matches the source within a tolerance bounded by
+        /// the quantizer step.
+        ///
+        /// At Q=32 the Y AC dequantizer is 36 (see quantizer_init_unittest);
+        /// after the DCT's 8x scaling and the rounding constants, a
+        /// per-pixel reconstruction error of up to ~16 is expected for
+        /// arbitrary input. We assert <= 32 to give comfortable headroom
+        /// against the worst-case rounding combinations.
+        /// </summary>
+        [Fact]
+        public void EncodeMacroblock_RandomInput_ReconstructionWithinQuantTolerance()
+        {
+            byte[] srcY = DeterministicBytes(256, seed: 1);
+            byte[] srcU = DeterministicBytes(64, seed: 2);
+            byte[] srcV = DeterministicBytes(64, seed: 3);
+
+            var fq = quantizer_init.BuildForQIndex(32);
+            var r = mb_encoder.EncodeMacroblockDcPred(
+                srcY, srcU, srcV,
+                aboveY: null, leftY: null,
+                aboveU: null, leftU: null,
+                aboveV: null, leftV: null,
+                fq: fq);
+
+            // At least some block carries non-EOB tokens (otherwise the
+            // input was effectively flat and this test isn't exercising
+            // anything).
+            int nonTrivialBlocks = 0;
+            if (r.Y2Block.Count > 1) nonTrivialBlocks++;
+            for (int i = 0; i < 16; i++) if (r.YBlocks[i].Count > 1) nonTrivialBlocks++;
+            for (int i = 0; i < 4; i++)
+            {
+                if (r.UBlocks[i].Count > 1) nonTrivialBlocks++;
+                if (r.VBlocks[i].Count > 1) nonTrivialBlocks++;
+            }
+            Assert.True(nonTrivialBlocks > 0, "test data was too flat — all blocks were EOB-only");
+
+            // Reconstruction error per pixel must be bounded.
+            const int kTol = 32;
+            for (int i = 0; i < 256; i++)
+            {
+                int diff = r.ReconY[i] - srcY[i];
+                Assert.True(diff >= -kTol && diff <= kTol,
+                    "Y[" + i + "] recon err " + diff + " exceeds tolerance " + kTol);
+            }
+            for (int i = 0; i < 64; i++)
+            {
+                int dU = r.ReconU[i] - srcU[i];
+                int dV = r.ReconV[i] - srcV[i];
+                Assert.True(dU >= -kTol && dU <= kTol, "U[" + i + "] recon err " + dU);
+                Assert.True(dV >= -kTol && dV <= kTol, "V[" + i + "] recon err " + dV);
+            }
+        }
+
+        // ---------- helpers ----------
+
+        private static byte[] FlatBytes(int n, byte v)
+        {
+            var b = new byte[n];
+            for (int i = 0; i < n; i++) b[i] = v;
+            return b;
+        }
+
+        // Same xorshift seed everywhere for reproducibility — these tests
+        // must produce the same input on every run regardless of CLR or OS.
+        private static byte[] DeterministicBytes(int n, int seed)
+        {
+            var b = new byte[n];
+            uint x = (uint)(0x9E3779B9 ^ seed);
+            for (int i = 0; i < n; i++)
+            {
+                x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+                b[i] = (byte)(x & 0xFF);
+            }
+            return b;
+        }
+    }
+}


### PR DESCRIPTION
## VP8 encoder foundation (PR 6 of N): per-macroblock encode pipeline

This PR adds the orchestrator that ties together everything we've shipped over the previous five PRs into a single `EncodeMacroblockDcPred` function. Given a 16×16 luma plane + two 8×8 chroma planes for one macroblock, plus optional 1-row-above + 1-column-left neighbour bytes, it produces:

1. **25 `TOKENEXTRA` streams** — 1 Y2 + 16 Y + 4 U + 4 V — ready for `vp8_pack_tokens` to turn into bits.
2. **The reconstructed macroblock** — the bytes a decoder will produce given the same bitstream, used both as context for subsequent MBs in real frames and as the verification anchor for these tests.

### Pipeline

1. **DC_PRED** for Y (16×16 mean of boundary samples) and UV (8×8 mean), with the standard "use 128 when neighbours are absent" fallback.
2. Subtract prediction → **residual**.
3. **Forward DCT** each 4×4 residual block (via `dct.vp8_short_fdct4x4_c` from PR 1).
4. **Walsh-transform** the 16 Y DCs into a **Y2** block (via `dct.vp8_short_walsh4x4_c`).
5. **Quantize** Y AC (DC zeroed), Y2, U, V using the tables built by `quantizer_init.BuildForQIndex` (PR 5).
6. **Tokenize** each block via `tokenize.vp8_tokenize_block` (PR 3) — block type 0 for Y AC with `firstCoeffIndex=1`, type 1 for Y2, type 2 for UV.
7. **Reconstruct**: inverse Walsh on the dequantized Y2 to recover the per-block Y DCs, then idct + add-prediction for every 4×4 block. Reuses the existing decoder-side `idctllm.vp8_short_idct4x4llm_c`.

### Tests

3 new tests, all green on first run:

- **Uniform-grey input with no neighbours.** Prediction = 128, residual = 0, every transformed block must collapse to a single EOB token, reconstruction must equal 128 everywhere.
- **Uniform input with non-128 neighbours** (Y=200, U=100, V=50). DC_PRED tracks the neighbours; reconstruction equals the source.
- **Deterministic pseudo-random source pixels.** Encoder produces non-trivial token streams (the test asserts at least one block has tokens beyond the EOB); reconstruction matches the source within a per-pixel tolerance bounded by the AC quantizer step at Q=32.

Why no libvpx C-reference test for token streams? That would require running the full libvpx encoder and is too heavy for a unit test. The orchestration's correctness rests on the individually-bit-exact primitives (DCT, Walsh, quantize, tokenize, quantizer tables — all reference-checked in prior PRs) plus the two structural invariants the tests pin down.

### What's NOT in this PR

- Frame orchestration (uncompressed header + coef-prob no-updates + per-MB modes + per-MB tokens + flush) — **PR 7**.
- Wiring `VP8Codec.EncodeVideo` — **PR 7**.
- Full encode → decode round-trip on a synthetic frame — **PR 7** (this is the moment of truth where prior AI attempts failed).

### Verification

- `dotnet build` clean.
- All 3 new tests green.
- Pre-existing GDI+/Bitmap failures unrelated.

### Author attribution

New files credit Claude (model: `claude-opus-4-7`).
