### PR TITLE
WebRTCGetStartedVP8Net: add per-second source + RTCP packet-count diagnostics

### DIFF
--- a/examples/WebRTCExamples/WebRTCGetStartedVP8Net/Program.cs
+++ b/examples/WebRTCExamples/WebRTCGetStartedVP8Net/Program.cs
@@ -129,8 +129,58 @@ namespace demo
             MediaStreamTrack audioTrack = new MediaStreamTrack(audioSource.GetAudioSourceFormats(), MediaStreamStatusEnum.SendRecv);
             pc.addTrack(audioTrack);
 
-            testPatternSource.OnVideoSourceEncodedSample += pc.SendVideo;
-            audioSource.OnAudioSourceEncodedSample += pc.SendAudio;
+            // ---- Diagnostic packet counters ----
+            //
+            // Two counters logged once per second on each stream:
+            //
+            //   * "src":   packets handed off by the source to pc.Send*.
+            //              Increments iff the source is still producing
+            //              encoded samples — answers "did our test
+            //              source / encoder stop?".
+            //
+            //   * "rtcp":  cumulative PacketCount field of our outgoing
+            //              RTCP Sender Reports, fired by SIPSorcery's
+            //              RTPSession.OnSendReport. SIPSorcery emits an
+            //              SR roughly every 5 s and sets PacketCount to
+            //              the total number of RTP packets that have
+            //              actually left this peer. If this counter
+            //              keeps growing while Chrome's webrtc-internals
+            //              packetsReceived stalls, packets are leaving
+            //              the .NET app but Chrome is dropping them
+            //              (suspected SRTP / DTLS issue). If "rtcp"
+            //              stalls when "src" stalls, the issue is at or
+            //              above the SIPSorcery send path.
+            int audioSrcCount = 0, videoSrcCount = 0;
+
+            testPatternSource.OnVideoSourceEncodedSample += (rtpTs, frame) =>
+            {
+                pc.SendVideo(rtpTs, frame);
+                int n = System.Threading.Interlocked.Increment(ref videoSrcCount);
+                if (n % 15 == 0) { logger.LogInformation("video src: {Count} frames (~{Sec:F0}s at 15 fps)", n, n / 15.0); }
+            };
+
+            audioSource.OnAudioSourceEncodedSample += (rtpTs, sample) =>
+            {
+                pc.SendAudio(rtpTs, sample);
+                int n = System.Threading.Interlocked.Increment(ref audioSrcCount);
+                if (n % 50 == 0) { logger.LogInformation("audio src: {Count} packets (~{Sec:F0}s at 50 pps)", n, n / 50.0); }
+            };
+
+            // Hook outgoing RTCP Sender Reports. PacketCount is the
+            // cumulative count of RTP packets the local SIPSorcery
+            // send path has emitted on each stream. Compare against
+            // Chrome's inbound-rtp packetsReceived to see whether
+            // packets are getting lost between the .NET app and
+            // Chrome. SIPSorcery emits SRs every ~5 s by default.
+            pc.OnSendReport += (mediaType, compound) =>
+            {
+                var sr = compound?.SenderReport;
+                if (sr != null)
+                {
+                    logger.LogInformation("rtcp SR {Media}: SSRC={SSRC,10} PacketCount={Pkts} OctetCount={Octets}",
+                        mediaType, sr.SSRC, sr.PacketCount, sr.OctetCount);
+                }
+            };
 
             pc.OnVideoFormatsNegotiated += (formats) => testPatternSource.SetVideoSourceFormat(formats.First());
             pc.OnAudioFormatsNegotiated += (formats) => audioSource.SetAudioSourceFormat(formats.First());


### PR DESCRIPTION
Adds two unconditional packet counters to the example so we can distinguish sender-side audio failure from receiver-side drop the next time audio cuts out mid-session.

## Why

Audio loss has been observed in this example after some seconds of streaming. chrome://webrtc-internals confirms `packetsLost = 0` on both streams and `iceState = connected` at failure time, with video continuing to flow normally on the same transport while audio's `bytesReceived/s` drops to 0. From the receiver's vantage point we can't tell whether:

- **(a)** The .NET sender stopped emitting audio packets (encoder/timer stuck, or `pc.SendAudio` failing silently); or
- **(b)** Packets are leaving the sender but Chrome is dropping them pre-stats — suspected SRTP / DTLS auth issue, which doesn't manifest as `packetsLost` or `bytesReceived` because failed-auth packets are discarded before being counted.

The earlier music-source-EOF hypothesis is ruled out: the embedded `Macroform_-_Simplicity.raw` is 200.6 s of music and the observed audio cut-off is at ~166 s with 35+ s of audio remaining in the file. So the source has more to give but something stops it.

## What this PR adds

1. **`src` counter** on the source-side encoded-sample events. Logs once per ~1 s of source rate:

   ```
   audio src: 50 packets (~1s at 50 pps)
   audio src: 100 packets (~2s at 50 pps)
   ...
   video src: 15 frames (~1s at 15 fps)
   video src: 30 frames (~2s at 15 fps)
   ...
   ```

   If this counter freezes at the moment audio dies, the source itself stopped producing — suspect (a).

2. **`rtcp` counter** from outgoing RTCP Sender Reports, hooked via `pc.OnSendReport`. SIPSorcery emits SRs every ~5 s by default and `PacketCount` is the cumulative count of RTP packets the local send path has actually emitted on each stream:

   ```
   rtcp SR audio: SSRC=1234567890 PacketCount=250 OctetCount=40000
   rtcp SR video: SSRC=2345678901 PacketCount=195 OctetCount=312000
   ```

   If `src` keeps incrementing past audio-loss but `rtcp` `PacketCount` on the audio SSRC stalls (or grows much slower than `src`), packets are being silently dropped between the source-side event and the wire — for example by SRTP encryption returning an error that `pc.SendAudio` swallows. If `src` stalls, the source itself is the issue.

## Decision matrix at the moment audio dies

| `src` audio | `rtcp` audio PacketCount | Chrome `packetsReceived` | Conclusion |
| --- | --- | --- | --- |
| stalls | stalls | stalls | Source-side: AudioExtrasSource timer / encoder stopped |
| growing | stalls | stalls | SIPSorcery's send path is silently dropping audio (auth fail / state corruption) |
| growing | growing | stalls | Network/Chrome is dropping audio (SRTP auth fail at receiver, or transport issue) |
| growing | growing | growing | Audio is still flowing — investigate why it's not being heard |

## Behaviour

No bitstream or timing changes. Pure observability. The example's existing Q=96/15fps configuration is unchanged. Both counters are unconditional — the example always produces these logs while running.

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.