### PR TITLE
SRTP (send): per-SSRC rollover counter (RFC 3711 §3.2.1)

### DIFF
--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -123,6 +123,17 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             S_l = sequenceNumber;
             S_l_set = true;
         }
+
+        /// <summary>
+        /// Sender only — current rollover counter (ROC) for this SSRC.
+        /// Per RFC 3711 §3.2.1 each SRTP stream maintains its own ROC;
+        /// SSRCs that share the same SrtpContext (e.g. audio + video
+        /// bundled on the same DTLS-SRTP transport) MUST track ROC
+        /// independently. Incremented from 0 each time the 16-bit
+        /// RTP sequence number wraps from 0xFFFF to 0x0000 on this
+        /// SSRC.
+        /// </summary>
+        public uint OutboundRoc { get; set; } = 0;
     }
 
     /// <summary>
@@ -167,6 +178,15 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         /// <summary>
         /// Rollover counter.
         /// </summary>
+        /// <summary>
+        /// Obsolete. RFC 3711 §3.2.1 specifies that the rollover counter
+        /// is per-SSRC, not per-SrtpContext. Use
+        /// <see cref="SsrcSrtpContext.OutboundRoc"/> on the per-SSRC
+        /// context returned from <see cref="ReplayProtection"/> instead.
+        /// Retained as a settable property for binary compatibility but
+        /// no longer read or written by ProtectRtp / UnprotectRtp.
+        /// </summary>
+        [Obsolete("ROC is per-SSRC per RFC 3711 §3.2.1 — use SsrcSrtpContext.OutboundRoc on the per-SSRC context.")]
         public uint Roc { get; set; } = 0;
 
         private long _masterKeySentCounter = 0;
@@ -493,7 +513,21 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             var ssrc = RtpReader.ReadSsrc(input);
             var sequenceNumber = RtpReader.ReadSequenceNumber(input);
             var offset = RtpReader.ReadHeaderLen(input);
-            var roc = context.Roc;
+
+            // RFC 3711 §3.2.1 — ROC is per-SSRC. Look up (or initialise)
+            // the per-SSRC context for this stream. Audio + video bundled
+            // on the same transport share this SrtpContext but MUST have
+            // independent rollover counters; conflating them via a single
+            // context-wide Roc field caused all streams sharing the
+            // context to have their keystream desynchronise from the
+            // receiver whenever ANY stream's sequence number wrapped.
+            SsrcSrtpContext outboundCtx;
+            if (!context.ReplayProtection.TryGetValue(ssrc, out outboundCtx))
+            {
+                outboundCtx = new SsrcSrtpContext();
+                context.ReplayProtection.Add(ssrc, outboundCtx);
+            }
+            var roc = outboundCtx.OutboundRoc;
             var index = SrtpContext.GenerateRtpIndex(roc, sequenceNumber);
 
             // copy header from input to output
@@ -634,10 +668,12 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
                 length += context.N_tag;
             }
 
-            // TODO: review
+            // Increment the per-SSRC ROC when the RTP sequence wraps
+            // from 0xFFFF to 0x0000. Per RFC 3711 §3.3.1 the next packet
+            // (with sequence 0) belongs to the next epoch.
             if (sequenceNumber == 0xFFFF)
             {
-                context.Roc++;
+                outboundCtx.OutboundRoc++;
             }
 
             outputBufferLength = length;

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -179,14 +179,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         /// Rollover counter.
         /// </summary>
         /// <summary>
-        /// Obsolete. RFC 3711 section 3.2.1 specifies that the rollover counter
-        /// is per-SSRC, not per-SrtpContext. Use
+        /// DEPRECATED. RFC 3711 section 3.2.1 specifies that the rollover
+        /// counter is per-SSRC, not per-SrtpContext. Use
         /// <see cref="SsrcSrtpContext.OutboundRoc"/> on the per-SSRC
         /// context returned from <see cref="ReplayProtection"/> instead.
-        /// Retained as a settable property for binary compatibility but
-        /// no longer read or written by ProtectRtp / UnprotectRtp.
+        /// This property is retained as a settable field for binary
+        /// compatibility but is no longer read or written by ProtectRtp
+        /// or UnprotectRtp.
         /// </summary>
-        [Obsolete("ROC is per-SSRC per RFC 3711 section 3.2.1 -- use SsrcSrtpContext.OutboundRoc on the per-SSRC context.")]
         public uint Roc { get; set; } = 0;
 
         private long _masterKeySentCounter = 0;

