### PR TITLE
VP8 encoder: allocation hygiene pass — eliminate per-frame GC pressure

### DIFF
--- a/src/VP8.Net/VP8Codec.cs
+++ b/src/VP8.Net/VP8Codec.cs
@@ -47,6 +47,14 @@ namespace Vpx.Net
         public VP8Codec()
         { }
 
+        // Pooled per-instance plane-split buffers, reused across calls.
+        // Resized lazily when the input dimensions change. Allocating these
+        // afresh each frame was a major chunk of the encoder's GC pressure
+        // (~440 KB per 640x480 frame).
+        private byte[] _srcY;
+        private byte[] _srcU;
+        private byte[] _srcV;
+
         public void ForceKeyFrame() => _forceKeyFrame = true;
         public bool IsSupported(VideoCodecsEnum codec) => codec == VideoCodecsEnum.VP8;
 
@@ -80,19 +88,18 @@ namespace Vpx.Net
                         (ySize + 2 * cSize) + " for " + width + "x" + height + ".");
                 }
 
-                byte[] srcY = new byte[ySize];
-                byte[] srcU = new byte[cSize];
-                byte[] srcV = new byte[cSize];
-                Buffer.BlockCopy(i420, 0,             srcY, 0, ySize);
-                Buffer.BlockCopy(i420, ySize,         srcU, 0, cSize);
-                Buffer.BlockCopy(i420, ySize + cSize, srcV, 0, cSize);
+                if (_srcY == null || _srcY.Length < ySize) _srcY = new byte[ySize];
+                if (_srcU == null || _srcU.Length < cSize) { _srcU = new byte[cSize]; _srcV = new byte[cSize]; }
+                Buffer.BlockCopy(i420, 0,             _srcY, 0, ySize);
+                Buffer.BlockCopy(i420, ySize,         _srcU, 0, cSize);
+                Buffer.BlockCopy(i420, ySize + cSize, _srcV, 0, cSize);
 
                 // ForceKeyFrame is currently the only mode (every frame is a
                 // keyframe in the foundation encoder). Reset the flag for
                 // API parity with future inter-frame support.
                 _forceKeyFrame = false;
 
-                return frame_encoder.EncodeKeyframe(srcY, srcU, srcV, width, height, DEFAULT_BASE_QINDEX);
+                return frame_encoder.EncodeKeyframe(_srcY, _srcU, _srcV, width, height, DEFAULT_BASE_QINDEX);
             }
         }
 

--- a/src/VP8.Net/frame_encoder.cs
+++ b/src/VP8.Net/frame_encoder.cs
@@ -67,6 +67,16 @@
 //                              skip optimisation. Cuts per-frame
 //                              tokenizer / pack_tokens work for any MB
 //                              without residual content.
