### PR TITLE
VP8 encoder: thread entropy contexts at frame scope (cross-MB fix)

### DIFF
--- a/src/VP8.Net/frame_encoder.cs
+++ b/src/VP8.Net/frame_encoder.cs
@@ -35,11 +35,28 @@
 // "left" / "above" neighbour buffers so that DC prediction matches the
 // decoder's reconstruction context exactly.
 //
+// Cross-MB entropy-context propagation: each MB's 9-slot above/left
+// entropy contexts (4 Y + 2 U + 2 V + 1 Y2) are maintained at frame
+// scope rather than per-MB. The above contexts are stored as one row
+// of 9-slot entries indexed by MB column position; left contexts are
+// kept as a single 9-slot array reset to zero at the start of each MB
+// row. Each call into mb_encoder.EncodeMacroblockDcPred passes both
+// arrays in by reference so that each block's initial probability-row
+// context matches the row the decoder will read with — this was the
+// root cause of the macroblock-aligned colour artefacts observed on
+// real webcam content with the previous per-MB-only contexts.
+//
 // Author(s):
 // Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
 //
 // History:
 // 25 Apr 2026  Claude          Created.
+// 26 Apr 2026  Claude          Thread above/left entropy contexts at
+//                              frame scope (previously they were local
+//                              to each MB and reset at MB boundaries,
+//                              which made the encoder use the wrong
+//                              probability rows for the decoder's
+//                              context state on non-uniform content).
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -160,9 +177,20 @@ namespace Vpx.Net
             byte[] aboveVRow = new byte[chromaW];
             // First row has no "above"; null indicates "use 128 default".
 
