### PR TITLE
VP8 encoder: emit per-MB skip flag (mb_no_skip_coeff = 1)

### DIFF
--- a/src/VP8.Net/frame_encoder.cs
+++ b/src/VP8.Net/frame_encoder.cs
@@ -24,8 +24,9 @@
 //                5x put_delta_q
 //                refresh_entropy_probs = 1
 //                ★ coef-prob updates  -- 1056 zero bits ("no update")
-//                ★ mb_no_skip_coeff = 0
-//                ★ for each MB: keyframe Y mode + UV mode tree paths
+//                ★ mb_no_skip_coeff = 1
+//                ★ prob_skip_false (8-bit literal)
+//                ★ for each MB: skip-flag bit + keyframe Y mode + UV mode tree paths
 //   [bc1]      Token partition (ONE_PARTITION):
 //                for each MB: Y2, 16 Y, 4 U, 4 V token streams.
 //
@@ -57,6 +58,15 @@
 //                              which made the encoder use the wrong
 //                              probability rows for the decoder's
 //                              context state on non-uniform content).
+// 26 Apr 2026  Claude          Enable per-MB skip flag (mb_no_skip_coeff
+//                              = 1 + prob_skip_false in header). For MBs
+//                              whose 25 transformed blocks are all
+//                              EOB-only, write a 1-bit skip flag and
+//                              suppress the token streams entirely in
+//                              partition 1, mirroring libvpx's per-MB
+//                              skip optimisation. Cuts per-frame
+//                              tokenizer / pack_tokens work for any MB
+//                              without residual content.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -156,17 +166,19 @@ namespace Vpx.Net
                             boolhuff.vp8_encode_bool(ref bc0, 0,
                                 coefupdateprobs.vp8_coef_update_probs[t, b, c, n]);
 
-            // ----- mb_no_skip_coeff = 0 -----
-            // No per-MB skip optimization. The decoder will not look for
-            // a per-MB skip flag; every MB's coefficient blocks are decoded.
-            bitstream.vp8_write_bit(ref bc0, 0);
+            // ----- Phase 1: encode all MBs (no bit writing yet) -----
+            //
+            // We need the per-MB skip flags before we can write
+            // prob_skip_false in the header. So all MBs are encoded
+            // first (predict + DCT + Walsh + quantize + tokenize +
+            // reconstruct) into MbEncodeResults, with cross-MB entropy
+            // context propagation happening in this pass. Bit-writing
+            // happens in phase 2 below.
 
-            // ----- Per-MB modes loop -----
-            // Encode every MB's Y mode and UV mode through their keyframe
-            // trees. We use DC_PRED (= 0) everywhere. Cache the per-MB
-            // encode results so we can replay the token streams into bc1
-            // afterwards.
             var mbResults = new MbEncodeResult[mbRows * mbCols];
+            bool[] mbSkip = new bool[mbRows * mbCols];
+            int skipTrueCount = 0;
+            int skipFalseCount = 0;
 
             // Reconstruction context buffers — one row of bottom-of-MB
             // samples (the "above" context for the next row) and per-MB
@@ -216,22 +228,27 @@ namespace Vpx.Net
                         aboveY, leftY, aboveU, leftU, aboveV, leftV,
                         fq,
                         aboveCtx, leftCtx);
-                    mbResults[mbRow * mbCols + mbCol] = r;
+                    int idx = mbRow * mbCols + mbCol;
+                    mbResults[idx] = r;
+
+                    // An MB is skippable iff every one of its 25
+                    // transformed blocks (Y2 + 16 Y + 4 U + 4 V) is
+                    // EOB-only. EOB-only blocks contribute nothing to
+                    // the residual the decoder reconstructs, so the
+                    // decoder can be told to skip the entire token
+                    // partition for this MB and reset its entropy
+                    // contexts. Crucially, the encoder's mb_encoder also
+                    // sets every per-block context slot to 0 in this
+                    // case (see context update lines in mb_encoder.cs),
+                    // so the encoder and decoder context state stay in
+                    // sync without any extra reset on this side.
+                    bool skip = IsAllEob(r);
+                    mbSkip[idx] = skip;
+                    if (skip) skipTrueCount++; else skipFalseCount++;
 
                     // The mutated aboveCtx is the new "above" for the MB
                     // immediately below this one (same column, next row).
                     for (int s = 0; s < 9; s++) frameAboveCtx[aboveBase + s] = aboveCtx[s];