+// 26 Apr 2026  Claude          Allocation hygiene pass: pool the per-MB
+//                              MbEncodeResult and scratch buffers in a
+//                              ThreadStatic FrameEncoderBuffers struct
+//                              that lives for the lifetime of the
+//                              encoding thread and is resized lazily on
+//                              dimension changes. Per-frame allocations
+//                              drop from ~18 MB to a few KB. Also fold
+//                              the ExtractPlane / ExtractRow /
+//                              ExtractColumn helpers from "allocate &
+//                              return" to "fill in place" form.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -87,8 +97,102 @@ using System.Collections.Generic;
 
 namespace Vpx.Net
 {
+    /// <summary>
+    /// Per-thread reusable scratch + pool storage for frame_encoder.
+    /// Allocated lazily on first call and resized only when the frame
+    /// dimensions change (which is rare in a streaming workload — the
+    /// camera/source resolution is usually fixed).
+    ///
+    /// All buffers held here are pure storage with no per-frame state;
+    /// the encoder fills them anew on every call.
+    /// </summary>
+    internal sealed class FrameEncoderBuffers
+    {
+        public int Width;
+        public int Height;
+        public int MbCols;
+        public int MbRows;
+
+        // Pool of MbEncodeResult instances, one per MB position. Each is
+        // Reset()'d before reuse.
+        public MbEncodeResult[] MbResults;
+        public bool[] MbSkip;
+
+        // Per-MB scratch shared by all MBs (single instance — only one MB
+        // is being encoded at a time on this thread).
+        public MbEncoderScratch Scratch = new MbEncoderScratch();
+
+        // Per-MB context state.
+        public byte[] FrameAboveCtx;     // mbCols * 9
+        public byte[] LeftCtx = new byte[9];
+        public byte[] AboveCtx = new byte[9];
+
+        // Reconstruction context buffers.
+        public byte[] AboveYRow;         // width
+        public byte[] AboveURow;         // width / 2
+        public byte[] AboveVRow;         // width / 2
+        public byte[] LeftY = new byte[16];
+        public byte[] LeftU = new byte[8];
+        public byte[] LeftV = new byte[8];
+        public byte[] AboveY = new byte[16];
+        public byte[] AboveU = new byte[8];
+        public byte[] AboveV = new byte[8];
+
+        // Per-MB source slices.
+        public byte[] MbY = new byte[256];
+        public byte[] MbU = new byte[64];
+        public byte[] MbV = new byte[64];
+
+        // Output buffer.
+        public byte[] OutBuf;
+
+        public void EnsureForFrame(int width, int height)
+        {
+            int chromaW = width / 2;
+            int mbCols = width / 16;
+            int mbRows = height / 16;
+            int total = mbCols * mbRows;
+
+            if (MbResults == null || MbResults.Length < total)
+            {
+                int oldLen = MbResults?.Length ?? 0;
+                var newResults = new MbEncodeResult[total];
+                if (oldLen > 0) System.Array.Copy(MbResults, newResults, oldLen);
+                for (int i = oldLen; i < total; i++) newResults[i] = new MbEncodeResult();
+                MbResults = newResults;
+            }
+            if (MbSkip == null || MbSkip.Length < total) MbSkip = new bool[total];
+
+            if (FrameAboveCtx == null || FrameAboveCtx.Length < mbCols * 9)
+                FrameAboveCtx = new byte[mbCols * 9];
+
+            if (AboveYRow == null || AboveYRow.Length < width)
+                AboveYRow = new byte[width];
+            if (AboveURow == null || AboveURow.Length < chromaW)
+            {
+                AboveURow = new byte[chromaW];
+                AboveVRow = new byte[chromaW];
+            }
+
+            int bufLen = System.Math.Max(4096, width * height * 2 + 1024);
+            if (OutBuf == null || OutBuf.Length < bufLen)
+                OutBuf = new byte[bufLen];
+
+            Width = width;
+            Height = height;
+            MbCols = mbCols;
+            MbRows = mbRows;
+        }
+    }
+
     public static unsafe class frame_encoder
     {
+        // Per-thread reusable buffers. Most encoders are called from the
+        // same thread for the lifetime of a stream, so this amortises the
+        // per-frame allocations to (effectively) zero after the first
+        // call.
+        [System.ThreadStatic]
+        private static FrameEncoderBuffers _buffers;
         // The keyframe Y mode tree (vp8_kf_ymode_tree, in entropymode.cs)
         // contains 4 internal nodes; the 4 corresponding probabilities live
         // in vp8_kf_ymode_prob = { 145, 156, 163, 128 }.
@@ -128,17 +232,19 @@ namespace Vpx.Net
             // Build the quantizer for this Q index.
             FrameQuantizer fq = quantizer_init.BuildForQIndex(qIndex);
 
+            // Pull per-thread scratch buffers (allocated lazily on first
+            // call, resized only on dimension changes).
+            var buf = _buffers ??= new FrameEncoderBuffers();
+            buf.EnsureForFrame(width, height);
+            var scratch = buf.Scratch;
+
             var cfg = new KeyframeHeaderConfig
             {
                 Width = width, Height = height,
                 BaseQindex = qIndex,
             };
 
-            // Allocate a generous output buffer. For the sizes we deal with
-            // (small synthetic frames) 64KB is plenty; production callers
-            // would size based on the source.
-            int bufLen = Math.Max(4096, width * height * 2 + 1024);
-            byte[] outBuf = new byte[bufLen];
+            byte[] outBuf = buf.OutBuf;
 
             // ----- Open the compressed first partition (header through refresh_entropy_probs) -----
             BOOL_CODER bc0 = new BOOL_CODER();
@@ -175,19 +281,16 @@ namespace Vpx.Net
             // context propagation happening in this pass. Bit-writing
             // happens in phase 2 below.
 
-            var mbResults = new MbEncodeResult[mbRows * mbCols];
-            bool[] mbSkip = new bool[mbRows * mbCols];
+            MbEncodeResult[] mbResults = buf.MbResults;
+            bool[] mbSkip = buf.MbSkip;
             int skipTrueCount = 0;
             int skipFalseCount = 0;
 
-            // Reconstruction context buffers — one row of bottom-of-MB
-            // samples (the "above" context for the next row) and per-MB
-            // right-edge buffers (the "left" context for the next MB in
-            // the row).
-            byte[] aboveYRow = new byte[width];
-            byte[] aboveURow = new byte[chromaW];
-            byte[] aboveVRow = new byte[chromaW];
-            // First row has no "above"; null indicates "use 128 default".
+            // Reconstruction context buffers (per-row "above" cache;
+            // per-MB "left" reused across MBs in a row).
+            byte[] aboveYRow = buf.AboveYRow;
+            byte[] aboveURow = buf.AboveURow;
+            byte[] aboveVRow = buf.AboveVRow;
 
             // Frame-scope entropy contexts. The above row stores one
             // 9-slot context per MB column position (4 Y + 2 U + 2 V + 1
@@ -197,38 +300,64 @@ namespace Vpx.Net
             // array that persists across MBs in a row and is reset at
             // each row boundary (no wrap-around). C-array layout (flat,
             // row-major-ish): aboveCtx[mbCol * 9 + slot].
-            byte[] frameAboveCtx = new byte[mbCols * 9];
+            byte[] frameAboveCtx = buf.FrameAboveCtx;
+            Array.Clear(frameAboveCtx, 0, mbCols * 9);
+
+            byte[] leftCtx = buf.LeftCtx;
+            byte[] aboveCtx = buf.AboveCtx;
+            byte[] mbY = buf.MbY;
+            byte[] mbU = buf.MbU;
+            byte[] mbV = buf.MbV;
+            byte[] aboveY = buf.AboveY;
+            byte[] aboveU = buf.AboveU;
+            byte[] aboveV = buf.AboveV;
+            byte[] leftY = buf.LeftY;
+            byte[] leftU = buf.LeftU;
+            byte[] leftV = buf.LeftV;
 
             for (int mbRow = 0; mbRow < mbRows; mbRow++)
             {
-                byte[] leftY = null, leftU = null, leftV = null;
-                byte[] leftCtx = new byte[9];   // reset at the start of each MB row
+                bool haveLeftNeighbour = false;
+                Array.Clear(leftCtx, 0, 9);
 
                 for (int mbCol = 0; mbCol < mbCols; mbCol++)
                 {
                     // Slice the 16x16 + 8x8 + 8x8 source for this MB.
-                    byte[] mbY = ExtractPlane(srcY, width,  mbCol * 16, mbRow * 16, 16, 16);
-                    byte[] mbU = ExtractPlane(srcU, chromaW, mbCol * 8,  mbRow * 8,  8, 8);
-                    byte[] mbV = ExtractPlane(srcV, chromaW, mbCol * 8,  mbRow * 8,  8, 8);
+                    ExtractPlaneInto(srcY, width,  mbCol * 16, mbRow * 16, 16, 16, mbY);
+                    ExtractPlaneInto(srcU, chromaW, mbCol * 8,  mbRow * 8,  8, 8,  mbU);
+                    ExtractPlaneInto(srcV, chromaW, mbCol * 8,  mbRow * 8,  8, 8,  mbV);
 
                     // Slice the relevant 16-byte (resp 8-byte) above row.
-                    byte[] aboveY = (mbRow == 0) ? null : ExtractRow(aboveYRow, mbCol * 16, 16);
-                    byte[] aboveU = (mbRow == 0) ? null : ExtractRow(aboveURow, mbCol * 8, 8);
-                    byte[] aboveV = (mbRow == 0) ? null : ExtractRow(aboveVRow, mbCol * 8, 8);
+                    bool haveAbove = mbRow > 0;
+                    if (haveAbove)
+                    {
+                        ExtractRowInto(aboveYRow, mbCol * 16, 16, aboveY);
+                        ExtractRowInto(aboveURow, mbCol * 8,  8,  aboveU);
+                        ExtractRowInto(aboveVRow, mbCol * 8,  8,  aboveV);
+                    }
 
                     // Pull this MB column's above context out of the
                     // frame-scope buffer; mb_encoder mutates it in place
                     // as it processes blocks, then we copy it back.
-                    byte[] aboveCtx = new byte[9];
                     int aboveBase = mbCol * 9;
                     for (int s = 0; s < 9; s++) aboveCtx[s] = frameAboveCtx[aboveBase + s];
 
+                    int idx = mbRow * mbCols + mbCol;
+                    var pooled = mbResults[idx];
+
                     var r = mb_encoder.EncodeMacroblockDcPred(
                         mbY, mbU, mbV,
-                        aboveY, leftY, aboveU, leftU, aboveV, leftV,
+                        haveAbove        ? aboveY : null,
+                        haveLeftNeighbour ? leftY : null,
+                        haveAbove        ? aboveU : null,
+                        haveLeftNeighbour ? leftU : null,
+                        haveAbove        ? aboveV : null,
+                        haveLeftNeighbour ? leftV : null,
                         fq,
-                        aboveCtx, leftCtx);
-                    int idx = mbRow * mbCols + mbCol;
+                        aboveCtx, leftCtx,
+                        pooled, scratch);
+                    // r is the same instance as `pooled`; explicit assign
+                    // not strictly needed but kept for symmetry.
                     mbResults[idx] = r;
 
                     // An MB is skippable iff every one of its 25
@@ -253,9 +382,10 @@ namespace Vpx.Net
                     // Update neighbour context for the next MB in this row
                     // (rightmost column of the MB's reconstruction) and for
                     // the next row (bottommost row).
-                    leftY = ExtractColumn(r.ReconY, srcStride: 16, columnIndex: 15, rows: 16);
-                    leftU = ExtractColumn(r.ReconU, srcStride: 8,  columnIndex: 7,  rows: 8);
-                    leftV = ExtractColumn(r.ReconV, srcStride: 8,  columnIndex: 7,  rows: 8);
+                    ExtractColumnInto(r.ReconY, srcStride: 16, columnIndex: 15, rows: 16, dst: leftY);
+                    ExtractColumnInto(r.ReconU, srcStride: 8,  columnIndex: 7,  rows: 8,  dst: leftU);
+                    ExtractColumnInto(r.ReconV, srcStride: 8,  columnIndex: 7,  rows: 8,  dst: leftV);
+                    haveLeftNeighbour = true;
 
                     CopyRowOut(r.ReconY, srcStride: 16, srcRow: 15,
                                dst: aboveYRow, dstOffset: mbCol * 16, count: 16);
@@ -295,7 +425,8 @@ namespace Vpx.Net
                 bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
 
             // ----- Phase 2b: per-MB skip flag + Y/UV mode trees -----
-            for (int i = 0; i < mbResults.Length; i++)
+            int totalMbsP2 = mbRows * mbCols;
+            for (int i = 0; i < totalMbsP2; i++)
             {
                 // Skip flag (boolean coder, prob_skip_false).
                 boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
@@ -334,7 +465,8 @@ namespace Vpx.Net
                 // tokens to partition 1, mirroring the decoder which on
                 // skip_flag = 1 calls vp8_reset_mb_tokens_context and
                 // never reads coefficient bits for the MB.
-                for (int i = 0; i < mbResults.Length; i++)
+                int totalMbs = mbRows * mbCols;
+                for (int i = 0; i < totalMbs; i++)
                 {
                     if (mbSkip[i]) continue;
 
@@ -372,27 +504,21 @@ namespace Vpx.Net
             return true;
         }
 
-        private static byte[] ExtractPlane(byte[] src, int srcStride, int x, int y, int w, int h)
+        private static void ExtractPlaneInto(byte[] src, int srcStride, int x, int y, int w, int h, byte[] dst)
         {
-            var b = new byte[w * h];
             for (int r = 0; r < h; r++)
                 for (int c = 0; c < w; c++)
-                    b[r * w + c] = src[(y + r) * srcStride + (x + c)];
-            return b;
+                    dst[r * w + c] = src[(y + r) * srcStride + (x + c)];
         }
 
-        private static byte[] ExtractRow(byte[] src, int offset, int count)
+        private static void ExtractRowInto(byte[] src, int offset, int count, byte[] dst)
         {
-            var b = new byte[count];
-            for (int i = 0; i < count; i++) b[i] = src[offset + i];
-            return b;
+            for (int i = 0; i < count; i++) dst[i] = src[offset + i];
         }
 
-        private static byte[] ExtractColumn(byte[] src, int srcStride, int columnIndex, int rows)
+        private static void ExtractColumnInto(byte[] src, int srcStride, int columnIndex, int rows, byte[] dst)
         {
-            var b = new byte[rows];
-            for (int r = 0; r < rows; r++) b[r] = src[r * srcStride + columnIndex];
-            return b;
+            for (int r = 0; r < rows; r++) dst[r] = src[r * srcStride + columnIndex];
         }
 
         private static void CopyRowOut(byte[] src, int srcStride, int srcRow,

--- a/src/VP8.Net/mb_encoder.cs
+++ b/src/VP8.Net/mb_encoder.cs
@@ -37,6 +37,18 @@
 //                              them at frame scope (cross-MB context
 //                              propagation). Also fix Y2 initial
 //                              context from boolean OR to CombineCtx.
+// 26 Apr 2026  Claude          Allocation hygiene pass: add optional
+//                              MbEncodeResult result and MbEncoderScratch
+//                              scratch parameters so the per-MB encode
+//                              path allocates nothing when called from
+//                              a pooled-state caller. MbEncodeResult
+//                              gains a Reset() method that clears its
+//                              25 token lists in place (initial capacity
+//                              17 each so they never grow). All inner
+//                              short[][] arrays are now scratch-pool
+//                              backed; the small fixed-size buffers in
+//                              IdctAndAddToPlane and InverseWalsh4x4
+//                              are stackalloc.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -70,10 +82,15 @@ namespace Vpx.Net
     /// </summary>
     public sealed class MbEncodeResult
     {
+        // Per-block token storage. Each list is pre-allocated with capacity
+        // 17 (16 coefficients max + 1 trailing EOB) so Add() never grows
+        // the backing array. Reset() clears all 25 lists in place without
+        // releasing the storage — designed for pool-based reuse from
+        // frame_encoder so per-MB encoding doesn't allocate.
         public List<TOKENEXTRA>[] YBlocks  = new List<TOKENEXTRA>[16];
         public List<TOKENEXTRA>[] UBlocks  = new List<TOKENEXTRA>[4];
         public List<TOKENEXTRA>[] VBlocks  = new List<TOKENEXTRA>[4];
-        public List<TOKENEXTRA>  Y2Block  = new List<TOKENEXTRA>();
+        public List<TOKENEXTRA>  Y2Block  = new List<TOKENEXTRA>(17);
 
         /// <summary>Reconstructed 16x16 luma pixels, raster order.</summary>
         public byte[] ReconY = new byte[16 * 16];
@@ -83,6 +100,63 @@ namespace Vpx.Net
 
         /// <summary>Reconstructed 8x8 V pixels, raster order.</summary>
         public byte[] ReconV = new byte[8 * 8];
+
+        public MbEncodeResult()
+        {
+            for (int i = 0; i < 16; i++) YBlocks[i] = new List<TOKENEXTRA>(17);
+            for (int i = 0; i < 4;  i++) UBlocks[i] = new List<TOKENEXTRA>(17);
+            for (int i = 0; i < 4;  i++) VBlocks[i] = new List<TOKENEXTRA>(17);
+        }
+
+        /// <summary>Clear all 25 token lists in place. Backing arrays are
+        /// retained so the next encode pass into this result allocates
+        /// nothing.</summary>
+        public void Reset()
+        {
+            Y2Block.Clear();
+            for (int i = 0; i < 16; i++) YBlocks[i].Clear();
+            for (int i = 0; i < 4;  i++) UBlocks[i].Clear();
+            for (int i = 0; i < 4;  i++) VBlocks[i].Clear();
+        }
+    }
+
+    /// <summary>
+    /// Per-MB scratch buffers held by the caller (frame_encoder) and
+    /// passed back into EncodeMacroblockDcPred so the per-MB encode path
+    /// allocates nothing on the hot path. All buffers are sized for the
+    /// fixed 16x16 luma + 8x8 chroma macroblock layout; nothing in here
+    /// has any state across calls — it's just storage.
+    /// </summary>
+    public sealed class MbEncoderScratch
+    {
+        public short[] ResidY = new short[256];   // 16x16 residual after DC_PRED subtract
+        public short[] ResidU = new short[64];    // 8x8 chroma U residual
+        public short[] ResidV = new short[64];    // 8x8 chroma V residual
+
+        public short[][] YCoef = new short[16][]; // 16 4x4 Y forward DCT outputs
+        public short[][] UCoef = new short[4][];  // 4 4x4 U forward DCT outputs
+        public short[][] VCoef = new short[4][];  // 4 4x4 V forward DCT outputs
+        public short[]   Y2In  = new short[16];   // 16 Y DCs prior to Walsh
+        public short[]   Y2Coef = new short[16];  // Walsh output
+
+        public short[][] YQ  = new short[16][];   // quantized Y AC blocks
+        public short[][] YDQ = new short[16][];   // dequantized Y AC blocks
+        public short[]   Y2Q  = new short[16];    // quantized Y2
+        public short[]   Y2DQ = new short[16];    // dequantized Y2
+        public short[][] UQ  = new short[4][];
+        public short[][] UDQ = new short[4][];
+        public short[][] VQ  = new short[4][];
+        public short[][] VDQ = new short[4][];
+        public int[]     YEob = new int[16];
+        public int[]     UEob = new int[4];
+        public int[]     VEob = new int[4];
+
+        public MbEncoderScratch()
+        {
+            for (int i = 0; i < 16; i++) { YCoef[i] = new short[16]; YQ[i] = new short[16]; YDQ[i] = new short[16]; }
+            for (int i = 0; i < 4;  i++) { UCoef[i] = new short[16]; UQ[i] = new short[16]; UDQ[i] = new short[16]; }
+            for (int i = 0; i < 4;  i++) { VCoef[i] = new short[16]; VQ[i] = new short[16]; VDQ[i] = new short[16]; }
+        }
     }
 
     public static class mb_encoder
@@ -119,7 +193,9 @@ namespace Vpx.Net
             byte[] aboveV, byte[] leftV,
             FrameQuantizer fq,
             byte[] aboveCtx = null,
-            byte[] leftCtx = null)
+            byte[] leftCtx = null,
+            MbEncodeResult result = null,
+            MbEncoderScratch scratch = null)
         {
             if (srcY == null || srcY.Length != 256) throw new ArgumentException("srcY must be 16*16");
             if (srcU == null || srcU.Length != 64)  throw new ArgumentException("srcU must be 8*8");
@@ -130,7 +206,19 @@ namespace Vpx.Net
             if (leftCtx != null && leftCtx.Length != 9)
                 throw new ArgumentException("leftCtx must have length 9 (4 Y + 2 U + 2 V + 1 Y2)", nameof(leftCtx));
 
-            var result = new MbEncodeResult();
+            // Pool semantics: when called by frame_encoder with a pooled
+            // result the caller has already Reset()'d the lists; when
+            // called by unit tests (or an external caller) without a
+            // pooled result, allocate a fresh one. Same for scratch.
+            if (result == null)
+            {
+                result = new MbEncodeResult();
+            }
+            else
+            {
+                result.Reset();
+            }
+            if (scratch == null) scratch = new MbEncoderScratch();
 
             // ---- Step 1: DC predictions ----
             byte yPred = DcPred16x16(aboveY, leftY);
@@ -138,31 +226,37 @@ namespace Vpx.Net
             byte vPred = DcPred8x8(aboveV, leftV);
 
             // ---- Step 2: residual = source - prediction ----
-            short[] residY = SubtractFlat(srcY, yPred);
-            short[] residU = SubtractFlat(srcU, uPred);
-            short[] residV = SubtractFlat(srcV, vPred);
+            short[] residY = scratch.ResidY;
+            short[] residU = scratch.ResidU;
+            short[] residV = scratch.ResidV;
+            SubtractFlatInto(srcY, yPred, residY);
+            SubtractFlatInto(srcU, uPred, residU);
+            SubtractFlatInto(srcV, vPred, residV);
 
             // ---- Step 3: forward DCT for each 4x4 block ----
             // Y: 16 blocks of 4x4 carved out of the 16x16 plane.
-            short[][] yCoef = new short[16][];
+            short[][] yCoef = scratch.YCoef;
             for (int by = 0; by < 4; by++)
             for (int bx = 0; bx < 4; bx++)
             {
                 int blkIdx = by * 4 + bx;
-                yCoef[blkIdx] = Fdct4x4FromPlane(residY, srcStride: 16,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                Fdct4x4FromPlaneInto(residY, srcStride: 16,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                    coef: yCoef[blkIdx]);
             }
             // U / V: 4 blocks of 4x4 each.
-            short[][] uCoef = new short[4][];
-            short[][] vCoef = new short[4][];
+            short[][] uCoef = scratch.UCoef;
+            short[][] vCoef = scratch.VCoef;
             for (int by = 0; by < 2; by++)
             for (int bx = 0; bx < 2; bx++)
             {
                 int blkIdx = by * 2 + bx;
-                uCoef[blkIdx] = Fdct4x4FromPlane(residU, srcStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
-                vCoef[blkIdx] = Fdct4x4FromPlane(residV, srcStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                Fdct4x4FromPlaneInto(residU, srcStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                    coef: uCoef[blkIdx]);
+                Fdct4x4FromPlaneInto(residV, srcStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                    coef: vCoef[blkIdx]);
             }
 
             // ---- Step 4: build Y2 block from the 16 Y DCs and Walsh-transform ----
@@ -170,33 +264,36 @@ namespace Vpx.Net
             // 16 Y DC coefficients are themselves transformed by a 4x4 Walsh
             // and then quantized as a "Y2" second-order block. The 16 Y AC
             // blocks then drop their DC (zero out coef[0]).
-            short[] y2In = new short[16];
+            short[] y2In = scratch.Y2In;
             for (int i = 0; i < 16; i++) y2In[i] = yCoef[i][0];
-            short[] y2Coef = Walsh4x4(y2In);
+            short[] y2Coef = scratch.Y2Coef;
+            Walsh4x4Into(y2In, y2Coef);
 
             // Zero out the DC of each Y AC block.
             for (int i = 0; i < 16; i++) yCoef[i][0] = 0;
 
             // ---- Step 5: quantize ----
-            short[][] yQ = new short[16][], yDQ = new short[16][];
-            int[] yEob = new int[16];
+            short[][] yQ = scratch.YQ;
+            short[][] yDQ = scratch.YDQ;
+            int[] yEob = scratch.YEob;
             for (int i = 0; i < 16; i++)
             {
-                yQ[i] = new short[16]; yDQ[i] = new short[16];
                 yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i]);
             }
 
-            short[] y2Q = new short[16], y2DQ = new short[16];
+            short[] y2Q = scratch.Y2Q;
+            short[] y2DQ = scratch.Y2DQ;
             int y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ);
 
-            short[][] uQ = new short[4][], uDQ = new short[4][];
-            short[][] vQ = new short[4][], vDQ = new short[4][];
-            int[] uEob = new int[4], vEob = new int[4];
+            short[][] uQ = scratch.UQ;
+            short[][] uDQ = scratch.UDQ;
+            short[][] vQ = scratch.VQ;
+            short[][] vDQ = scratch.VDQ;
+            int[] uEob = scratch.UEob;
+            int[] vEob = scratch.VEob;
             for (int i = 0; i < 4; i++)
             {
-                uQ[i] = new short[16]; uDQ[i] = new short[16];
                 uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i]);
-                vQ[i] = new short[16]; vDQ[i] = new short[16];
                 vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i]);
             }
 