+            // Frame-scope entropy contexts. The above row stores one
+            // 9-slot context per MB column position (4 Y + 2 U + 2 V + 1
+            // Y2 = 9 slots), reused across MB rows so that an MB at
+            // (row r, col c) reads its above context from the bottom of
+            // the MB at (r-1, c). The left context is a single 9-slot
+            // array that persists across MBs in a row and is reset at
+            // each row boundary (no wrap-around). C-array layout (flat,
+            // row-major-ish): aboveCtx[mbCol * 9 + slot].
+            byte[] frameAboveCtx = new byte[mbCols * 9];
+
             for (int mbRow = 0; mbRow < mbRows; mbRow++)
             {
                 byte[] leftY = null, leftU = null, leftV = null;
+                byte[] leftCtx = new byte[9];   // reset at the start of each MB row
 
                 for (int mbCol = 0; mbCol < mbCols; mbCol++)
                 {
@@ -176,11 +204,23 @@ namespace Vpx.Net
                     byte[] aboveU = (mbRow == 0) ? null : ExtractRow(aboveURow, mbCol * 8, 8);
                     byte[] aboveV = (mbRow == 0) ? null : ExtractRow(aboveVRow, mbCol * 8, 8);
 
+                    // Pull this MB column's above context out of the
+                    // frame-scope buffer; mb_encoder mutates it in place
+                    // as it processes blocks, then we copy it back.
+                    byte[] aboveCtx = new byte[9];
+                    int aboveBase = mbCol * 9;
+                    for (int s = 0; s < 9; s++) aboveCtx[s] = frameAboveCtx[aboveBase + s];
+
                     var r = mb_encoder.EncodeMacroblockDcPred(
                         mbY, mbU, mbV,
                         aboveY, leftY, aboveU, leftU, aboveV, leftV,
-                        fq);
+                        fq,
+                        aboveCtx, leftCtx);
                     mbResults[mbRow * mbCols + mbCol] = r;
+
+                    // The mutated aboveCtx is the new "above" for the MB
+                    // immediately below this one (same column, next row).
+                    for (int s = 0; s < 9; s++) frameAboveCtx[aboveBase + s] = aboveCtx[s];
 
                     // Encode the Y mode (DC_PRED) -> bits 1, 0, 0 with
                     // probs vp8_kf_ymode_prob[0..2].

--- a/src/VP8.Net/mb_encoder.cs
+++ b/src/VP8.Net/mb_encoder.cs
@@ -31,6 +31,12 @@
 //
 // History:
 // 25 Apr 2026  Claude          Created.
+// 26 Apr 2026  Claude          Lift above/left context arrays out of
+//                              per-call allocation: now optional
+//                              parameters so frame_encoder can thread
+//                              them at frame scope (cross-MB context
+//                              propagation). Also fix Y2 initial
+//                              context from boolean OR to CombineCtx.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -94,18 +100,35 @@ namespace Vpx.Net
         ///           MB, or null if this is the left column.
         ///   aboveU/leftU/aboveV/leftV: the 8-byte chroma equivalents.
         ///   fq:     quantizer tables built by quantizer_init.BuildForQIndex.
+        ///   aboveCtx, leftCtx: optional 9-byte entropy-context arrays
+        ///           (4 Y + 2 U + 2 V + 1 Y2 slots). When null, fresh
+        ///           zero-filled arrays are allocated for this single MB
+        ///           and discarded after — the per-MB-isolation behaviour
+        ///           used by mb_encoder unit tests. When non-null, the
+        ///           caller (typically frame_encoder) maintains them at
+        ///           frame scope and threads them across MBs: this method
+        ///           reads each block's initial context from them and
+        ///           writes the resulting non-zero/zero flag back, in
+        ///           place. See the comment block inside the method for
+        ///           the threading rules.
         /// </summary>
         public static MbEncodeResult EncodeMacroblockDcPred(
             byte[] srcY, byte[] srcU, byte[] srcV,
             byte[] aboveY, byte[] leftY,
             byte[] aboveU, byte[] leftU,
             byte[] aboveV, byte[] leftV,
-            FrameQuantizer fq)
+            FrameQuantizer fq,
+            byte[] aboveCtx = null,
+            byte[] leftCtx = null)
         {
             if (srcY == null || srcY.Length != 256) throw new ArgumentException("srcY must be 16*16");
             if (srcU == null || srcU.Length != 64)  throw new ArgumentException("srcU must be 8*8");
             if (srcV == null || srcV.Length != 64)  throw new ArgumentException("srcV must be 8*8");
             if (fq == null) throw new ArgumentNullException(nameof(fq));
+            if (aboveCtx != null && aboveCtx.Length != 9)
+                throw new ArgumentException("aboveCtx must have length 9 (4 Y + 2 U + 2 V + 1 Y2)", nameof(aboveCtx));
+            if (leftCtx != null && leftCtx.Length != 9)
+                throw new ArgumentException("leftCtx must have length 9 (4 Y + 2 U + 2 V + 1 Y2)", nameof(leftCtx));
 
             var result = new MbEncodeResult();
 
@@ -196,12 +219,27 @@ namespace Vpx.Net
             // context stays 0), but broke once any block carried a
             // non-zero coefficient — the encoder wrote with prob row 0 and
             // the decoder, computing context 1 from its own state machine,
-            // read with prob row 1. Output: garbled chroma in the test.
+            // read with prob row 1.
             //
-            // For now the above/left arrays are local to the MB; multi-MB
-            // context propagation is a follow-up.
-            byte[] aboveCtx = new byte[9];
-            byte[] leftCtx = new byte[9];
+            // The follow-up bug history (this PR): when the contexts are
+            // local to the MB they reset to 0 at every MB boundary. Within
+            // an MB that's right (every MB is independent of the others
+            // for prediction in keyframe-only intra), but between MBs in
+            // the same row (left context) and between MB rows (above
+            // context) the decoder DOES thread context — so the encoder
+            // must too, or the decoder reads with a different prob row
+            // from the one the encoder wrote with.
+            //
+            // The fix: aboveCtx and leftCtx are now optional parameters.
+            // When null (the default), behaviour matches the old per-MB
+            // semantics — useful for unit-testing this function in
+            // isolation. When non-null (the path taken by frame_encoder),
+            // the caller maintains them at frame scope, threading
+            // aboveCtx by MB column position (read before this call,
+            // write back after) and leftCtx across MBs in a row (reset
+            // to zero at the start of each row).
+            if (aboveCtx == null) aboveCtx = new byte[9];
+            if (leftCtx == null) leftCtx = new byte[9];
 
             // Block type per libvpx:
             //   type 0 = Y AC (firstCoeffIndex = 1; DC went to Y2)
@@ -216,7 +254,7 @@ namespace Vpx.Net
             bool y2NonZero = tokenize.vp8_tokenize_block(y2Q,
                 firstCoeffIndex: 0, eob: y2Eob,
                 blockType: 1,
-                initialContext: aboveCtx[slot] | leftCtx[slotL],
+                initialContext: CombineCtx(aboveCtx[slot], leftCtx[slotL]),
                 coefProbs: default_coef_probs_c.default_coef_probs,
                 output: result.Y2Block);
             aboveCtx[slot] = leftCtx[slotL] = (byte)(y2NonZero ? 1 : 0);

--- a/test/VP8.Net.UnitTest/frame_encoder_unittest.cs
+++ b/test/VP8.Net.UnitTest/frame_encoder_unittest.cs
@@ -18,6 +18,10 @@
 //
 // History:
 // 25 Apr 2026  Claude          Created.
+// 26 Apr 2026  Claude          Add checkerboard tests that exercise
+//                              cross-MB entropy-context propagation
+//                              (would fail with maxErr ~97 on master
+//                              before the frame-scope context fix).
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -79,6 +83,46 @@ namespace Vpx.Net.UnitTest
             AssertExact(yuv, decoded);
         }
 
