### PR TITLE
VP8 P-frame foundation: reference frame storage + key/inter cadence (PR 1 of 5)

### DIFF
--- a/src/VP8.Net/VP8Codec.cs
+++ b/src/VP8.Net/VP8Codec.cs
@@ -97,6 +97,49 @@ namespace Vpx.Net
             }
         }
 
+        // Default cadence for keyframes when inter coding lands in a
+        // future PR. 30 = one keyframe per second at 30 fps. Currently
+        // every frame is still a keyframe (the inter-encoding path is
+        // built up across PRs 2-5 of the P-frame foundation series), so
+        // this property only controls the internal state machine for now.
+        private const int DEFAULT_KEYFRAME_INTERVAL_FRAMES = 30;
+
+        private int _keyframeIntervalFrames = DEFAULT_KEYFRAME_INTERVAL_FRAMES;
+        private int _framesSinceLastKeyframe = 0;
+
+        /// <summary>
+        /// Number of frames between forced keyframes. Set to 1 to force
+        /// every frame to be a keyframe; 30 (default) gives one keyframe
+        /// per second at 30 fps. Range [1, int.MaxValue].
+        ///
+        /// Note: as of PR 1 of the P-frame foundation series the inter
+        /// encoding path is not yet implemented, so EncodeVideo emits a
+        /// keyframe every call regardless of this setting. The value is
+        /// honoured by the internal frame counter so the keyframe-vs-
+        /// inter decision logic can be wired up in subsequent PRs
+        /// without behaviour changing here.
+        /// </summary>
+        public int KeyframeIntervalFrames
+        {
+            get => _keyframeIntervalFrames;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value),
+                        "KeyframeIntervalFrames must be at least 1.");
+                }
+                _keyframeIntervalFrames = value;
+            }
+        }
+
+        /// <summary>
+        /// Read-only count of frames emitted since the last keyframe
+        /// (resets to 0 immediately after a keyframe is encoded).
+        /// Exposed primarily for tests and diagnostics.
+        /// </summary>
+        public int FramesSinceLastKeyframe => _framesSinceLastKeyframe;
+
         public byte[] EncodeVideo(int width, int height, byte[] sample, VideoPixelFormatsEnum pixelFormat, VideoCodecsEnum codec)
         {
             lock (_encoderLock)
@@ -129,12 +172,38 @@ namespace Vpx.Net
                 Buffer.BlockCopy(i420, ySize,         _srcU, 0, cSize);
                 Buffer.BlockCopy(i420, ySize + cSize, _srcV, 0, cSize);
 
-                // ForceKeyFrame is currently the only mode (every frame is a
-                // keyframe in the foundation encoder). Reset the flag for
-                // API parity with future inter-frame support.
+                // Decide keyframe vs inter for this call.
+                // - Forced keyframe (via ForceKeyFrame()): always keyframe.
+                // - Frame counter reached interval: keyframe.
+                // - First frame of stream / no valid reference: keyframe.
+                // - Otherwise: inter.
+                //
+                // Note: as of PR 1 of the P-frame foundation series the
+                // inter branch falls through to EncodeKeyframe too. PRs
+                // 2-5 build out the actual inter encoding path. The
+                // decision logic is in place here so later PRs are pure
+                // implementation flips and not interface changes.
+                bool forceKey = _forceKeyFrame
+                              || _framesSinceLastKeyframe == 0
+                              || _framesSinceLastKeyframe >= _keyframeIntervalFrames;
                 _forceKeyFrame = false;
 
-                return frame_encoder.EncodeKeyframe(_srcY, _srcU, _srcV, width, height, _baseQIndex);
+                byte[] result;
+                if (forceKey)
+                {
+                    result = frame_encoder.EncodeKeyframe(_srcY, _srcU, _srcV, width, height, _baseQIndex);
+                    _framesSinceLastKeyframe = 1;
+                }
+                else
+                {
+                    // PR 1 of N: inter encoding not yet implemented;
+                    // fall through to keyframe to preserve current
+                    // behaviour. Subsequent PRs replace this call with
+                    // the real inter frame encoder.
+                    result = frame_encoder.EncodeKeyframe(_srcY, _srcU, _srcV, width, height, _baseQIndex);
+                    _framesSinceLastKeyframe++;
+                }
+                return result;
             }
         }
 