@@ -250,7 +347,6 @@ namespace Vpx.Net
             // -- Y2 block (block index 24) --
             int slot = entropy.vp8_block2above[24];   // = 8
             int slotL = entropy.vp8_block2left[24];   // = 8
-            result.Y2Block = new List<TOKENEXTRA>();
             bool y2NonZero = tokenize.vp8_tokenize_block(y2Q,
                 firstCoeffIndex: 0, eob: y2Eob,
                 blockType: 1,
@@ -264,7 +360,6 @@ namespace Vpx.Net
             {
                 int s = entropy.vp8_block2above[i];
                 int sL = entropy.vp8_block2left[i];
-                result.YBlocks[i] = new List<TOKENEXTRA>();
                 bool nz = tokenize.vp8_tokenize_block(yQ[i],
                     firstCoeffIndex: 1, eob: yEob[i],
                     blockType: 0,
@@ -280,7 +375,6 @@ namespace Vpx.Net
                 int blkIdx = 16 + i;
                 int s = entropy.vp8_block2above[blkIdx];
                 int sL = entropy.vp8_block2left[blkIdx];
-                result.UBlocks[i] = new List<TOKENEXTRA>();
                 bool nz = tokenize.vp8_tokenize_block(uQ[i],
                     firstCoeffIndex: 0, eob: uEob[i],
                     blockType: 2,
@@ -296,7 +390,6 @@ namespace Vpx.Net
                 int blkIdx = 20 + i;
                 int s = entropy.vp8_block2above[blkIdx];
                 int sL = entropy.vp8_block2left[blkIdx];
-                result.VBlocks[i] = new List<TOKENEXTRA>();
                 bool nz = tokenize.vp8_tokenize_block(vQ[i],
                     firstCoeffIndex: 0, eob: vEob[i],
                     blockType: 2,
@@ -308,12 +401,13 @@ namespace Vpx.Net
 
             // ---- Step 7: reconstruct ----
             // Inverse Walsh on the Y2 block to recover the (quantized) DC of
-            // each Y block. libvpx's inverse Walsh writes the per-block DC
-            // into mb_dqcoeff[i*16].
-            short[] y2InvOut = InverseWalsh4x4(y2DQ);
+            // each Y block. We write directly into the existing y2In scratch
+            // buffer (now holding the recovered DCs) — y2In is no longer
+            // needed for its phase-4 role at this point.
+            InverseWalsh4x4Into(y2DQ, y2In);
             for (int i = 0; i < 16; i++)
             {
-                yDQ[i][0] = y2InvOut[i];
+                yDQ[i][0] = y2In[i];
             }
 
             // For each Y block: idct(dq) + prediction -> reconstructed.
@@ -369,45 +463,44 @@ namespace Vpx.Net
             return (byte)((sum + count / 2) / count);
         }
 
-        /// <summary>Subtracts a flat prediction value from each source byte.</summary>
-        private static short[] SubtractFlat(byte[] src, byte pred)
+        /// <summary>Subtracts a flat prediction value from each source byte
+        /// into <paramref name="dst"/>. <paramref name="dst"/> must be at
+        /// least as long as <paramref name="src"/>.</summary>
+        private static void SubtractFlatInto(byte[] src, byte pred, short[] dst)
         {
-            var r = new short[src.Length];
-            for (int i = 0; i < src.Length; i++) r[i] = (short)(src[i] - pred);
-            return r;
+            for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred);
         }
 
         /// <summary>
         /// Extract a 4x4 sub-block from <paramref name="plane"/> (raster order
-        /// at <paramref name="srcStride"/>) into a contiguous 16-short
-        /// buffer, then forward-DCT it.
+        /// at <paramref name="srcStride"/>) and forward-DCT it into the
+        /// provided <paramref name="coef"/> buffer (must be at least 16
+        /// shorts long). The intermediate 4x4 input block is stack-
+        /// allocated so this entire helper does no heap allocation.
         /// </summary>
-        private static unsafe short[] Fdct4x4FromPlane(short[] plane, int srcStride, int blockOffsetX, int blockOffsetY)
+        private static unsafe void Fdct4x4FromPlaneInto(short[] plane, int srcStride, int blockOffsetX, int blockOffsetY, short[] coef)
         {
-            short[] block = new short[16];
+            Span<short> block = stackalloc short[16];
             for (int r = 0; r < 4; r++)
             for (int c = 0; c < 4; c++)
                 block[r * 4 + c] = plane[(blockOffsetY + r) * srcStride + (blockOffsetX + c)];
 
-            short[] coef = new short[16];
             fixed (short* inP = block)
             fixed (short* outP = coef)
             {
                 dct.vp8_short_fdct4x4_c(inP, outP, pitch: 8);
             }
-            return coef;
         }
 
-        /// <summary>4x4 Walsh-Hadamard on a 16-element input.</summary>
-        private static unsafe short[] Walsh4x4(short[] input)
+        /// <summary>4x4 Walsh-Hadamard from <paramref name="input"/> into
+        /// the supplied <paramref name="outBuf"/>. No allocation.</summary>
+        private static unsafe void Walsh4x4Into(short[] input, short[] outBuf)
         {
-            short[] outBuf = new short[16];
             fixed (short* inP = input)
             fixed (short* outP = outBuf)
             {
                 dct.vp8_short_walsh4x4_c(inP, outP, pitch: 8);
             }
-            return outBuf;
         }
 
         /// <summary>
@@ -435,16 +528,13 @@ namespace Vpx.Net
         /// <summary>
         /// Bit-exact port of libvpx's vp8_short_inv_walsh4x4_c for 16 inputs
         /// (the second-order inverse Walsh used in 16x16 intra modes).
-        /// libvpx writes into an MB-wide dqcoeff buffer; we return a flat
-        /// 16-element array of "DC values per Y block" instead, since the
-        /// caller decides where to install them.
+        /// libvpx writes into an MB-wide dqcoeff buffer; we write into the
+        /// supplied <paramref name="outBuf"/>. The 16-element row-pass
+        /// scratch is stack-allocated. No heap allocation.
         /// </summary>
-        private static short[] InverseWalsh4x4(short[] input)
+        private static void InverseWalsh4x4Into(short[] input, short[] outBuf)
         {
-            // Adapted from idctllm.cs vp8_short_inv_walsh4x4_c — one buffer
-            // pass that puts the recovered DC of each Y block into the
-            // returned 16-element array (one per Y block).
-            int[] tmp = new int[16];
+            Span<int> tmp = stackalloc int[16];
             int a1, b1, c1, d1, a2, b2, c2, d2;
 
             // Stage 1 — rows.
@@ -462,7 +552,6 @@ namespace Vpx.Net
             }
 
             // Stage 2 — columns.
-            short[] outBuf = new short[16];
             for (int i = 0; i < 4; i++)
             {
                 a1 = tmp[0 * 4 + i] + tmp[3 * 4 + i];
@@ -480,13 +569,13 @@ namespace Vpx.Net
                 outBuf[2 * 4 + i] = (short)((c2 + 3) >> 3);
                 outBuf[3 * 4 + i] = (short)((d2 + 3) >> 3);
             }
-            return outBuf;
         }
 
         /// <summary>
         /// Inverse-DCT a 16-element block, add a flat prediction, write the
         /// resulting bytes to a 4x4 sub-block of <paramref name="dstPlane"/>.
         /// Reuses the existing decoder-side idctllm.vp8_short_idct4x4llm_c.
+        /// The 4x4 prediction and output buffers are stack-allocated.
         /// </summary>
         private static unsafe void IdctAndAddToPlane(short[] dqcoeff, byte pred,
             byte[] dstPlane, int dstStride, int blockOffsetX, int blockOffsetY)
@@ -494,15 +583,13 @@ namespace Vpx.Net
             // The decoder's idct adds to a prediction buffer and clamps to
             // [0, 255]. Build a 4x4 prediction buffer (all = pred), call
             // idct, then copy back to the destination plane.
-            byte[] predBuf = new byte[16];
+            byte* predBuf = stackalloc byte[16];
             for (int i = 0; i < 16; i++) predBuf[i] = pred;
-            byte[] dstBuf = new byte[16];
+            byte* dstBuf = stackalloc byte[16];
 
             fixed (short* coefP = dqcoeff)
-            fixed (byte* predP = predBuf)
-            fixed (byte* dstP = dstBuf)
             {
-                idctllm.vp8_short_idct4x4llm_c(coefP, predP, 4, dstP, 4);
+                idctllm.vp8_short_idct4x4llm_c(coefP, predBuf, 4, dstBuf, 4);
             }
 
             for (int r = 0; r < 4; r++)

--- a/src/VP8.Net/tokenize.cs
+++ b/src/VP8.Net/tokenize.cs
@@ -178,16 +178,65 @@ namespace Vpx.Net
             return true;
         }
 
-        // Helper: copy a single 11-element probability row out of the 4D
-        // coefProbs table. Allocates per call — fine for tests; in PR 5
-        // the macroblock-level driver will batch this with a per-frame
-        // cache instead.
+        // 4 block types x 8 coef bands x 3 prev-token contexts = 96 unique
+        // probability rows in the default_coef_probs table. The encoder
+        // hot path calls SliceProbRow up to ~75 times per MB (= ~90,000
+        // calls per 640x480 frame). Each fresh allocation is ~32 bytes
+        // (16 byte header + 11 byte payload aligned to 8); allocating
+        // 90K of those per frame is ~3 MB/sec of GC pressure on a
+        // 30 fps stream, which is exactly the kind of per-frame
+        // allocation the encoder needs to avoid.
+        //
+        // Caching strategy: lazily build a flat vp8_prob[][] keyed by
+        // (type * 24 + band * 3 + ctx) the first time we see a given
+        // coefProbs reference, and reuse on every subsequent call. The
+        // common case (and only case in the current encoder) is the
+        // singleton default_coef_probs.default_coef_probs table.
+        private static vp8_prob[,,,] s_cachedTable;
+        private static vp8_prob[][]  s_cachedRows;
+        private static readonly object s_cacheLock = new object();
+
         private static vp8_prob[] SliceProbRow(vp8_prob[,,,] coefProbs, int type, int band, int ctx)
         {
-            int n = coefProbs.GetLength(3);
-            var row = new vp8_prob[n];
-            for (int i = 0; i < n; i++) row[i] = coefProbs[type, band, ctx, i];
-            return row;
+            // Fast path: same table reference as the previous cache fill.
+            if (object.ReferenceEquals(coefProbs, s_cachedTable))
+            {
+                return s_cachedRows[type * 24 + band * 3 + ctx];
+            }
+
+            // Cache miss: build the cache for this table, then return.
+            return BuildCacheAndSlice(coefProbs, type, band, ctx);
+        }
+
+        private static vp8_prob[] BuildCacheAndSlice(vp8_prob[,,,] coefProbs, int type, int band, int ctx)
+        {
+            lock (s_cacheLock)
+            {
+                if (!object.ReferenceEquals(coefProbs, s_cachedTable))
+                {
+                    int blockTypes = coefProbs.GetLength(0);
+                    int coefBands  = coefProbs.GetLength(1);
+                    int prevCtx    = coefProbs.GetLength(2);
+                    int nodes      = coefProbs.GetLength(3);
+                    var rows = new vp8_prob[blockTypes * coefBands * prevCtx][];
+                    for (int t = 0; t < blockTypes; t++)
+                        for (int b = 0; b < coefBands; b++)
+                            for (int c = 0; c < prevCtx; c++)
+                            {
+                                var row = new vp8_prob[nodes];
+                                for (int i = 0; i < nodes; i++)
+                                    row[i] = coefProbs[t, b, c, i];
+                                rows[t * (coefBands * prevCtx) + b * prevCtx + c] = row;
+                            }
+                    // Publish atomically so concurrent readers see a fully
+                    // initialised cache.
+                    System.Threading.Interlocked.Exchange(ref s_cachedRows,  rows);
+                    System.Threading.Interlocked.Exchange(ref s_cachedTable, coefProbs);
+                }
+                return s_cachedRows[type * (coefProbs.GetLength(1) * coefProbs.GetLength(2))
+                                  + band * coefProbs.GetLength(2)
+                                  + ctx];
+            }
         }
     }
 }


