### PR TITLE
VP8 P-frame foundation: inter (P-frame) header writer (PR 2 of 5)

### DIFF
--- a/src/VP8.Net/bitstream.cs
+++ b/src/VP8.Net/bitstream.cs
@@ -102,6 +102,57 @@ namespace Vpx.Net
         public int UvAcDeltaQ;
     }
 
+    /// <summary>
+    /// Per-call configuration for an INTER (P-frame) header. Subset of
+    /// <see cref="KeyframeHeaderConfig"/> -- inter frames omit the start
+    /// code, dimensions, color_space and clamp_type (those fields are
+    /// keyframe-only).
+    ///
+    /// As of PR 2 of the P-frame foundation series the inter-encoder is
+    /// not yet wired into VP8Codec.EncodeVideo; this header writer + its
+    /// FinishInterFrameFirstPartition counterpart exist as standalone
+    /// pieces that can be bit-exactly tested against the existing VP8
+    /// decoder before PRs 3-5 plumb them into the actual encode path.
+    /// </summary>
+    public sealed class InterFrameHeaderConfig
+    {
+        /// <summary>Profile / version (3 bits, 0..7). 0 = baseline profile.</summary>
+        public int Version;
+
+        /// <summary>true if the frame is to be displayed (sets show_frame bit to 1).</summary>
+        public bool ShowFrame = true;
+
+        /// <summary>Loop filter type (1 bit). 0 = normal, 1 = simple.</summary>
+        public int FilterType;
+
+        /// <summary>Loop filter level (6 bits, 0..63). 0 disables the filter.</summary>
+        public int FilterLevel;
+
+        /// <summary>Loop filter sharpness (3 bits, 0..7).</summary>
+        public int SharpnessLevel;
+
+        /// <summary>log2 of the number of token partitions (2 bits, 0..2). 0 = single partition.</summary>
+        public int Log2NumberOfTokenPartitions;
+
+        /// <summary>Frame baseline quantizer index (7 bits, 0..127).</summary>
+        public int BaseQindex;
+
+        /// <summary>Y1 DC quantizer delta (signed 5-bit value).</summary>
+        public int Y1DcDeltaQ;
+
+        /// <summary>Y2 DC quantizer delta.</summary>
+        public int Y2DcDeltaQ;
+
+        /// <summary>Y2 AC quantizer delta.</summary>
+        public int Y2AcDeltaQ;
+
+        /// <summary>UV DC quantizer delta.</summary>
+        public int UvDcDeltaQ;
+
+        /// <summary>UV AC quantizer delta.</summary>
+        public int UvAcDeltaQ;
+    }
+
     public static unsafe class bitstream
     {
         /// <summary>
@@ -300,6 +351,192 @@ namespace Vpx.Net
             if (Math.Abs(cfg.UvDcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.UvDcDeltaQ), cfg.UvDcDeltaQ, "UvDcDeltaQ must be -15..15.");
             if (Math.Abs(cfg.UvAcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.UvAcDeltaQ), cfg.UvAcDeltaQ, "UvAcDeltaQ must be -15..15.");
             _ = dqRange;
+        }
+
+        // -----------------------------------------------------------------
+        // Inter (P-frame) header writer (PR 2 of the VP8 P-frame
+        // foundation series).
+        //
+        // Mirrors the keyframe-header writer above for the inter-frame
+        // path of libvpx vp8_pack_bitstream. The bool-coded fields up
+        // through refresh_last_frame are emitted here; the 1056 coef-
+        // prob "no update" bits, the mb_no_skip_coeff / prob_skip_false
+        // pair, the prob_intra / prob_last / prob_gf trio, the
+        // intra-mode prob update flags, the MV prob update bits, and
+        // the per-MB modes/refs/tokens are emitted by the caller (the
+        // frame_encoder, in subsequent PRs of this series). The split
+        // matches the keyframe path: StartXxxHeader writes "everything
+        // before the per-frame entropy state update bits" and the
+        // caller composes the rest.
+        //
+        // Inter frame layout vs keyframe (per RFC 6386 section 9 and
+        // libvpx vp8_pack_bitstream):
+        //
+        //   - 3-byte frame tag with key_frame_flag = 1 (versus 0 for
+        //     keyframes -- the bit semantics are inverted from intuition).
+        //     Patched in FinishInterFrameFirstPartition once the
+        //     first_partition_length is known.
+        //   - NO start code (0x9D 0x01 0x2A) -- keyframe-only.
+        //   - NO width/height -- keyframe-only.
+        //   - color_space and clamp_type bits -- keyframe-only.
+        //   - segmentation_enabled (always 0 here, like the keyframe
+        //     path).
+        //   - filter_type, filter_level (6), sharpness_level (3).
+        //   - mode_ref_lf_delta_enabled (always 0 here).
+        //   - log2_nbr_of_dct_partitions (2 bits).
+        //   - base_qindex (7 bits) + 5x put_delta_q.
+        //   - INTER-ONLY: refresh_golden_frame (1 bit, 0).
+        //   - INTER-ONLY: refresh_alt_ref_frame (1 bit, 0).
+        //   - INTER-ONLY: copy_buffer_to_gf (2 bits, 0) -- only when
+        //     refresh_golden_frame == 0.
+        //   - INTER-ONLY: copy_buffer_to_arf (2 bits, 0) -- only when
+        //     refresh_alt_ref_frame == 0.
+        //   - INTER-ONLY: ref_frame_sign_bias[GOLDEN] (1 bit, 0).
+        //   - INTER-ONLY: ref_frame_sign_bias[ALTREF] (1 bit, 0).
+        //   - refresh_entropy_probs (1 bit, 1).
+        //   - INTER-ONLY: refresh_last_frame (1 bit, 1).
+        //
+        // For our simple P-frame model every inter frame uses LAST_FRAME
+        // as its only reference -- GOLDEN_FRAME and ALTREF_FRAME are not
+        // refreshed (refresh flags = 0) and not copied (copy flags = 0).
+        // refresh_last_frame = 1 makes the freshly-encoded frame the
+        // next inter frame's reference, as expected for a simple
+        // sequential P-frame stream.
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Length of the inter-frame uncompressed prefix (just the 3-byte
+        /// frame tag -- inter frames have no start code or dimensions).
+        /// The boolean coder begins at byte 3.
+        /// </summary>
+        public const int INTER_FRAME_PREFIX_BYTES = FRAME_TAG_BYTES;
+
+        /// <summary>
+        /// Open the boolean coder for an inter frame and write the
+        /// uncompressed frame tag (patched at finish time) plus the
+        /// compressed first-partition prefix up through
+        /// refresh_last_frame.
+        /// </summary>
+        /// <returns>The byte offset where the boolean coder begins
+        /// emitting -- equal to <see cref="INTER_FRAME_PREFIX_BYTES"/>.</returns>
+        public static int StartInterFrameHeader(byte* dest, int destLen, InterFrameHeaderConfig cfg, ref BOOL_CODER bc)
+        {
+            if (cfg == null) throw new ArgumentNullException(nameof(cfg));
+            if (dest == null) throw new ArgumentNullException(nameof(dest));
+            if (destLen < INTER_FRAME_PREFIX_BYTES)
+            {
+                throw new ArgumentException("Destination buffer too small for inter-frame header prefix.", nameof(destLen));
+            }
+            ValidateInterConfig(cfg);
+
+            // Bytes 0-2: frame tag -- left blank for now and patched in
+            // FinishInterFrameFirstPartition once the partition size is
+            // known. Inter frames have no start code or dimensions
+            // afterwards -- the bool coder begins immediately at byte 3.
+            dest[0] = 0; dest[1] = 0; dest[2] = 0;
+
+            int firstPartitionStart = INTER_FRAME_PREFIX_BYTES;
+            bc = new BOOL_CODER();
+            boolhuff.vp8_start_encode(ref bc, dest + firstPartitionStart, dest + destLen);
+
+            // segmentation_enabled = 0 (no per-MB segmentation features).
+            vp8_write_bit(ref bc, 0);
+
+            // Loop filter params.
+            vp8_write_bit(ref bc, cfg.FilterType);
+            boolhuff.vp8_encode_value(ref bc, cfg.FilterLevel, 6);
+            boolhuff.vp8_encode_value(ref bc, cfg.SharpnessLevel, 3);
+
+            // mode_ref_lf_delta_enabled = 0
+            vp8_write_bit(ref bc, 0);
+
+            // log2_nbr_of_dct_partitions
+            boolhuff.vp8_encode_value(ref bc, cfg.Log2NumberOfTokenPartitions, 2);
+
+            // Frame baseline quantizer index.
+            boolhuff.vp8_encode_value(ref bc, cfg.BaseQindex, 7);
+
+            // Five quantizer-delta fields (Y1DC, Y2DC, Y2AC, UVDC, UVAC).
+            put_delta_q(ref bc, cfg.Y1DcDeltaQ);
+            put_delta_q(ref bc, cfg.Y2DcDeltaQ);
+            put_delta_q(ref bc, cfg.Y2AcDeltaQ);
+            put_delta_q(ref bc, cfg.UvDcDeltaQ);
+            put_delta_q(ref bc, cfg.UvAcDeltaQ);
+
+            // Inter-only: golden / altref refresh + copy + sign-bias.
+            // We do not refresh either reference, do not copy, and use
+            // sign_bias = 0 for both -- matches the simple P-frame model
+            // where LAST_FRAME is the only reference in active use.
+            vp8_write_bit(ref bc, 0);   // refresh_golden_frame
+            vp8_write_bit(ref bc, 0);   // refresh_alt_ref_frame
+            // refresh_golden == 0 -> write copy_buffer_to_gf (2 bits, 0).
+            boolhuff.vp8_encode_value(ref bc, 0, 2);
+            // refresh_alt_ref == 0 -> write copy_buffer_to_arf (2 bits, 0).
+            boolhuff.vp8_encode_value(ref bc, 0, 2);
+            vp8_write_bit(ref bc, 0);   // sign_bias[GOLDEN]
+            vp8_write_bit(ref bc, 0);   // sign_bias[ALTREF]
+
+            // refresh_entropy_probs = 1 -- matches the keyframe path's
+            // choice. The decoder uses default probability tables either
+            // way; this bit signals whether the post-frame probability
+            // updates persist or are discarded.
+            vp8_write_bit(ref bc, 1);
+
+            // Inter-only: refresh_last_frame = 1 -- this frame becomes
+            // the reference for the next inter frame, which is the
+            // expected behaviour for a simple sequential P-frame stream.
+            vp8_write_bit(ref bc, 1);
+
+            return firstPartitionStart;
+        }
+
+        /// <summary>
+        /// Closes the boolean coder for partition 0 of an inter frame
+        /// and patches the 3-byte frame tag with first_partition_length,
+        /// show_frame, version, and key_frame_flag = 1 (inter).
+        /// </summary>
+        /// <returns>Total bytes written into <paramref name="dest"/>:
+        /// <see cref="INTER_FRAME_PREFIX_BYTES"/> + bytes consumed by
+        /// the boolean coder.</returns>
+        public static int FinishInterFrameFirstPartition(byte* dest, InterFrameHeaderConfig cfg, ref BOOL_CODER bc)
+        {
+            // Flush trailing bits of the boolean coder.
+            boolhuff.vp8_stop_encode(ref bc);
+
+            int firstPartitionLength = (int)bc.pos;
+
+            // Pack the frame tag exactly as libvpx does:
+            //
+            //   v = (length << 5) | (show_frame << 4) | (version << 1) | key_frame_flag
+            //
+            // and write it little-endian into bytes 0..2. Note
+            // key_frame_flag is 1 for inter frames and 0 for keyframes.
+            int keyFrameFlag = 1; // inter
+            int showFrame = cfg.ShowFrame ? 1 : 0;
+            int v = (firstPartitionLength << 5)
+                  | (showFrame << 4)
+                  | ((cfg.Version & 0x7) << 1)
+                  | keyFrameFlag;
+
+            dest[0] = (byte)(v & 0xff);
+            dest[1] = (byte)((v >> 8) & 0xff);
+            dest[2] = (byte)((v >> 16) & 0xff);
+
+            return INTER_FRAME_PREFIX_BYTES + firstPartitionLength;
+        }
+
+        private static void ValidateInterConfig(InterFrameHeaderConfig cfg)
+        {
+            if ((uint)cfg.Version > 7) throw new ArgumentOutOfRangeException(nameof(cfg.Version), cfg.Version, "Version must be 0..7.");
+            if ((uint)cfg.BaseQindex > 0x7F) throw new ArgumentOutOfRangeException(nameof(cfg.BaseQindex), cfg.BaseQindex, "BaseQindex must be 0..127.");
+            if ((uint)cfg.FilterLevel > 0x3F) throw new ArgumentOutOfRangeException(nameof(cfg.FilterLevel), cfg.FilterLevel, "FilterLevel must be 0..63.");
+            if ((uint)cfg.SharpnessLevel > 0x07) throw new ArgumentOutOfRangeException(nameof(cfg.SharpnessLevel), cfg.SharpnessLevel, "SharpnessLevel must be 0..7.");
+            if ((uint)cfg.Log2NumberOfTokenPartitions > 2) throw new ArgumentOutOfRangeException(nameof(cfg.Log2NumberOfTokenPartitions), cfg.Log2NumberOfTokenPartitions, "Log2NumberOfTokenPartitions must be 0..2.");
+            if (Math.Abs(cfg.Y1DcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y1DcDeltaQ), cfg.Y1DcDeltaQ, "Y1DcDeltaQ must be -15..15.");
+            if (Math.Abs(cfg.Y2DcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y2DcDeltaQ), cfg.Y2DcDeltaQ, "Y2DcDeltaQ must be -15..15.");
+            if (Math.Abs(cfg.Y2AcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y2AcDeltaQ), cfg.Y2AcDeltaQ, "Y2AcDeltaQ must be -15..15.");
+            if (Math.Abs(cfg.UvDcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.UvDcDeltaQ), cfg.UvDcDeltaQ, "UvDcDeltaQ must be -15..15.");
+            if (Math.Abs(cfg.UvAcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.UvAcDeltaQ), cfg.UvAcDeltaQ, "UvAcDeltaQ must be -15..15.");
         }
 
         // -----------------------------------------------------------------

--- a/test/VP8.Net.UnitTest/inter_frame_header_unittest.cs
+++ b/test/VP8.Net.UnitTest/inter_frame_header_unittest.cs
@@ -1,0 +1,284 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: inter_frame_header_unittest.cs
+//
+// Description: Unit tests for the VP8 inter-frame (P-frame) header writer,
+// added in PR 2 of the P-frame foundation series. The writer emits the
+// uncompressed 3-byte frame tag (key_frame_flag = 1, no start code, no
+// dimensions) plus the compressed first-partition prefix through
+// refresh_last_frame.
+//
+// Tests cover:
+//   - Frame tag round-trip: write a header, parse the 3-byte tag, verify
+//     key_frame_flag = 1, show_frame, version, and first_partition_length
+//     all decode to the values we wrote.
+//   - No start code at byte 3: inter frames omit the 0x9D 0x01 0x2A
+//     marker; bytes 3+ contain the bool-coded compressed first partition.
+//   - Compressed first partition round-trip: feed the bool-coder bytes
+//     back through the existing decoder's dboolhuff and verify every
+//     field decodes to the value we wrote (segmentation=0, filter
+//     params, log2_partitions, qindex, delta-q values, golden/altref
+//     refresh flags, sign biases, refresh_entropy_probs,
+//     refresh_last_frame).
+//
+// This is sufficient correctness coverage for PR 2 -- the existing C#
+// decoder is the same one used in production and any divergence in the
+// new writer's output would surface as a parse mismatch here.
+// Bit-exact-against-libvpx tests (matching what bitstream_unittest.cs
+// does for the keyframe path) can be added later if needed; the
+// round-trip approach is more reliable for header-prefix code where
+// every bit is read back through the decoder anyway.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 27 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class inter_frame_header_unittest
+    {
+        // ---------- Frame tag round-trip ----------
+
+        [Fact]
+        public void StartInterFrameHeader_FrameTag_KeyFrameFlagIsOne()
+        {
+            byte[] buf = new byte[256];
+            BOOL_CODER bc = default;
+            var cfg = new InterFrameHeaderConfig
+            {
+                BaseQindex = 32,
+            };
+            int total;
+            fixed (byte* p = buf)
+            {
+                bitstream.StartInterFrameHeader(p, buf.Length, cfg, ref bc);
+                total = bitstream.FinishInterFrameFirstPartition(p, cfg, ref bc);
+            }
+
+            // 3-byte frame tag, little-endian.
+            int v = buf[0] | (buf[1] << 8) | (buf[2] << 16);
+            int keyFrameFlag = v & 0x1;
+            int version = (v >> 1) & 0x7;
+            int showFrame = (v >> 4) & 0x1;
+            int firstPartitionLength = v >> 5;
+
+            Assert.Equal(1, keyFrameFlag);   // <-- 1 for inter (opposite of intuition)
+            Assert.Equal(0, version);
+            Assert.Equal(1, showFrame);
+            // Inter frame prefix is just the 3-byte tag (no start code, no
+            // dimensions), so first_partition_length covers everything from
+            // byte 3 to the end.
+            Assert.Equal(total - 3, firstPartitionLength);
+        }
+
+        [Fact]
+        public void StartInterFrameHeader_NoStartCodeAtByte3()
+        {
+            byte[] buf = new byte[256];
+            BOOL_CODER bc = default;
+            var cfg = new InterFrameHeaderConfig { BaseQindex = 32 };
+            fixed (byte* p = buf)
+            {
+                bitstream.StartInterFrameHeader(p, buf.Length, cfg, ref bc);
+                bitstream.FinishInterFrameFirstPartition(p, cfg, ref bc);
+            }
+
+            // Byte 3 onwards is the bool-coder. There must NOT be the
+            // keyframe start code 0x9D 0x01 0x2A there.
+            //
+            // (The bool-coder always emits a high-entropy first byte so
+            // the chance of a coincidental match is low, but assert the
+            // strict interpretation: byte 3 happens to be the SECOND
+            // byte after the bool coder is initialised, and the
+            // sequence is not the start code.)
+            bool startCodePresent = buf[3] == 0x9D && buf[4] == 0x01 && buf[5] == 0x2A;
+            Assert.False(startCodePresent, "Inter frame must not contain the keyframe start code at byte 3.");
+        }
+
+        // ---------- Compressed first-partition round-trip ----------
+
+        [Fact]
+        public void StartInterFrameHeader_CompressedFirstPartitionDecodesToInputs()
+        {
+            byte[] buf = new byte[256];
+            BOOL_CODER bc = default;
+            var cfg = new InterFrameHeaderConfig
+            {
+                BaseQindex = 24,
+                FilterLevel = 7,
+                SharpnessLevel = 3,
+                FilterType = 1,
+                Log2NumberOfTokenPartitions = 0,
+            };
+            int total;
+            fixed (byte* p = buf)
+            {
+                bitstream.StartInterFrameHeader(p, buf.Length, cfg, ref bc);
+                total = bitstream.FinishInterFrameFirstPartition(p, cfg, ref bc);
+            }
+
+            // Feed the bool-coder bytes (starting at byte 3 -- inter
+            // frames have no start code or dimensions) back through the
+            // existing decoder's bool reader.
+            int boolStart = bitstream.INTER_FRAME_PREFIX_BYTES;
+            byte[] partition = new byte[total - boolStart + 8];  // pad for decoder lookahead
+            System.Array.Copy(buf, boolStart, partition, 0, total - boolStart);
+
+            BOOL_DECODER br = new BOOL_DECODER();
+            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+
+            // Read the same fields the writer emitted, in the same order.
+            int segmentation       = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int filterType         = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int filterLevel        = dboolhuff.vp8_decode_value(ref br, 6);
+            int sharpnessLevel     = dboolhuff.vp8_decode_value(ref br, 3);
+            int modeRefLfDelta     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int log2NumPartitions  = dboolhuff.vp8_decode_value(ref br, 2);
+            int baseQindex         = dboolhuff.vp8_decode_value(ref br, 7);
+            // 5x put_delta_q. With all delta-q values zero, each one
+            // emits a single 0 bit (no delta).
+            int dqY1Dc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int dqY2Dc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int dqY2Ac   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int dqUvDc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int dqUvAc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            // Inter-only fields.
+            int refreshGolden      = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int refreshAltRef      = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int copyBufferToGf     = dboolhuff.vp8_decode_value(ref br, 2);   // refreshGolden==0 -> read 2 bits
+            int copyBufferToArf    = dboolhuff.vp8_decode_value(ref br, 2);   // refreshAltRef==0 -> read 2 bits
+            int signBiasGolden     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int signBiasAltRef     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int refreshEntropy     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            int refreshLastFrame   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+
+            Assert.Equal(0,                  segmentation);
+            Assert.Equal(cfg.FilterType,     filterType);
+            Assert.Equal(cfg.FilterLevel,    filterLevel);
+            Assert.Equal(cfg.SharpnessLevel, sharpnessLevel);
+            Assert.Equal(0,                  modeRefLfDelta);
+            Assert.Equal(cfg.Log2NumberOfTokenPartitions, log2NumPartitions);
+            Assert.Equal(cfg.BaseQindex,     baseQindex);
+            Assert.Equal(0,                  dqY1Dc);
+            Assert.Equal(0,                  dqY2Dc);
+            Assert.Equal(0,                  dqY2Ac);
+            Assert.Equal(0,                  dqUvDc);
+            Assert.Equal(0,                  dqUvAc);
+            Assert.Equal(0,                  refreshGolden);
+            Assert.Equal(0,                  refreshAltRef);
+            Assert.Equal(0,                  copyBufferToGf);
+            Assert.Equal(0,                  copyBufferToArf);
+            Assert.Equal(0,                  signBiasGolden);
+            Assert.Equal(0,                  signBiasAltRef);
+            Assert.Equal(1,                  refreshEntropy);
+            Assert.Equal(1,                  refreshLastFrame);
+        }
+
+        [Fact]
+        public void StartInterFrameHeader_WithDeltaQ_RoundTrips()
+        {
+            // Negative Y1DC delta + positive Y2AC delta: exercises the
+            // put_delta_q sign+magnitude path (1 flag bit, then 4-bit
+            // magnitude + 1 sign bit when non-zero).
+            var cfg = new InterFrameHeaderConfig
+            {
+                BaseQindex = 48,
+                Y1DcDeltaQ = -3,
+                Y2AcDeltaQ = 5,
+            };
+
+            byte[] buf = new byte[256];
+            BOOL_CODER bc = default;
+            int total;
+            fixed (byte* p = buf)
+            {
+                bitstream.StartInterFrameHeader(p, buf.Length, cfg, ref bc);
+                total = bitstream.FinishInterFrameFirstPartition(p, cfg, ref bc);
+            }
+
+            // Frame tag should still be valid.
+            int v = buf[0] | (buf[1] << 8) | (buf[2] << 16);
+            int keyFrameFlag = v & 0x1;
+            int firstPartitionLength = v >> 5;
+            Assert.Equal(1, keyFrameFlag);
+            Assert.Equal(total - 3, firstPartitionLength);
+
+            // Decode the delta-q fields and verify they recover.
+            int boolStart = bitstream.INTER_FRAME_PREFIX_BYTES;
+            byte[] partition = new byte[total - boolStart + 8];
+            System.Array.Copy(buf, boolStart, partition, 0, total - boolStart);
+
+            BOOL_DECODER br = new BOOL_DECODER();
+            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+
+            // Skip past the fields before delta-q.
+            dboolhuff.vp8dx_decode_bool(ref br, 128);            // segmentation
+            dboolhuff.vp8dx_decode_bool(ref br, 128);            // filterType
+            dboolhuff.vp8_decode_value(ref br, 6);               // filterLevel
+            dboolhuff.vp8_decode_value(ref br, 3);               // sharpness
+            dboolhuff.vp8dx_decode_bool(ref br, 128);            // modeRefLfDelta
+            dboolhuff.vp8_decode_value(ref br, 2);               // log2partitions
+            dboolhuff.vp8_decode_value(ref br, 7);               // baseQindex
+
+            // Delta-q fields. Each is: 1 bit "is non-zero?" then
+            // (if non-zero) 4-bit magnitude + 1 bit sign.
+            int y1dc = ReadDeltaQ(ref br);
+            int y2dc = ReadDeltaQ(ref br);
+            int y2ac = ReadDeltaQ(ref br);
+            int uvdc = ReadDeltaQ(ref br);
+            int uvac = ReadDeltaQ(ref br);
+
+            Assert.Equal(cfg.Y1DcDeltaQ, y1dc);
+            Assert.Equal(cfg.Y2DcDeltaQ, y2dc);
+            Assert.Equal(cfg.Y2AcDeltaQ, y2ac);
+            Assert.Equal(cfg.UvDcDeltaQ, uvdc);
+            Assert.Equal(cfg.UvAcDeltaQ, uvac);
+        }
+
+        private static int ReadDeltaQ(ref BOOL_DECODER br)
+        {
+            int hasDelta = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            if (hasDelta == 0) { return 0; }
+            int magnitude = dboolhuff.vp8_decode_value(ref br, 4);
+            int sign      = dboolhuff.vp8dx_decode_bool(ref br, 128);
+            return sign != 0 ? -magnitude : magnitude;
+        }
+
+        // ---------- ValidateConfig ----------
+
+        [Fact]
+        public void StartInterFrameHeader_BaseQindexOutOfRangeThrows()
+        {
+            var cfg = new InterFrameHeaderConfig { BaseQindex = 200 };
+            byte[] buf = new byte[256];
+            BOOL_CODER bc = default;
+            fixed (byte* p = buf)
+            {
+                byte* pp = p;
+                Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+                    bitstream.StartInterFrameHeader(pp, buf.Length, cfg, ref bc));
+            }
+        }
+
+        [Fact]
+        public void StartInterFrameHeader_DeltaQOutOfRangeThrows()
+        {
+            var cfg = new InterFrameHeaderConfig { BaseQindex = 32, Y1DcDeltaQ = 50 };
+            byte[] buf = new byte[256];
+            BOOL_CODER bc = default;
+            fixed (byte* p = buf)
+            {
+                byte* pp = p;
+                Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+                    bitstream.StartInterFrameHeader(pp, buf.Length, cfg, ref bc));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Second in the P-frame foundation series. Adds `StartInterFrameHeader` + `FinishInterFrameFirstPartition` + `InterFrameHeaderConfig` to `src/bitstream.cs`, mirroring the existing keyframe header writer for the inter-frame path of libvpx `vp8_pack_bitstream`. PR 1 plumbed the state; this PR adds the bitstream layer; PRs 3-5 will produce the per-MB inter encoding and wire the whole thing into `VP8Codec`.

## What's in the inter header that's NOT in the keyframe header

Per RFC 6386 §9 and the VP8.Net decoder's existing parsing in `decodeframe.cs` / `decodemv.cs`, an inter frame writes:

- 3-byte frame tag with `key_frame_flag = 1` (versus 0 for keyframes; bit semantics are inverted from intuition). Patched in `FinishInterFrameFirstPartition` once `first_partition_length` is known. **Inter frames have no start code or dimensions afterwards**, so the bool coder begins at byte 3 (vs byte 10 for keyframes).
- `segmentation_enabled`, filter params, `mode_ref_lf_delta_enabled`, `log2_partitions`, `base_qindex`, 5× `put_delta_q` — same as keyframe.
- **inter-only**: `refresh_golden_frame` (1 bit, 0).
- **inter-only**: `refresh_alt_ref_frame` (1 bit, 0).
- **inter-only**: `copy_buffer_to_gf` (2 bits, 0) — only when `refresh_golden_frame == 0`.
- **inter-only**: `copy_buffer_to_arf` (2 bits, 0) — only when `refresh_alt_ref_frame == 0`.
- **inter-only**: `ref_frame_sign_bias[GOLDEN]` (1 bit, 0).
- **inter-only**: `ref_frame_sign_bias[ALTREF]` (1 bit, 0).
- `refresh_entropy_probs` (1 bit, 1) — shared with keyframe.
- **inter-only**: `refresh_last_frame` (1 bit, 1).

For our simple sequential P-frame model LAST_FRAME is the only reference in active use; GOLDEN_FRAME and ALTREF_FRAME are not refreshed and not copied. `refresh_last_frame = 1` makes the freshly-encoded frame the next inter frame's reference.

## Where the writer stops

Mirroring the keyframe path, `StartInterFrameHeader` stops at `refresh_last_frame`. The 1056 coef-prob 'no update' bits, the `mb_no_skip_coeff`/`prob_skip_false` pair, the `prob_intra` / `prob_last` / `prob_gf` trio, the intra-mode prob update flags, the MV prob update bits, and the per-MB modes/refs/tokens are written by the caller (`frame_encoder`, in PR 5). The split keeps each header-writer function focused and matches the way keyframe encoding is already structured.

## Tests

Six new unit tests in `test/VP8.Net.UnitTest/inter_frame_header_unittest.cs`:

- frame tag's `key_frame_flag` is 1 for inter, `show_frame = 1`, `first_partition_length` covers everything after byte 3.
- byte 3 onwards is bool-coder data, **not** the keyframe start code `0x9D 0x01 0x2A`.
- compressed first partition decodes back to inputs through the existing decoder's `dboolhuff` (covers all 19 of the inter-header bool-coded fields including the inter-only golden/altref/sign bias bits).
- delta-q values round-trip with negative + positive magnitudes through `put_delta_q`'s sign+magnitude path.
- `ValidateInterConfig` throws on out-of-range `BaseQindex`.
- `ValidateInterConfig` throws on out-of-range delta-q.

Bit-exact tests against libvpx C reference output (matching what `bitstream_unittest.cs` does for the keyframe path) are out of scope for PR 2 — the round-trip via the existing C# decoder gives the same correctness guarantee, the decoder is the same one used in production for years, and a divergence in either side would surface here.

Full VP8.Net suite: **110 pass, 2 pre-existing System.Drawing/GDI+ failures (Windows-only) unchanged from master, 1 skip.**

## What's NOT in this PR (subsequent PRs in the series)

| # | Title |
| - | --- |
| 3 | ZEROMV inter MB encoder (`mb_encoder.EncodeMacroblockZeroMvLast`) |
| 4 | Per-MB inter mode + ref bits writer |
| 5 | `frame_encoder.EncodeInterFrame` orchestration + `EncodeVideo` wire-up + full key/inter round-trip test |

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.