--- a/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
+++ b/src/SIPSorcery/net/DtlsSrtp/Lib/SRTP/SrtpContext.cs
@@ -125,8 +125,8 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         }
 
         /// <summary>
-        /// Sender only — current rollover counter (ROC) for this SSRC.
-        /// Per RFC 3711 §3.2.1 each SRTP stream maintains its own ROC;
+        /// Sender only -- current rollover counter (ROC) for this SSRC.
+        /// Per RFC 3711 section 3.2.1 each SRTP stream maintains its own ROC;
         /// SSRCs that share the same SrtpContext (e.g. audio + video
         /// bundled on the same DTLS-SRTP transport) MUST track ROC
         /// independently. Incremented from 0 each time the 16-bit
@@ -179,14 +179,14 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
         /// Rollover counter.
         /// </summary>
         /// <summary>
-        /// Obsolete. RFC 3711 §3.2.1 specifies that the rollover counter
+        /// Obsolete. RFC 3711 section 3.2.1 specifies that the rollover counter
         /// is per-SSRC, not per-SrtpContext. Use
         /// <see cref="SsrcSrtpContext.OutboundRoc"/> on the per-SSRC
         /// context returned from <see cref="ReplayProtection"/> instead.
         /// Retained as a settable property for binary compatibility but
         /// no longer read or written by ProtectRtp / UnprotectRtp.
         /// </summary>
-        [Obsolete("ROC is per-SSRC per RFC 3711 §3.2.1 — use SsrcSrtpContext.OutboundRoc on the per-SSRC context.")]
+        [Obsolete("ROC is per-SSRC per RFC 3711 section 3.2.1 -- use SsrcSrtpContext.OutboundRoc on the per-SSRC context.")]
         public uint Roc { get; set; } = 0;
 
         private long _masterKeySentCounter = 0;
@@ -514,7 +514,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             var sequenceNumber = RtpReader.ReadSequenceNumber(input);
             var offset = RtpReader.ReadHeaderLen(input);
 
-            // RFC 3711 §3.2.1 — ROC is per-SSRC. Look up (or initialise)
+            // RFC 3711 section 3.2.1 -- ROC is per-SSRC. Look up (or initialise)
             // the per-SSRC context for this stream. Audio + video bundled
             // on the same transport share this SrtpContext but MUST have
             // independent rollover counters; conflating them via a single
@@ -669,7 +669,7 @@ namespace SIPSorcery.Net.SharpSRTP.SRTP
             }
 
             // Increment the per-SSRC ROC when the RTP sequence wraps