--- a/src/VP8.Net/frame_encoder.cs
+++ b/src/VP8.Net/frame_encoder.cs
@@ -146,6 +146,22 @@ namespace Vpx.Net
         // Output buffer.
         public byte[] OutBuf;
 
+        // Reference-frame storage. After every successful encode,
+        // EncodeKeyframe / future EncodeInterFrame copies the
+        // per-MB reconstructed pixels here, building a frame-sized
+        // copy of what the decoder will see as the most recent
+        // decoded frame. Inter frames (PR 3+) will use this as the
+        // prediction reference.
+        //
+        // LastFrameValid starts false and is set true after the first
+        // successful encode. Inter encoding requires it to be true;
+        // when false (first frame of stream, or after a forced reset)
+        // the frame must be a keyframe regardless of interval.
+        public byte[] LastFrameY;
+        public byte[] LastFrameU;
+        public byte[] LastFrameV;
+        public bool LastFrameValid;
+
         public void EnsureForFrame(int width, int height)
         {
             int chromaW = width / 2;
@@ -177,6 +193,24 @@ namespace Vpx.Net
             int bufLen = System.Math.Max(4096, width * height * 2 + 1024);
             if (OutBuf == null || OutBuf.Length < bufLen)
                 OutBuf = new byte[bufLen];
+
+            int ySize = width * height;
+            int cSize = chromaW * (height / 2);
+            if (LastFrameY == null || LastFrameY.Length < ySize)
+            {
+                LastFrameY = new byte[ySize];
+            }
+            if (LastFrameU == null || LastFrameU.Length < cSize)
+            {
+                LastFrameU = new byte[cSize];
+                LastFrameV = new byte[cSize];
+            }
+            // Dimension change invalidates any previously-stored
+            // reference frame.
+            if (Width != width || Height != height)
+            {
+                LastFrameValid = false;
+            }
 
             Width = width;
             Height = height;
@@ -395,6 +429,45 @@ namespace Vpx.Net
                                dst: aboveVRow, dstOffset: mbCol * 8, count: 8);
                 }
             }
+
+            // ----- Save the reconstructed frame as the next inter
+            //       prediction reference -----
+            //
+            // For each MB we already have its 16x16 Y + 8x8 U + 8x8 V
+            // reconstruction in mbResults[idx].ReconY/U/V (the bytes
+            // the decoder will produce given the same bitstream).
+            // Stitch them into LastFrameY/U/V so the next inter frame
+            // (added in PR 3+) can use this as its prediction source.
+            //
+            // PR 1 just plumbs the storage; nothing currently consumes
+            // the saved reference. The work is unconditional regardless
+            // because (a) the per-MB cost is O(384 bytes) so trivial,
+            // and (b) this lets PR 5's wire-up happen as a flip rather
+            // than a behaviour change to EncodeKeyframe.
+            for (int mbRow = 0; mbRow < mbRows; mbRow++)
+            {
+                for (int mbCol = 0; mbCol < mbCols; mbCol++)
+                {
+                    var r = mbResults[mbRow * mbCols + mbCol];
+
+                    int yBase = (mbRow * 16) * width + (mbCol * 16);
+                    for (int row = 0; row < 16; row++)
+                    {
+                        Buffer.BlockCopy(r.ReconY, row * 16,
+                            buf.LastFrameY, yBase + row * width, 16);
+                    }
+
+                    int cBase = (mbRow * 8) * chromaW + (mbCol * 8);
+                    for (int row = 0; row < 8; row++)
+                    {
+                        Buffer.BlockCopy(r.ReconU, row * 8,
+                            buf.LastFrameU, cBase + row * chromaW, 8);
+                        Buffer.BlockCopy(r.ReconV, row * 8,
+                            buf.LastFrameV, cBase + row * chromaW, 8);
+                    }
+                }
+            }
+            buf.LastFrameValid = true;
 
             // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
             //

