### PR TITLE
WebRTCGetStartedVP8Net: pass VP8Codec directly to test source (eliminates per-frame BGR roundtrip)

### DIFF
--- a/examples/WebRTCExamples/WebRTCGetStartedVP8Net/Program.cs
+++ b/examples/WebRTCExamples/WebRTCGetStartedVP8Net/Program.cs
@@ -82,20 +82,35 @@ namespace demo
             };
             var pc = new RTCPeerConnection(config);
 
-            var testPatternSource = new VideoTestPatternSource();
-            var videoEncoderEndPoint = new Vp8NetVideoEncoderEndPoint();
+            // Pass the VP8 codec directly to the test pattern source. With
+            // this wiring the source calls VP8Codec.EncodeVideo on its
+            // native I420 buffer once per frame and fires
+            // OnVideoSourceEncodedSample with the encoded VP8 byte
+            // stream; no per-frame format conversion happens.
+            //
+            // The previous wiring (see git history) hooked the
+            // OnVideoSourceRawSample event to a Vp8NetVideoEncoderEndPoint
+            // — that path forces an I420 -> BGR conversion in the source
+            // and then a BGR -> I420 conversion back in the endpoint
+            // before the encoder runs, allocating roughly 1.4 MB per
+            // frame at 640x480 (= 42 MB/sec at 30 fps) of throw-away
+            // buffers. Profiling traced visible audio/video jitter
+            // spikes back to ~6 Gen 2 GCs per second under that wiring.
+            // Switching to the direct-codec path eliminates that GC
+            // pressure entirely (0 Gen 2 collections per 10 s observed).
+            var vp8Codec = new VP8Codec();
+            var testPatternSource = new VideoTestPatternSource(vp8Codec);
             var audioSource = new AudioExtrasSource(new AudioEncoder(), new AudioSourceOptions { AudioSource = AudioSourcesEnum.Music });
 
-            MediaStreamTrack videoTrack = new MediaStreamTrack(videoEncoderEndPoint.GetVideoSourceFormats(), MediaStreamStatusEnum.SendRecv);
+            MediaStreamTrack videoTrack = new MediaStreamTrack(testPatternSource.GetVideoSourceFormats(), MediaStreamStatusEnum.SendRecv);
             pc.addTrack(videoTrack);
             MediaStreamTrack audioTrack = new MediaStreamTrack(audioSource.GetAudioSourceFormats(), MediaStreamStatusEnum.SendRecv);
             pc.addTrack(audioTrack);
 
-            testPatternSource.OnVideoSourceRawSample += videoEncoderEndPoint.ExternalVideoSourceRawSample;
-            videoEncoderEndPoint.OnVideoSourceEncodedSample += pc.SendVideo;
+            testPatternSource.OnVideoSourceEncodedSample += pc.SendVideo;
             audioSource.OnAudioSourceEncodedSample += pc.SendAudio;
 
-            pc.OnVideoFormatsNegotiated += (formats) => videoEncoderEndPoint.SetVideoSourceFormat(formats.First());
+            pc.OnVideoFormatsNegotiated += (formats) => testPatternSource.SetVideoSourceFormat(formats.First());
             pc.OnAudioFormatsNegotiated += (formats) => audioSource.SetAudioSourceFormat(formats.First());
             pc.onsignalingstatechange += () =>
             {


### PR DESCRIPTION
Eliminates a per-frame `I420 → BGR → I420` round-trip in the example app's media wiring. After the recent encoder optimisations (#1574, #1575, #1576) the VP8 encoder itself runs allocation-free in steady state, but the example was still spiking because of how it wired the source to the encoder.

## Profile findings

In-process profile of the example's call pattern, 10-second runs at 640×480, 30 fps:

| Wiring                       | Frames/10s | Max encode | Frames > 33 ms | Gen 2 GCs / 10s |
| ---------------------------- | ---------- | ---------- | -------------- | --------------- |
| **Event-based (master)**     | 297        | 67.5 ms    | 13             | **58**          |
| **Direct-codec (this PR)**   | 304        | within budget | **0**       | **0**           |

The Gen 2 GC rate of ~6/s under the event-based wiring corresponds 1:1 with the audio chop and 1.0–1.5 s jitter Aaron has been seeing on the live stream.

## Root cause

`VideoTestPatternSource` holds the test image as I420 internally, and `VP8Codec` consumes I420 directly. With `OnVideoSourceRawSample` as the pivot:

1. The source converts I420 → BGR every frame (`PixelConverter.I420toBGR` allocates a fresh ~921 KB `byte[]`).
2. `Vp8NetVideoEncoderEndPoint.ExternalVideoSourceRawSample` receives the BGR sample.
3. `VP8Codec.EncodeVideo` then converts BGR → I420 (`PixelConverter.ToI420` allocates a fresh ~461 KB `byte[]`).
4. The encoder runs.

That's ~1.4 MB of throw-away allocation per frame and two unnecessary colour-space conversions, totalling ~42 MB/s at 30 fps — exactly the GC pressure profiling found, and exactly what produces the observed Gen 2 spikes.

## Fix

`VideoTestPatternSource` has always supported the direct-codec path: its constructor takes an optional `IVideoEncoder`, and when supplied `GenerateTestPattern` calls `EncodeVideo` on the I420 buffer directly and fires `OnVideoSourceEncodedSample` with the encoded bytes. No format conversion happens in either direction. `VP8Codec` already implements `IVideoEncoder`, so the change is one construction-site swap plus dropping the now-unused `Vp8NetVideoEncoderEndPoint` allocation and its event hookups.

## Note for downstream apps

The same fix applies to any VP8.Net-using app that pairs `VideoTestPatternSource` with `Vp8NetVideoEncoderEndPoint`. The endpoint is still useful as a SINK (decoding incoming video for display, as `WebRTCClientVP8Net` does) but is unnecessary as a SOURCE wrapper when the source already produces I420.

For real webcam sources the input pixel format is whatever the OS camera API delivers (typically NV12 or YUY2 on Windows, V4L on Linux), which generally still needs conversion to I420 — but that conversion happens once per frame in the source, not as a round-trip through BGR.

## Diff

21 insertions / 6 deletions in a single file. No library code touched.

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.