### PR DESCRIPTION
Eliminates effectively all per-frame heap allocation in the encoder hot path. Live-stream feedback under #1575: even with the test pattern as input, the encoder was triggering jitter spikes up to 4 seconds — the signature of major Gen 2 GC pauses.

## Profile of master

Microbenchmark: 640×480 I420 test pattern, 500 frames after 10-frame warmup, .NET 8 server GC.

Profiling showed **~18 MB allocated per frame** (= 553 MB/sec at 30 fps), roughly evenly split across:

- Per-token `byte[11]` allocations from `tokenize.SliceProbRow` (~75 calls per non-skip MB, ~90,000 calls per frame).
- Fresh `List<TOKENEXTRA>` backing arrays for each of the 25 transformed blocks per MB.
- Per-MB `short[16][]` / `short[16]` / `int[16]` internal scratch arrays in `mb_encoder.EncodeMacroblockDcPred`.
- `byte[256]` / `byte[64]` / `byte[64]` source-plane slices, `byte[16]` / `byte[8]` neighbour-row slices, `byte[9]` entropy-context buffers in `frame_encoder`.
- Three `byte[]` (~440 KB total at 640×480) for the I420 plane split in `VP8Codec.EncodeVideo`.

## Changes

1. **`tokenize.cs`** — `SliceProbRow` now lazily caches its 96-row output (4 block types × 8 coef bands × 3 prev-token contexts) on first call with a given `coefProbs` reference, returning the cached row reference on subsequent calls.
2. **`mb_encoder.cs`** — `MbEncodeResult`'s 25 token `List`s are pre-allocated with capacity 17 in the constructor so `Add()` never grows the backing. New `Reset()` clears them in place. New `MbEncoderScratch` class holds all per-MB inner arrays (residY, yCoef[16][16], yQ/yDQ, y2 / U / V equivalents, EOBs); pre-allocated once, reused across all MBs and frames. `EncodeMacroblockDcPred` gains optional `result` and `scratch` parameters — `null`-default preserves old allocate-fresh behaviour for unit tests, non-`null` reuses the pool. The small fixed-size buffers in `IdctAndAddToPlane` and `InverseWalsh4x4` are now `stackalloc`.
3. **`frame_encoder.cs`** — new internal `FrameEncoderBuffers` class held as `[ThreadStatic]`. Owns the `MbEncodeResult[mbCols*mbRows]` pool, `MbEncoderScratch`, frame-scope context arrays, all source-plane and neighbour-row scratch buffers, and the output buffer. Lazily resized on dimension change; in steady state (single-resolution stream) it's allocated once for the lifetime of the encoder thread. `ExtractPlane`/`ExtractRow`/`ExtractColumn` helpers were 'allocate and return'; they're now 'fill the supplied buffer in place'.
4. **`VP8Codec.cs`** — the three plane-split `byte[]` allocations (~440 KB per 640×480 frame) are pooled as instance fields.