--- a/test/VP8.Net.UnitTest/vp8codec_keyframe_interval_unittest.cs
+++ b/test/VP8.Net.UnitTest/vp8codec_keyframe_interval_unittest.cs
@@ -1,0 +1,171 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: vp8codec_keyframe_interval_unittest.cs
+//
+// Description: Unit tests for the KeyframeIntervalFrames property and
+// keyframe-vs-inter cadence state machine on VP8Codec, added in PR 1
+// of the P-frame foundation series. The actual inter encoding path
+// is not implemented yet, so these tests exercise only the counter
+// behaviour; correctness of the eventual inter bitstream is tested
+// in PRs 3-5.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 27 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using SIPSorceryMedia.Abstractions;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public class vp8codec_keyframe_interval_unittest
+    {
+        // ---------- KeyframeIntervalFrames property ----------
+
+        [Fact]
+        public void KeyframeIntervalFrames_DefaultIs30()
+        {
+            var codec = new VP8Codec();
+            Assert.Equal(30, codec.KeyframeIntervalFrames);
+        }
+
+        [Fact]
+        public void KeyframeIntervalFrames_SetTo1Allowed()
+        {
+            var codec = new VP8Codec();
+            codec.KeyframeIntervalFrames = 1;
+            Assert.Equal(1, codec.KeyframeIntervalFrames);
+        }
+
+        [Fact]
+        public void KeyframeIntervalFrames_SetToZeroThrows()
+        {
+            var codec = new VP8Codec();
+            Assert.Throws<ArgumentOutOfRangeException>(() => codec.KeyframeIntervalFrames = 0);
+        }
+
+        [Fact]
+        public void KeyframeIntervalFrames_SetToNegativeThrows()
+        {
+            var codec = new VP8Codec();
+            Assert.Throws<ArgumentOutOfRangeException>(() => codec.KeyframeIntervalFrames = -1);
+        }
+
+        // ---------- Frame-counter cadence ----------
+
+        [Fact]
+        public void FramesSinceLastKeyframe_IsZeroBeforeFirstEncode()
+        {
+            var codec = new VP8Codec();
+            Assert.Equal(0, codec.FramesSinceLastKeyframe);
+        }
+
+        [Fact]
+        public void FramesSinceLastKeyframe_IsOneAfterFirstEncode()
+        {
+            var codec = new VP8Codec();
+            byte[] yuv = MakeFlatI420(16, 16, y: 128, u: 128, v: 128);
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            // First encode is always a keyframe (no reference yet) -> counter = 1.
+            Assert.Equal(1, codec.FramesSinceLastKeyframe);
+        }
+
+        [Fact]
+        public void FramesSinceLastKeyframe_IncrementsOnInterFrames()
+        {
+            var codec = new VP8Codec { KeyframeIntervalFrames = 30 };
+            byte[] yuv = MakeFlatI420(16, 16, y: 128, u: 128, v: 128);
+
+            // Encode 5 frames. With interval=30, frames 2..5 should be inter
+            // (and the counter should go 1, 2, 3, 4, 5 across them).
+            for (int i = 1; i <= 5; i++)
+            {
+                codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+                Assert.Equal(i, codec.FramesSinceLastKeyframe);
+            }
+        }
+
+        [Fact]
+        public void FramesSinceLastKeyframe_ResetsAfterIntervalKeyframe()
+        {
+            var codec = new VP8Codec { KeyframeIntervalFrames = 3 };
+            byte[] yuv = MakeFlatI420(16, 16, y: 128, u: 128, v: 128);
+
+            // Frame 1: keyframe (first frame). counter -> 1.
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.Equal(1, codec.FramesSinceLastKeyframe);
+
+            // Frame 2: inter. counter -> 2.
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.Equal(2, codec.FramesSinceLastKeyframe);
+
+            // Frame 3: inter (counter == interval == 3 means we've sent
+            // 2 inter frames since last key, this 3rd would be the next
+            // keyframe). counter -> 3.
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.Equal(3, codec.FramesSinceLastKeyframe);
+
+            // Frame 4: counter has reached interval, this is the next
+            // keyframe. counter resets to 1.
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.Equal(1, codec.FramesSinceLastKeyframe);
+
+            // Frame 5: inter again. counter -> 2.
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.Equal(2, codec.FramesSinceLastKeyframe);
+        }
+
+        [Fact]
+        public void ForceKeyFrame_ResetsCounter()
+        {
+            var codec = new VP8Codec { KeyframeIntervalFrames = 30 };
+            byte[] yuv = MakeFlatI420(16, 16, y: 128, u: 128, v: 128);
+
+            // Run a few frames into the cadence.
+            for (int i = 0; i < 5; i++)
+            {
+                codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            }
+            Assert.Equal(5, codec.FramesSinceLastKeyframe);
+
+            // ForceKeyFrame -> next encode is a keyframe -> counter = 1.
+            codec.ForceKeyFrame();
+            codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.Equal(1, codec.FramesSinceLastKeyframe);
+        }
+
+        [Fact]
+        public void KeyframeIntervalFrames_OneEveryFrameIsKeyframe()
+        {
+            var codec = new VP8Codec { KeyframeIntervalFrames = 1 };
+            byte[] yuv = MakeFlatI420(16, 16, y: 128, u: 128, v: 128);
+
+            // With interval = 1, every encode is a keyframe; counter
+            // resets to 1 each time.
+            for (int i = 0; i < 5; i++)
+            {
+                codec.EncodeVideo(16, 16, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+                Assert.Equal(1, codec.FramesSinceLastKeyframe);
+            }
+        }
+
+        // ---------- helpers ----------
+
+        private static byte[] MakeFlatI420(int width, int height, byte y, byte u, byte v)
+        {
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var b = new byte[ySize + 2 * cSize];
+            for (int i = 0; i < ySize; i++) b[i] = y;
+            for (int i = 0; i < cSize; i++) b[ySize + i] = u;
+            for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = v;
+            return b;
+        }
+    }
+}