+        // ---------- Cross-MB entropy-context propagation ----------
+        //
+        // These tests exercise non-uniform content across multiple MBs
+        // in the same row and across multiple MB rows. A regression
+        // in either direction (omitting the frame-scope above-context,
+        // or omitting the row-scope left-context) shows up here as
+        // visibly garbled output past the first MB while the first MB
+        // alone decodes correctly.
+        //
+        // Discriminator: on master before the fix, the 32x16 case
+        // produced maxErr=97 / MAE=25.77 and the 32x32 case produced
+        // maxErr=97 / MAE=37.97; the fix brings both to maxErr<=4 /
+        // MAE<=1.53. The asserted bound of 16 is well below the
+        // bug-present floor and well above the bug-fixed ceiling.
+
+        [Fact]
+        public void EncodeAndDecode_Checkerboard32x16_CrossMbContextRoundTrips()
+        {
+            // 32x16 = 2 MBs side by side; same row.
+            const int W = 32, H = 16;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            byte[] decoded = EncodeAndDecodeI420(yuv, W, H, qIndex: 32);
+
+            AssertWithin(yuv, decoded, tol: 16);
+        }
+
+        [Fact]
+        public void EncodeAndDecode_Checkerboard32x32_CrossMbRowAndColumnRoundTrips()
+        {
+            // 32x32 = 2x2 MB grid; exercises both cross-row above
+            // context and cross-column left context.
+            const int W = 32, H = 32;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            byte[] decoded = EncodeAndDecodeI420(yuv, W, H, qIndex: 32);
+
+            AssertWithin(yuv, decoded, tol: 16);
+        }
+
         // ---------- helpers ----------
 
         // Encode an I420 source via the public VP8Codec, then decode using
@@ -135,6 +179,26 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < ySize; i++) b[i] = y;
             for (int i = 0; i < cSize; i++) b[ySize + i] = u;
             for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = v;