## Measurement

| Metric                         | master  | this PR  | delta   |
| ------------------------------ | ------- | -------- | ------- |
| Per-frame elapsed              | 13.4 ms | **6.3 ms**   |  **-53%**   |
| Per-frame allocations          | 18.45 MB| **0.01 MB**  |  **-99.95%**|
| GC Gen 0 collections (500 fr)  | 50+     | **0**        |  -100%  |
| GC Gen 1 collections           | 49+     | **0**        |  -100%  |
| GC Gen 2 collections           | 30+     | **0**        |  -100%  |
| Theoretical max framerate      | 75 fps  | **160 fps**  |  +113%  |

**Zero GC collections in 500 frames** — the multi-second jitter spikes Aaron is seeing on the live stream are Gen 2 pauses, and this run produces none.

The remaining 0.01 MB/frame is the `byte[]` returned by `EncodeKeyframe` (~4.7 KB encoded keyframe), which is by contract a fresh allocation handed to the caller.

## Behaviour

**No bitstream change. No test regressions.** The 104 existing VP8.Net unit tests pass (including byte-exact reference checks against libvpx C output on dct/walsh/quantize/tokenize/pack_tokens/quantizer_init/bitstream/frame_encoder, plus all the cross-MB context and skip-MB round-trip tests added in #1574 and #1575). The two pre-existing System.Drawing/GDI+ failures (Windows-only Bitmap APIs) are unchanged from master.

The `mb_encoder` unit tests still call `EncodeMacroblockDcPred` without a pooled result/scratch — the null-default path matches the previous allocate-fresh behaviour exactly, so those tests are unaffected.

## Reproducer

The microbenchmark is a single-file console app calling `VP8Codec.EncodeVideo` in a tight loop on a synthetic 640×480 I420 test pattern. Happy to attach it as a README in a follow-up if useful for regression-checking future changes.

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.