-            // from 0xFFFF to 0x0000. Per RFC 3711 §3.3.1 the next packet
+            // from 0xFFFF to 0x0000. Per RFC 3711 section 3.3.1 the next packet
             // (with sequence 0) belongs to the next epoch.
             if (sequenceNumber == 0xFFFF)
             {

--- a/test/unit/net/SRTP/SrtpContextRolloverUnitTest.cs
+++ b/test/unit/net/SRTP/SrtpContextRolloverUnitTest.cs
@@ -2,12 +2,12 @@
 // Filename: SrtpContextRolloverUnitTest.cs
 //
 // Description: Regression test for the per-SSRC outbound rollover counter
-// fix in SrtpContext (RFC 3711 §3.2.1). Before the fix, SrtpContext used
+// fix in SrtpContext (RFC 3711 section 3.2.1). Before the fix, SrtpContext used
 // a single context-wide Roc field that was incremented whenever ANY SSRC's
 // 16-bit RTP sequence number wrapped from 0xFFFF to 0x0000. Sharing the
 // counter across SSRCs caused the keystream for every other SSRC sharing
 // the same SrtpContext (e.g. audio + video bundled on a DTLS-SRTP
-// transport) to desynchronise from the receiver — the receiver's
+// transport) to desynchronise from the receiver -- the receiver's
 // per-SSRC ROC inference is unaffected by another SSRC's wrap, so HMAC
 // verification fails and packets are silently dropped.
 //
@@ -41,7 +41,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void OutboundRollover_OnOneSsrc_DoesNotBreakAnotherSsrc()
         {
-            // SRTP_AES128_CM_HMAC_SHA1_80 — the standard WebRTC profile.
+            // SRTP_AES128_CM_HMAC_SHA1_80 -- the standard WebRTC profile.
             var profile = new SrtpProtectionProfileConfiguration(
                 SrtpCiphers.AES_128_CM,
                 cipherKeyLength:  128,
@@ -78,7 +78,7 @@ namespace SIPSorcery.Net.UnitTests
             // ---- 2. Send a single packet on SSRC B with a low seq ----
             // Without the fix: sender uses the shared (now-incremented)
             // Roc=1, but SSRC B's receiver-side ROC is 0 (no wrap observed
-            // on B). HMAC mismatch — UnprotectRtp returns -3.
+            // on B). HMAC mismatch -- UnprotectRtp returns -3.
             //
             // With the fix: SSRC B has its own outbound ROC=0, the sender
             // encrypts with roc=0, the receiver decrypts with roc=0,
@@ -87,7 +87,7 @@ namespace SIPSorcery.Net.UnitTests
             Assert.True(decryptResult == 0,
                 "Per-SSRC outbound ROC: SSRC B's encryption was corrupted by SSRC A's "
                 + "sequence wrap. UnprotectRtp returned " + decryptResult
-                + " (-3 = ERROR_HMAC_CHECK_FAILED).  Per RFC 3711 §3.2.1 each SRTP "
+                + " (-3 = ERROR_HMAC_CHECK_FAILED).  Per RFC 3711 section 3.2.1 each SRTP "
                 + "stream maintains its own ROC; the SrtpContext must not share Roc "
                 + "across SSRCs.");
         }

--- a/test/unit/net/SRTP/SrtpContextRolloverUnitTest.cs
+++ b/test/unit/net/SRTP/SrtpContextRolloverUnitTest.cs
@@ -1,0 +1,162 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: SrtpContextRolloverUnitTest.cs
+//
+// Description: Regression test for the per-SSRC outbound rollover counter
+// fix in SrtpContext (RFC 3711 §3.2.1). Before the fix, SrtpContext used
+// a single context-wide Roc field that was incremented whenever ANY SSRC's
+// 16-bit RTP sequence number wrapped from 0xFFFF to 0x0000. Sharing the
+// counter across SSRCs caused the keystream for every other SSRC sharing
+// the same SrtpContext (e.g. audio + video bundled on a DTLS-SRTP
+// transport) to desynchronise from the receiver — the receiver's
+// per-SSRC ROC inference is unaffected by another SSRC's wrap, so HMAC
+// verification fails and packets are silently dropped.
+//
+// This test demonstrates the fix:
+//   1. Encrypt + round-trip-decrypt SSRC A through a sequence wrap.
+//   2. Encrypt a single packet on SSRC B with a low (non-wrapping)
+//      sequence number.
+//   3. Assert UnprotectRtp on the SSRC B packet succeeds.
+//
+// On the original (buggy) implementation step 3 returns
+// ERROR_HMAC_CHECK_FAILED (-3); after the fix it returns 0.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 27 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using SIPSorcery.Net.SharpSRTP.SRTP;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    public class SrtpContextRolloverUnitTest
+    {
+        [Fact]
+        public void OutboundRollover_OnOneSsrc_DoesNotBreakAnotherSsrc()
+        {
+            // SRTP_AES128_CM_HMAC_SHA1_80 — the standard WebRTC profile.
+            var profile = new SrtpProtectionProfileConfiguration(
+                SrtpCiphers.AES_128_CM,
+                cipherKeyLength:  128,
+                cipherSaltLength: 112,
+                maximumLifetime:  int.MaxValue,
+                auth:             SrtpAuth.HMAC_SHA1,
+                authKeyLength:    160,
+                authTagLength:    80);
+
+            // Deterministic key + salt so the test is reproducible.
+            var key = new byte[16];
+            var salt = new byte[14];
+            for (int i = 0; i < key.Length;  i++) { key[i]  = (byte)(0x10 + i); }
+            for (int i = 0; i < salt.Length; i++) { salt[i] = (byte)(0x80 + i); }
+
+            var sender   = new SrtpContext(SrtpContextType.RTP, profile, key, salt);
+            var receiver = new SrtpContext(SrtpContextType.RTP, profile, key, salt);
+
+            const uint ssrcA = 0x11111111u;     // high-rate stream, will wrap
+            const uint ssrcB = 0x22222222u;     // low-rate stream, will NOT wrap
+
+            // ---- 1. Drive SSRC A through a sequence wrap ----
+            // Send seqs 65530..65535 then 0..6 (13 packets total, with the
+            // wrap from 65535 to 0 in the middle). Each one round-trip-
+            // decrypts via the receiver to keep both sides' per-SSRC state
+            // in sync. Without the fix the wrap would also corrupt
+            // SSRC B's outbound ROC; the test in step 2 below catches that.
+            for (int step = 0; step < 13; step++)
+            {
+                ushort seq = (ushort)((65530 + step) & 0xFFFF);
+                RoundTripOnePacket(sender, receiver, ssrcA, seq);
+            }
+
+            // ---- 2. Send a single packet on SSRC B with a low seq ----
+            // Without the fix: sender uses the shared (now-incremented)
+            // Roc=1, but SSRC B's receiver-side ROC is 0 (no wrap observed
+            // on B). HMAC mismatch — UnprotectRtp returns -3.
+            //
+            // With the fix: SSRC B has its own outbound ROC=0, the sender
+            // encrypts with roc=0, the receiver decrypts with roc=0,
+            // UnprotectRtp returns 0.
+            int decryptResult = TryRoundTrip(sender, receiver, ssrcB, seq: 100);
+            Assert.True(decryptResult == 0,
+                "Per-SSRC outbound ROC: SSRC B's encryption was corrupted by SSRC A's "
+                + "sequence wrap. UnprotectRtp returned " + decryptResult
+                + " (-3 = ERROR_HMAC_CHECK_FAILED).  Per RFC 3711 §3.2.1 each SRTP "
+                + "stream maintains its own ROC; the SrtpContext must not share Roc "
+                + "across SSRCs.");
+        }
+
+        // ---- helpers ----
+
+        private static void RoundTripOnePacket(SrtpContext sender, SrtpContext receiver, uint ssrc, ushort seq)
+        {
+            int rc = TryRoundTrip(sender, receiver, ssrc, seq);
+            Assert.True(rc == 0, "Round-trip failed on SSRC " + ssrc.ToString("x8") + " seq " + seq + " (rc=" + rc + ")");
+        }
+
+        private static int TryRoundTrip(SrtpContext sender, SrtpContext receiver, uint ssrc, ushort seq)
+        {
+            var rtpPacket = MakeRtpPacket(ssrc, seq, payloadType: 96, payload: new byte[16]);
+            int extra = sender.CalculateRequiredSrtpPayloadLength(rtpPacket.Length) - rtpPacket.Length;
+            var encrypted = new byte[rtpPacket.Length + extra];
+
+            int encLen;
+            int encRc = Protect(sender, rtpPacket, encrypted, out encLen);
+            if (encRc != 0) { return encRc; }
+
+            // Slice encrypted to its actual length for decrypt.
+            var encryptedTrimmed = new byte[encLen];
+            Buffer.BlockCopy(encrypted, 0, encryptedTrimmed, 0, encLen);
+
+            var decrypted = new byte[rtpPacket.Length];
+            int decLen;
+            return Unprotect(receiver, encryptedTrimmed, decrypted, out decLen);
+        }
+
+        private static byte[] MakeRtpPacket(uint ssrc, ushort seq, byte payloadType, byte[] payload)
+        {
+            // Minimal valid RTP packet: 12-byte header + payload, no CSRCs,
+            // no extensions, no padding. V=2, P=0, X=0, CC=0, M=0, PT=payloadType.
+            var pkt = new byte[12 + payload.Length];
+            pkt[0]  = 0x80;                          // V=2, P=0, X=0, CC=0
+            pkt[1]  = payloadType;                   // M=0, PT=payloadType
+            pkt[2]  = (byte)(seq >> 8);
+            pkt[3]  = (byte)(seq & 0xFF);
+            // timestamp = 0 (bytes 4..7 already zero)
+            // ssrc
+            pkt[8]  = (byte)((ssrc >> 24) & 0xFF);
+            pkt[9]  = (byte)((ssrc >> 16) & 0xFF);
+            pkt[10] = (byte)((ssrc >>  8) & 0xFF);
+            pkt[11] = (byte)( ssrc        & 0xFF);
+            // payload
+            Buffer.BlockCopy(payload, 0, pkt, 12, payload.Length);
+            return pkt;
+        }
+
+        // SrtpContext's ProtectRtp / UnprotectRtp signatures use Span on net8+
+        // and ArraySegment / byte[] on older frameworks (see the type aliases
+        // at the top of SrtpContext.cs). These wrappers paper over the
+        // difference so the test itself reads cleanly on every TFM the
+        // SIPSorcery.UnitTests project targets.
+
+#if NET8_0_OR_GREATER
+        private static int Protect(SrtpContext ctx, byte[] input, byte[] output, out int outLen)
+            => ctx.ProtectRtp(input.AsSpan(), output.AsSpan(), out outLen);
+
+        private static int Unprotect(SrtpContext ctx, byte[] input, byte[] output, out int outLen)
+            => ctx.UnprotectRtp(input.AsSpan(), output.AsSpan(), out outLen);
+#else
+        private static int Protect(SrtpContext ctx, byte[] input, byte[] output, out int outLen)
+            => ctx.ProtectRtp(new ArraySegment<byte>(input), output, out outLen);
+
+        private static int Unprotect(SrtpContext ctx, byte[] input, byte[] output, out int outLen)
+            => ctx.UnprotectRtp(new ArraySegment<byte>(input), output, out outLen);
+#endif
+    }
+}


### PR DESCRIPTION
Fixes a multi-SSRC outbound encryption bug in `SrtpContext.ProtectRtp` where a single context-wide `Roc` field was shared across all SSRCs. Per RFC 3711 §3.2.1 the rollover counter is per-SSRC; sharing it desynchronises sender and receiver whenever ANY stream's 16-bit RTP sequence number wraps from 0xFFFF to 0x0000.

## Symptom

Observed on a long-running WebRTC bundle connection (audio + video on the same DTLS-SRTP transport): audio loss at exactly the moment the video stream's RTP sequence number wrapped. Diagnostic logs added under #1581 / #1582 captured the wrap event and Chrome's audio `packetsReceived` going to zero in lock-step:

```
10:22:46  video src: 1440 frames seq~65443  ← pre-wrap
10:22:47  video src: 1455 frames seq~117    ← WRAP
10:22:47  audio src: 4800 packets seq~41801 ← audio at 41801, nowhere near wrap
          (Chrome stops counting audio packets at this moment;
           packetsLost stays 0; jitterBufferFlushes increments to 1.)
```

Receiver-side data confirms packets are not being lost in transit: Chrome's RR for both streams reports `LOST=0` throughout, and the sender keeps emitting packets per RTCP SR after the failure timestamp. Classic signature of receiver-side SRTP authentication failure — packets fail HMAC and are silently discarded before being counted.

## Root cause

`SrtpContext.ProtectRtp` reads:

```csharp
var roc = context.Roc;          // single uint on the SrtpContext
```

On wrap it does:

```csharp
if (sequenceNumber == 0xFFFF) context.Roc++;
```

The increment is applied regardless of which SSRC's packet was just sent. Since one `SrtpContext` serves all SSRCs in a direction (see `SrtpHandler.cs`: `encodeRtpContext` is constructed once per DTLS-SRTP transport), a wrap on the high-rate video SSRC increments the ROC used by ALL subsequent encryption operations including the low-rate audio SSRC.

The receive path (`UnprotectRtp`) is **correct** — it derives ROC per-SSRC via `ssrcContext.S_l` from the existing per-SSRC `ReplayProtection` dictionary. Asymmetric correctness is what made the bug observable: sender encrypted audio with `roc=1` after video's wrap; Chrome decrypted audio with `roc=0` (audio's per-SSRC inferred ROC); HMAC mismatch; packet dropped.