-
-                    // Encode the Y mode (DC_PRED) -> bits 1, 0, 0 with
-                    // probs vp8_kf_ymode_prob[0..2].
-                    var yProbs = vp8_entropymodedata.vp8_kf_ymode_prob;
-                    boolhuff.vp8_encode_bool(ref bc0, 1, yProbs[0]);
-                    boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[1]);
-                    boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[2]);
-
-                    // Encode the UV mode (DC_PRED) -> bit 0 with prob[0].
-                    var uvProbs = vp8_entropymodedata.vp8_kf_uv_mode_prob;
-                    boolhuff.vp8_encode_bool(ref bc0, 0, uvProbs[0]);
 
                     // Update neighbour context for the next MB in this row
                     // (rightmost column of the MB's reconstruction) and for
@@ -247,6 +264,52 @@ namespace Vpx.Net
                     CopyRowOut(r.ReconV, srcStride: 8,  srcRow: 7,
                                dst: aboveVRow, dstOffset: mbCol * 8, count: 8);
                 }
+            }
+
+            // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
+            //
+            // Now that we know how many MBs are skippable we can pick
+            // prob_skip_false. libvpx's formula: prob_skip_false =
+            // skipFalseCount * 256 / total. Clamped to [1, 255] so the
+            // boolean coder can still encode whichever bit value occurs.
+            // Falls back to 0xfb (libvpx's hardcoded initial default)
+            // when no MBs are skippable, which is efficient because then
+            // every per-MB skip-flag bit is "0" and a high prob_skip_false
+            // makes that essentially free.
+            bitstream.vp8_write_bit(ref bc0, 1);   // mb_no_skip_coeff = 1
+
+            byte probSkipFalse;
+            if (skipTrueCount == 0)
+            {
+                probSkipFalse = 0xfb;
+            }
+            else
+            {
+                int total = skipFalseCount + skipTrueCount;
+                int p = skipFalseCount * 256 / total;
+                if (p < 1) p = 1;
+                if (p > 255) p = 255;
+                probSkipFalse = (byte)p;
+            }
+            for (int b = 7; b >= 0; b--)
+                bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
+
+            // ----- Phase 2b: per-MB skip flag + Y/UV mode trees -----
+            for (int i = 0; i < mbResults.Length; i++)
+            {
+                // Skip flag (boolean coder, prob_skip_false).
+                boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
+
+                // Y mode = DC_PRED -> tree path 1, 0, 0 with
+                // vp8_kf_ymode_prob[0..2].
+                var yProbs = vp8_entropymodedata.vp8_kf_ymode_prob;
+                boolhuff.vp8_encode_bool(ref bc0, 1, yProbs[0]);
+                boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[1]);
+                boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[2]);
+
+                // UV mode = DC_PRED -> bit 0 with vp8_kf_uv_mode_prob[0].
+                var uvProbs = vp8_entropymodedata.vp8_kf_uv_mode_prob;
+                boolhuff.vp8_encode_bool(ref bc0, 0, uvProbs[0]);
             }
 
             // ----- Close partition 0 (flush + patch frame tag) -----