+            return b;
+        }
+
+        // Y has a 2x2-pixel checkerboard pattern (dark / light); UV are
+        // flat 128 to keep the test focused on the luma path. The 2x2
+        // tile size means most 4x4 transformed blocks contain a busy
+        // mix of high-frequency components, so quantization at Q=32
+        // produces non-zero coefficient tokens in essentially every
+        // block - which is the configuration where the cross-MB
+        // entropy-context bug manifests.
+        private static byte[] MakeCheckerboardI420(int width, int height, byte dark, byte light)
+        {
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var b = new byte[ySize + 2 * cSize];
+            for (int row = 0; row < height; row++)
+                for (int col = 0; col < width; col++)
+                    b[row * width + col] = ((((row >> 1) ^ (col >> 1)) & 1) != 0) ? dark : light;
+            for (int i = 0; i < cSize; i++) b[ySize + i] = 128;
+            for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = 128;
             return b;
         }
 


### PR DESCRIPTION
Fixes the macroblock-aligned colour artefacts visible on real webcam content with the foundation encoder from #1571 — the bug was called out in that PR's description and in the new diary entry in #1573.

## Root cause

`mb_encoder.EncodeMacroblockDcPred` allocated fresh zero-filled `above_context` / `left_context` arrays inside every call. Within an MB the threading was correct, but at MB boundaries the encoder's contexts reset to zero while the decoder's frame-level contexts kept whatever state the previous MB had produced. For non-zero residuals (i.e. real content) the encoder wrote bits with prob row 0 / 0 while the decoder read them with prob row 1 / 2 — every block past the first row / column of each MB silently miscoded.

The visible symptom on master with a webcam stream is a stable, macroblock-aligned field of solid-coloured blocks. On the 32×16 checkerboard test added here, master decodes Y row 0 starting from MB 1 as `131,131,131,131,126,126,126,126,121,121,121,121...` — the probability-row mismatch collapses high-frequency tokens.

## Fix

**`mb_encoder.cs`** — `above_context` / `left_context` become optional parameters. When `null` (the default) the function allocates them locally; preserves the existing per-MB-isolation behaviour the `mb_encoder_unittest.cs` tests depend on. When non-null the caller maintains them at frame scope and passes them in by reference so they're mutated in place.

**`frame_encoder.cs`** — maintains a flat `frameAboveCtx[mbCols * 9]` buffer indexed by MB column position (one 9-slot context per column), copies the relevant slice into a per-MB `above_ctx` before each call, copies the mutated result back after. `left_ctx` is a single 9-slot array allocated and zeroed at the start of each MB row so it persists across MBs in a row but resets at row boundaries — exactly matching the libvpx decoder's threading rule.

Also fixes a small consistency bug in `mb_encoder`: the Y2 block's initial context was computed with boolean OR (`|`) instead of via `CombineCtx` (the `(above != 0) + (left != 0)` sum used everywhere else). With per-MB contexts both started at 0 so OR == sum; with frame-scope contexts both can be non-zero and the difference matters (`CombineCtx` returns `{0, 1, 2}`, OR returns `{0, 1}`).

## Tests

Adds two checkerboard tests that the prior `frame_encoder_unittest.cs` suite was missing — the previous round-trip tests all used uniform content, where every block reduces to a single EOB token and context state never matters.

| Test                           | master `maxErr` | this PR `maxErr` |
| ------------------------------ | --------------- | ---------------- |
| Checkerboard 32×16 (2 MBs row) | **97**          | **4**            |
| Checkerboard 32×32 (2×2 grid)  | **97**          | **4**            |

Both new tests assert `maxErr <= 16` — well below the bug-present floor (97) and above the bug-fixed ceiling (4), so the bound is robust to encoder tuning that doesn't change the underlying threading.

The 5 prior `frame_encoder` + 3 prior `mb_encoder` tests all still pass with the refactored signature. Full VP8.Net suite locally: **102 pass, 2 pre-existing System.Drawing/GDI+ failures (Windows-only Bitmap APIs) unchanged from master, 1 skip.**

## Diary

[#1573](https://github.com/sipsorcery-org/sipsorcery/pull/1573) flagged this fix as the immediate next step in the roadmap. Once both PRs land I'll push a small follow-up to update the diary file with the fix's actual numbers (this PR's `maxErr` table) and tick the bug off the "Known issues" list.

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.