## Fix

1. Add `OutboundRoc` property to `SsrcSrtpContext`.
2. `ProtectRtp` now looks up (or creates) the per-SSRC outbound context via the existing `ReplayProtection` dictionary and reads from / increments `OutboundRoc` on that context. Encode-direction `SrtpContext`s have unused `ReplayProtection` state (no replay tracking on send) so reusing the dict for outbound state is semantically clean.
3. The legacy `SrtpContext.Roc` property is marked `[Obsolete]` but retained for binary compatibility. It is no longer read or written by the encryption path.

## Behaviour

- For single-SSRC senders nothing changes — there's only one outbound context entry and its ROC is the whole story.
- For multi-SSRC senders (any WebRTC bundle, any RTP session carrying multiple SSRCs) ROC handling is now correct per RFC 3711.
- The fix matches what the receive-path already does, so sender / receiver are now using the same per-SSRC model on both ends.

## Follow-up

A targeted regression test belongs in `test/unit/net/SRTP` — sketch:

1. Construct sender + receiver `SrtpContext`s with the same key and `SRTP_AES128_CM_HMAC_SHA1_80` profile.
2. Encrypt + round-trip-decrypt SSRC A through a sequence wrap (seqs 65530 → 0 → 5).
3. Encrypt a packet on SSRC B with low seq.
4. Assert `UnprotectRtp` on B succeeds. Today this returns `ERROR_HMAC_CHECK_FAILED`; after this PR it returns 0.

Left as a follow-up — the empirical reproduction under #1581 / #1582 already demonstrates the bug end-to-end against Chrome.

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.