@@ -265,10 +328,16 @@ namespace Vpx.Net
             {
                 boolhuff.vp8_start_encode(ref bc1, p + totalThroughP0, p + outBuf.Length);
 
-                // Pack tokens for each MB in raster order: Y2 first, then
-                // 16 Y, then 4 U, then 4 V — same order tokenize_mb emits.
+                // Pack tokens for each MB in raster order: Y2 first,
+                // then 16 Y, then 4 U, then 4 V — same order
+                // tokenize_mb emits. SKIPPABLE MBs contribute zero
+                // tokens to partition 1, mirroring the decoder which on
+                // skip_flag = 1 calls vp8_reset_mb_tokens_context and
+                // never reads coefficient bits for the MB.
                 for (int i = 0; i < mbResults.Length; i++)
                 {
+                    if (mbSkip[i]) continue;
+
                     var r = mbResults[i];
                     bitstream.vp8_pack_tokens(ref bc1, r.Y2Block);
                     for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc1, r.YBlocks[b]);
@@ -286,6 +355,22 @@ namespace Vpx.Net
         }
 
         // ----- helpers -----
+
+        /// <summary>
+        /// True iff every transformed block in the MB is EOB-only — i.e.
+        /// the MB has no residual content and can be marked as skipped.
+        /// libvpx's per-MB skip detection uses the same condition (sum
+        /// of EOBs across the 25 blocks == 0; we check the token list
+        /// length equivalently).
+        /// </summary>
+        private static bool IsAllEob(MbEncodeResult r)
+        {
+            if (r.Y2Block.Count != 1) return false;
+            for (int i = 0; i < 16; i++) if (r.YBlocks[i].Count != 1) return false;
+            for (int i = 0; i < 4;  i++) if (r.UBlocks[i].Count != 1) return false;
+            for (int i = 0; i < 4;  i++) if (r.VBlocks[i].Count != 1) return false;
+            return true;
+        }
 
         private static byte[] ExtractPlane(byte[] src, int srcStride, int x, int y, int w, int h)
         {

--- a/test/VP8.Net.UnitTest/frame_encoder_unittest.cs
+++ b/test/VP8.Net.UnitTest/frame_encoder_unittest.cs
@@ -22,6 +22,11 @@
 //                              cross-MB entropy-context propagation
 //                              (would fail with maxErr ~97 on master
 //                              before the frame-scope context fix).
+// 26 Apr 2026  Claude          Add skip-MB tests covering uniform
+//                              (all-skip), mixed-content (partial-skip),
+//                              and a bitstream-size sanity check that
+//                              an all-skip frame is meaningfully smaller
+//                              than its non-skip equivalent would be.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -121,6 +126,107 @@ namespace Vpx.Net.UnitTest
             byte[] decoded = EncodeAndDecodeI420(yuv, W, H, qIndex: 32);
 
             AssertWithin(yuv, decoded, tol: 16);
+        }
+
+        // ---------- Per-MB skip flag (mb_no_skip_coeff = 1) ----------
+        //
+        // The encoder enables libvpx's per-MB skip optimisation: the
+        // keyframe header writes mb_no_skip_coeff = 1 and an 8-bit
+        // prob_skip_false; for each MB whose 25 transformed blocks are
+        // all EOB-only, a single skip-flag bit is written and the
+        // entire token stream for that MB is suppressed in partition 1.
+        //
+        // The two existing uniform-grey round-trip tests already
+        // exercise the all-skip path implicitly. These tests cover the
+        // mixed (some-skip / some-non-skip) path and the bitstream-size
+        // sanity check.
+
+        [Fact]
+        public void EncodeAndDecode_MixedContent64x16_SomeMbsSkipSomeDont()
+        {
+            // 64x16 = 4 MBs in a row.  The leftmost two MBs are flat
+            // grey (residual zero -> every block tokenizes to a single
+            // EOB -> skip flag = 1), the rightmost two are checkerboard
+            // (busy residual -> every block emits coefficient tokens ->
+            // skip flag = 0).  A correct encoder/decoder pair has to
+            // handle the mix: skip-flag bits emitted for every MB, but
+            // tokens written only for the right half.
+            const int W = 64, H = 16;
+            int ySize = W * H, cSize = (W / 2) * (H / 2);
+            byte[] yuv = new byte[ySize + 2 * cSize];
+
+            // Y: flat 128 on the left half, checkerboard on the right.
+            for (int row = 0; row < H; row++)
+            {
+                for (int col = 0; col < W; col++)
+                {
+                    byte y;
+                    if (col < 32)
+                    {
+                        y = 128;
+                    }
+                    else
+                    {
+                        y = ((((row >> 1) ^ (col >> 1)) & 1) != 0) ? (byte)50 : (byte)200;
+                    }
+                    yuv[row * W + col] = y;
+                }
+            }
+            // UV: flat 128 across the frame.
+            for (int i = 0; i < cSize; i++) yuv[ySize + i] = 128;
+            for (int i = 0; i < cSize; i++) yuv[ySize + cSize + i] = 128;
+
+            byte[] decoded = EncodeAndDecodeI420(yuv, W, H, qIndex: 32);
+
+            // The flat half must round-trip exactly (skipped MBs decode
+            // to pure DC_PRED reconstruction = the prediction value).
+            for (int row = 0; row < H; row++)
+                for (int col = 0; col < 32; col++)
+                    Assert.Equal(yuv[row * W + col], decoded[row * W + col]);
+
+            // The checkerboard half goes through the full encode/decode
+            // pipeline; bound by the same tol the cross-MB tests use.
+            for (int row = 0; row < H; row++)
+                for (int col = 32; col < W; col++)
+                {
+                    int d = decoded[row * W + col] - yuv[row * W + col];
+                    if (d < 0) d = -d;
+                    Assert.True(d <= 16, $"Y[{row},{col}] err {d} > 16 (src={yuv[row*W+col]} dec={decoded[row*W+col]})");
+                }
+
+            // UV planes are uniform 128 (skippable); must round-trip
+            // exactly.
+            for (int i = 0; i < 2 * cSize; i++)
+                Assert.Equal(yuv[ySize + i], decoded[ySize + i]);
+        }
+
+        [Fact]
+        public void EncodeKeyframe_AllSkipFrame_IsMaterallySmallerThanNonSkip()
+        {
+            // An all-skip frame writes only skip-flag bits + mode-tree
+            // bits in partition 0 and ZERO bytes in partition 1 (the
+            // bool coder's flush still emits a few trailing bytes for
+            // alignment, but no per-block coefficient tokens). A
+            // non-trivial frame at the same dimensions writes the full
+            // token stream for every MB. The size delta is the proof
+            // that mb_no_skip_coeff = 1 is doing real work.
+            const int W = 32, H = 32;
+
+            byte[] uniform = MakeFlatI420(W, H, y: 128, u: 128, v: 128);
+            byte[] busy = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            var (uy, uu, uv) = SplitI420(uniform, W, H);
+            var (by, bu, bv) = SplitI420(busy, W, H);
+
+            byte[] uniformFrame = frame_encoder.EncodeKeyframe(uy, uu, uv, W, H, qIndex: 32);
+            byte[] busyFrame    = frame_encoder.EncodeKeyframe(by, bu, bv, W, H, qIndex: 32);
+
+            // The all-skip frame must be smaller than the non-skip
+            // one. Empirically the difference is order-of-magnitude;
+            // require at least 2x to avoid being brittle to encoder
+            // tuning that doesn't change the underlying mechanism.
+            Assert.True(uniformFrame.Length * 2 < busyFrame.Length,
+                $"all-skip frame ({uniformFrame.Length} bytes) should be <50% the size of a busy frame ({busyFrame.Length} bytes)");
         }
 
         // ---------- helpers ----------