### PR DESCRIPTION
First in a five-PR series adding inter-frame (P-frame) support to the VP8.Net encoder. Each PR ships an independently-testable piece; this one is purely state-plumbing and produces no observable bitstream change.

## What this PR adds

### 1. Reference-frame storage on `FrameEncoderBuffers`

```
LastFrameY      : byte[width * height]
LastFrameU      : byte[chromaW * chromaH]
LastFrameV      : byte[chromaW * chromaH]
LastFrameValid  : bool
```

Allocated in `EnsureForFrame`, invalidated on dimension change.

At the end of `EncodeKeyframe` (after every MB's reconstruction is computed) the per-MB `ReconY/U/V` buffers are stitched into the frame-sized `LastFrameY/U/V` arrays. `LastFrameValid` is set true.

Stores the bytes the decoder will produce given the same bitstream, which is what later inter frames will need to use as their prediction reference (PR 3+).

### 2. Key/inter cadence on `VP8Codec`

```
KeyframeIntervalFrames  : int, [1, int.MaxValue], default 30
FramesSinceLastKeyframe : int, read-only counter, exposed for diagnostics + tests
```

`EncodeVideo` now picks keyframe-vs-inter via:

- `ForceKeyFrame()` flag set → keyframe (counter → 1)
- First frame of stream → keyframe (counter → 1)
- counter ≥ interval → keyframe (counter → 1)
- otherwise → inter (counter += 1)

The **inter branch currently calls `EncodeKeyframe` too** — the real inter encoder lands in PR 5 with the bitstream pieces from PRs 2-4. Wiring the decision logic in this PR rather than later means PRs 2-5 are pure implementation flips on existing call sites, not interface changes that ripple into every consumer.

## Tests

Eight new unit tests in `test/VP8.Net.UnitTest/vp8codec_keyframe_interval_unittest.cs`:

- default interval is 30
- interval = 1 allowed (every-frame-is-keyframe)
- interval ≤ 0 throws `ArgumentOutOfRangeException`
- `FramesSinceLastKeyframe` is 0 before first encode
- first encode sets counter to 1
- inter frames increment counter to 2, 3, 4, 5…
- interval boundary resets counter back to 1
- `ForceKeyFrame()` resets counter on next encode
- interval = 1 keeps counter at 1 indefinitely

The existing 10 `frame_encoder` + 3 `mb_encoder` + 3 checkerboard / mixed-content / size + 5 bitstream tests + the DCT / Walsh / quantize / tokenize / pack_tokens / quantizer_init bit-exact references all still pass. Full VP8.Net suite: **114 pass, 2 pre-existing System.Drawing/GDI+ failures (Windows-only) unchanged from master, 1 skip.**

## What's NOT in this PR (subsequent PRs in the series)

| # | Title |
| - | --- |
| 2 | Inter-frame header writer (`StartInterFrameHeader`) |
| 3 | ZEROMV inter MB encoder (`mb_encoder.EncodeMacroblockZeroMvLast`) |
| 4 | Per-MB inter mode + ref bits writer |
| 5 | `frame_encoder.EncodeInterFrame` orchestration + `EncodeVideo` wire-up + full key/inter round-trip test against the existing decoder |

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.