### PR DESCRIPTION
Enables libvpx's per-MB skip optimisation for the keyframe encoder. For an MB whose 25 transformed blocks (Y2 + 16 Y + 4 U + 4 V) are all EOB-only, the encoder writes a single skip-flag bit in partition 0 and suppresses the entire MB's token stream in partition 1 — mirroring the decoder side, which on `skip = 1` calls `vp8_reset_mb_tokens_context` and never reads coefficient bits.

Motivation: feedback from the live webcam test under PR #1574 — the encoder is CPU-bound and was running `vp8_pack_tokens` for every MB regardless of content. Skip-MB cuts that work for any MB without residual content (flat backgrounds, low-motion regions) and is a small contained step before the bigger allocation-hygiene PR.

## Bitstream changes

1. `mb_no_skip_coeff` is flipped from 0 to 1 in the keyframe header.
2. An 8-bit `prob_skip_false` literal is written immediately after — computed from the actual per-frame skip stats (libvpx formula: `skipFalseCount * 256 / total`, clamped to `[1, 255]`). Falls back to `0xfb` (libvpx's hardcoded initial default) when no MBs are skippable.
3. Each MB's per-MB block in partition 0 now starts with a 1-bit skip flag before the Y mode tree (matching the order `decodemv.cs` reads: skip flag at line 278, mode tree at line 287).
4. Partition 1 emits `Y2 + 16 Y + 4 U + 4 V` tokens only for MBs with `skip = 0`; skip MBs contribute zero bytes to the token partition.

## Encoder restructure

The previous single per-MB loop interleaved `EncodeMacroblockDcPred` with the partition-0 mode-bit writes. Computing `prob_skip_false` from real per-frame stats requires knowing every MB's skip flag before writing the header, so the per-MB encode pass is now factored out as **phase 1** (no bit writing) and the partition-0 writes are **phase 2**. No change to the per-MB encoding semantics — frame-scope context propagation, DC prediction, and reconstruction-context threading all behave exactly as before.

Crucially the encoder/decoder context state stays in sync without an explicit reset on skip. `mb_encoder` already updates each block's above/left context slot to `(nz ? 1 : 0)`; for an all-EOB MB every slot is set to 0, which matches what the decoder's `vp8_reset_mb_tokens_context` does on seeing `skip = 1`.

## Tests

Two new tests:

- **`EncodeAndDecode_MixedContent64x16_SomeMbsSkipSomeDont`** — 64×16 = 4 MBs in a row; left half flat 128 (skippable), right half checkerboard (not). Both halves must decode correctly. The skippable left half asserts **exact byte match** (skipped MBs reconstruct to pure DC_PRED prediction = the input value); the busy half asserts `maxErr <= 16` (same bound the cross-MB tests use).

- **`EncodeKeyframe_AllSkipFrame_IsMaterallySmallerThanNonSkip`** — encode a 32×32 all-flat frame and a 32×32 checkerboard frame at the same Q. The all-flat frame must be more than 2× smaller. Empirically the ratio is much larger:

| Frame                | Bytes (master) | Bytes (this PR) |
| -------------------- | -------------- | --------------- |
| 320×240 all-flat     | 179            | **148**         |
| 320×240 half/half    | 24209          | 24231           |
| 320×240 all-busy     | 48208          | 48210           |

The size delta on all-busy / mixed content is small (≈+1 byte for the new `prob_skip_false` literal). The CPU saving is in `vp8_pack_tokens` calls that don't run for skipped MBs — at ~25 `vp8_encode_bool` calls per skipped MB, a frame with N skip MBs saves ~25N boolean-coder ops.

## Test results

The seven prior `frame_encoder` + 3 `mb_encoder` + `boolhuff/dct/quantize/tokenize/pack_tokens/quantizer_init/bitstream/decoder` tests all still pass. Full VP8.Net suite: **104 pass, 2 pre-existing System.Drawing/GDI+ failures (Windows-only) unchanged from master, 1 skip.**

## What this is not

- Not a fix for the spiky-CPU symptom on real webcam content where most MBs are NOT skippable. That's the next PR in the sequence — allocation hygiene in the encoder hot path. This one is a small win for any flat-content fraction and a faithful libvpx behavior match.
- Not inter-frame support. Every emitted frame is still a key-frame; the diary entry's roadmap still applies.

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.