### PR TITLE
VP8 P-frame foundation: ZEROMV inter MB encoder (PR 3 of 5)

### DIFF
--- a/src/VP8.Net/mb_encoder.cs
+++ b/src/VP8.Net/mb_encoder.cs
@@ -49,6 +49,14 @@
 //                              backed; the small fixed-size buffers in
 //                              IdctAndAddToPlane and InverseWalsh4x4
 //                              are stackalloc.
+// 27 Apr 2026  Claude          PR 3 of P-frame foundation: add
+//                              EncodeMacroblockZeroMvLast for ZEROMV
+//                              LAST_FRAME inter coding. Reuses the
+//                              existing DCT / Walsh / quantize /
+//                              tokenize / inverse-transform pipeline;
+//                              the only new piece is per-pixel
+//                              prediction from the last frame at the
+//                              same MB position.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -431,6 +439,244 @@ namespace Vpx.Net
             return result;
         }
 
+        /// <summary>
+        /// Encode one 16x16 macroblock as an inter MB using ZEROMV with
+        /// LAST_FRAME as the reference. The prediction is the same-position
+        /// 16x16 Y + 8x8 U + 8x8 V samples from the previous frame's
+        /// reconstruction (motion vector = (0, 0)). Residual = source -
+        /// prediction; the rest of the pipeline is identical to
+        /// EncodeMacroblockDcPred (forward DCT + Walsh on Y DCs +
+        /// quantize + tokenize + reconstruct).
+        ///
+        /// PR 3 of the P-frame foundation series. The caller (frame_encoder
+        /// in PR 5) supplies the per-MB prediction by extracting the
+        /// relevant 16x16 / 8x8 / 8x8 samples from the FrameEncoderBuffers
+        /// last-frame reference (added in PR 1).
+        ///
+        /// Inputs:
+        ///   srcY:   16*16 luma source bytes, raster order.
+        ///   srcU:   8*8 chroma U source, raster order.
+        ///   srcV:   8*8 chroma V source, raster order.
+        ///   predY:  16*16 luma prediction (same position from last frame).
+        ///   predU:  8*8 chroma U prediction.
+        ///   predV:  8*8 chroma V prediction.
+        ///   fq:     quantizer tables built by quantizer_init.BuildForQIndex.
+        ///   aboveCtx, leftCtx: optional 9-byte entropy-context arrays as
+        ///           per EncodeMacroblockDcPred.
+        ///   result, scratch: optional pooled buffers (see
+        ///           EncodeMacroblockDcPred for the pooling contract).
+        /// </summary>
+        public static MbEncodeResult EncodeMacroblockZeroMvLast(
+            byte[] srcY, byte[] srcU, byte[] srcV,
+            byte[] predY, byte[] predU, byte[] predV,
+            FrameQuantizer fq,
+            byte[] aboveCtx = null,
+            byte[] leftCtx = null,
+            MbEncodeResult result = null,
+            MbEncoderScratch scratch = null)
+        {
+            if (srcY == null  || srcY.Length  != 256) throw new ArgumentException("srcY must be 16*16");
+            if (srcU == null  || srcU.Length  != 64)  throw new ArgumentException("srcU must be 8*8");
+            if (srcV == null  || srcV.Length  != 64)  throw new ArgumentException("srcV must be 8*8");
+            if (predY == null || predY.Length != 256) throw new ArgumentException("predY must be 16*16");
+            if (predU == null || predU.Length != 64)  throw new ArgumentException("predU must be 8*8");
+            if (predV == null || predV.Length != 64)  throw new ArgumentException("predV must be 8*8");
+            if (fq == null) throw new ArgumentNullException(nameof(fq));
+            if (aboveCtx != null && aboveCtx.Length != 9)
+                throw new ArgumentException("aboveCtx must have length 9 (4 Y + 2 U + 2 V + 1 Y2)", nameof(aboveCtx));
+            if (leftCtx != null && leftCtx.Length != 9)
+                throw new ArgumentException("leftCtx must have length 9 (4 Y + 2 U + 2 V + 1 Y2)", nameof(leftCtx));
+
+            // Pool semantics — see EncodeMacroblockDcPred for the full
+            // explanation. When result/scratch are null we allocate
+            // fresh; otherwise we reuse the supplied instances.
+            if (result == null)
+            {
+                result = new MbEncodeResult();
+            }
+            else
+            {
+                result.Reset();
+            }
+            if (scratch == null) scratch = new MbEncoderScratch();
+            if (aboveCtx == null) aboveCtx = new byte[9];
+            if (leftCtx == null) leftCtx = new byte[9];
+
+            // ---- Step 1: residual = source - prediction ----
+            //
+            // ZEROMV LAST_FRAME means the prediction is the *exact*
+            // same-position samples from the last frame's
+            // reconstruction. Per-pixel subtraction (vs the single-byte
+            // prediction used by DC_PRED) is the only difference at this
+            // layer; everything below it is identical.
+            short[] residY = scratch.ResidY;
+            short[] residU = scratch.ResidU;
+            short[] residV = scratch.ResidV;
+            SubtractPerPixelInto(srcY, predY, residY);
+            SubtractPerPixelInto(srcU, predU, residU);
+            SubtractPerPixelInto(srcV, predV, residV);
+
+            // ---- Step 2: forward DCT for each 4x4 block ----
+            // Same code path as DC_PRED: 16 Y blocks (4x4 carved from
+            // the 16x16 residual plane), 4 U blocks, 4 V blocks.
+            short[][] yCoef = scratch.YCoef;
+            for (int by = 0; by < 4; by++)
+            for (int bx = 0; bx < 4; bx++)
+            {
+                int blkIdx = by * 4 + bx;
+                Fdct4x4FromPlaneInto(residY, srcStride: 16,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                    coef: yCoef[blkIdx]);
+            }
+            short[][] uCoef = scratch.UCoef;
+            short[][] vCoef = scratch.VCoef;
+            for (int by = 0; by < 2; by++)
+            for (int bx = 0; bx < 2; bx++)
+            {
+                int blkIdx = by * 2 + bx;
+                Fdct4x4FromPlaneInto(residU, srcStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                    coef: uCoef[blkIdx]);
+                Fdct4x4FromPlaneInto(residV, srcStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                    coef: vCoef[blkIdx]);
+            }
+
+            // ---- Step 3: Y2 (Walsh) on the 16 Y DCs + zero Y AC DCs ----
+            // Same as DC_PRED. ZEROMV is a 16x16 inter mode so the Y2
+            // second-order block is enabled and the Y AC blocks have
+            // their DC dropped (firstCoeffIndex = 1 in tokenize).
+            short[] y2In = scratch.Y2In;
+            for (int i = 0; i < 16; i++) y2In[i] = yCoef[i][0];
+            short[] y2Coef = scratch.Y2Coef;
+            Walsh4x4Into(y2In, y2Coef);
+
+            for (int i = 0; i < 16; i++) yCoef[i][0] = 0;
+
+            // ---- Step 4: quantize ----
+            short[][] yQ = scratch.YQ;
+            short[][] yDQ = scratch.YDQ;
+            int[] yEob = scratch.YEob;
+            for (int i = 0; i < 16; i++)
+            {
+                yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i]);
+            }
+
+            short[] y2Q = scratch.Y2Q;
+            short[] y2DQ = scratch.Y2DQ;
+            int y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ);
+
+            short[][] uQ = scratch.UQ;
+            short[][] uDQ = scratch.UDQ;
+            short[][] vQ = scratch.VQ;
+            short[][] vDQ = scratch.VDQ;
+            int[] uEob = scratch.UEob;
+            int[] vEob = scratch.VEob;
+            for (int i = 0; i < 4; i++)
+            {
+                uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i]);
+                vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i]);
+            }
+
+            // ---- Step 5: tokenize, with per-block above/left contexts ----
+            // Same context-handling rules as EncodeMacroblockDcPred (see
+            // the long comment block there explaining
+            // VP8_COMBINEENTROPYCONTEXTS and the cross-MB threading
+            // requirement). Inter MBs share the same coef-prob table as
+            // intra MBs of equivalent type, so default_coef_probs is
+            // re-used here.
+
+            // -- Y2 block (block index 24) --
+            int slot = entropy.vp8_block2above[24];
+            int slotL = entropy.vp8_block2left[24];
+            bool y2NonZero = tokenize.vp8_tokenize_block(y2Q,
+                firstCoeffIndex: 0, eob: y2Eob,
+                blockType: 1,
+                initialContext: CombineCtx(aboveCtx[slot], leftCtx[slotL]),
+                coefProbs: default_coef_probs_c.default_coef_probs,
+                output: result.Y2Block);
+            aboveCtx[slot] = leftCtx[slotL] = (byte)(y2NonZero ? 1 : 0);
+
+            // -- 16 Y AC blocks --
+            for (int i = 0; i < 16; i++)
+            {
+                int s = entropy.vp8_block2above[i];
+                int sL = entropy.vp8_block2left[i];
+                bool nz = tokenize.vp8_tokenize_block(yQ[i],
+                    firstCoeffIndex: 1, eob: yEob[i],
+                    blockType: 0,
+                    initialContext: CombineCtx(aboveCtx[s], leftCtx[sL]),
+                    coefProbs: default_coef_probs_c.default_coef_probs,
+                    output: result.YBlocks[i]);
+                aboveCtx[s] = leftCtx[sL] = (byte)(nz ? 1 : 0);
+            }
+
+            // -- 4 U blocks --
+            for (int i = 0; i < 4; i++)
+            {
+                int blkIdx = 16 + i;
+                int s = entropy.vp8_block2above[blkIdx];
+                int sL = entropy.vp8_block2left[blkIdx];
+                bool nz = tokenize.vp8_tokenize_block(uQ[i],
+                    firstCoeffIndex: 0, eob: uEob[i],
+                    blockType: 2,
+                    initialContext: CombineCtx(aboveCtx[s], leftCtx[sL]),
+                    coefProbs: default_coef_probs_c.default_coef_probs,
+                    output: result.UBlocks[i]);
+                aboveCtx[s] = leftCtx[sL] = (byte)(nz ? 1 : 0);
+            }
+
+            // -- 4 V blocks --
+            for (int i = 0; i < 4; i++)
+            {
+                int blkIdx = 20 + i;
+                int s = entropy.vp8_block2above[blkIdx];
+                int sL = entropy.vp8_block2left[blkIdx];
+                bool nz = tokenize.vp8_tokenize_block(vQ[i],
+                    firstCoeffIndex: 0, eob: vEob[i],
+                    blockType: 2,
+                    initialContext: CombineCtx(aboveCtx[s], leftCtx[sL]),
+                    coefProbs: default_coef_probs_c.default_coef_probs,
+                    output: result.VBlocks[i]);
+                aboveCtx[s] = leftCtx[sL] = (byte)(nz ? 1 : 0);
+            }
+
+            // ---- Step 6: reconstruct ----
+            // Inverse Walsh recovers the per-block DC. Then per-block
+            // IDCT + add the per-pixel prediction (vs DC_PRED's flat
+            // single-byte prediction).
+            InverseWalsh4x4Into(y2DQ, y2In);
+            for (int i = 0; i < 16; i++)
+            {
+                yDQ[i][0] = y2In[i];
+            }
+
+            for (int by = 0; by < 4; by++)
+            for (int bx = 0; bx < 4; bx++)
+            {
+                int blkIdx = by * 4 + bx;
+                IdctAndAddBlockToPlane(yDQ[blkIdx],
+                    predPlane: predY, predStride: 16,
+                    dstPlane: result.ReconY, dstStride: 16,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+            }
+            for (int by = 0; by < 2; by++)
+            for (int bx = 0; bx < 2; bx++)
+            {
+                int blkIdx = by * 2 + bx;
+                IdctAndAddBlockToPlane(uDQ[blkIdx],
+                    predPlane: predU, predStride: 8,
+                    dstPlane: result.ReconU, dstStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                IdctAndAddBlockToPlane(vDQ[blkIdx],
+                    predPlane: predV, predStride: 8,
+                    dstPlane: result.ReconV, dstStride: 8,
+                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+            }
+
+            return result;
+        }
+
         // ---------- helpers ----------
 
         /// <summary>
@@ -469,6 +715,14 @@ namespace Vpx.Net
         private static void SubtractFlatInto(byte[] src, byte pred, short[] dst)
         {
             for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred);
+        }
+
+        /// <summary>Per-pixel subtract: dst[i] = src[i] - pred[i]. Used by
+        /// the ZEROMV inter path where the prediction is a same-position
+        /// MB from the last frame's reconstruction. Lengths must match.</summary>
+        private static void SubtractPerPixelInto(byte[] src, byte[] pred, short[] dst)
+        {
+            for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred[i]);
         }
 
         /// <summary>
@@ -585,6 +839,35 @@ namespace Vpx.Net
             // idct, then copy back to the destination plane.
             byte* predBuf = stackalloc byte[16];
             for (int i = 0; i < 16; i++) predBuf[i] = pred;
+            byte* dstBuf = stackalloc byte[16];
+
+            fixed (short* coefP = dqcoeff)
+            {
+                idctllm.vp8_short_idct4x4llm_c(coefP, predBuf, 4, dstBuf, 4);
+            }
+
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+                dstPlane[(blockOffsetY + r) * dstStride + (blockOffsetX + c)] = dstBuf[r * 4 + c];
+        }
+
+        /// <summary>
+        /// Per-pixel-prediction variant of IdctAndAddToPlane. Extracts the
+        /// relevant 4x4 sub-block of <paramref name="predPlane"/> as the
+        /// prediction buffer (vs the flat-byte version used by DC_PRED),
+        /// then runs the same inverse-DCT + clamp-and-add through the
+        /// existing decoder-side idctllm.vp8_short_idct4x4llm_c.
+        /// </summary>
+        private static unsafe void IdctAndAddBlockToPlane(short[] dqcoeff,
+            byte[] predPlane, int predStride,
+            byte[] dstPlane, int dstStride,
+            int blockOffsetX, int blockOffsetY)
+        {
+            byte* predBuf = stackalloc byte[16];
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+                predBuf[r * 4 + c] = predPlane[(blockOffsetY + r) * predStride + (blockOffsetX + c)];
+
             byte* dstBuf = stackalloc byte[16];
 
             fixed (short* coefP = dqcoeff)

--- a/test/VP8.Net.UnitTest/mb_encoder_zeromv_unittest.cs
+++ b/test/VP8.Net.UnitTest/mb_encoder_zeromv_unittest.cs
@@ -1,0 +1,189 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: mb_encoder_zeromv_unittest.cs
+//
+// Description: Unit tests for the per-MB ZEROMV inter encoder
+// (mb_encoder.EncodeMacroblockZeroMvLast), added in PR 3 of the
+// P-frame foundation series.
+//
+// Three tests:
+//   1. Source == prediction (no motion, exact match) -> residual is
+//      zero, every block tokenizes to a single EOB, reconstruction
+//      equals the prediction.
+//   2. Source = prediction + small constant offset -> residual is a
+//      flat constant, encodes to a small set of tokens, reconstruction
+//      matches the source within the quantizer's tolerance.
+//   3. Deterministic pseudo-random source over a flat prediction ->
+//      reconstruction matches the source within tolerance and at least
+//      one block carries non-EOB tokens (i.e. the test actually
+//      exercises the coefficient encode path).
+//
+// These three together prove the ZEROMV inter pipeline (per-pixel
+// subtract -> fdct -> walsh -> quantize -> tokenize -> dequantize ->
+// inverse-walsh -> idct + per-pixel add) is internally consistent and
+// matches the existing DC_PRED MB encoder's structure for the same
+// shape of input.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 27 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public class mb_encoder_zeromv_unittest
+    {
+        // ---------- Test 1: source == prediction -> zero residual ----------
+
+        [Fact]
+        public void EncodeMacroblockZeroMvLast_SourceEqualsPrediction_AllBlocksEob()
+        {
+            byte[] src = MakeFlat(256, 128);
+            byte[] pred = MakeFlat(256, 128);   // identical to source
+            byte[] srcU = MakeFlat(64, 100);
+            byte[] predU = MakeFlat(64, 100);
+            byte[] srcV = MakeFlat(64, 50);
+            byte[] predV = MakeFlat(64, 50);
+
+            var fq = quantizer_init.BuildForQIndex(32);
+            var r = mb_encoder.EncodeMacroblockZeroMvLast(
+                src, srcU, srcV,
+                pred, predU, predV,
+                fq);
+
+            // Every transformed block must reduce to a single EOB token.
+            Assert.Single(r.Y2Block);
+            Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.Y2Block[0].Token);
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Single(r.YBlocks[i]);
+                Assert.Equal((byte)entropy.DCT_EOB_TOKEN, r.YBlocks[i][0].Token);
+            }
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.Single(r.UBlocks[i]);
+                Assert.Single(r.VBlocks[i]);
+            }
+
+            // Reconstruction must match the source/prediction exactly
+            // (zero residual -> reconstruction is identical to prediction).
+            for (int i = 0; i < 256; i++) Assert.Equal((byte)128, r.ReconY[i]);
+            for (int i = 0; i < 64;  i++) Assert.Equal((byte)100, r.ReconU[i]);
+            for (int i = 0; i < 64;  i++) Assert.Equal((byte)50,  r.ReconV[i]);
+        }
+
+        // ---------- Test 2: small constant offset -> small residual, recon within tol ----------
+
+        [Fact]
+        public void EncodeMacroblockZeroMvLast_ConstantOffset_RoundTripsWithinTolerance()
+        {
+            // pred = 100 everywhere, source = 110 everywhere -> residual = 10
+            // The encoder will quantize the 10-amplitude DC component;
+            // recon should land back near 110 within the quantizer step.
+            byte[] src   = MakeFlat(256, 110);
+            byte[] pred  = MakeFlat(256, 100);
+            byte[] srcU  = MakeFlat(64,  130);
+            byte[] predU = MakeFlat(64,  120);
+            byte[] srcV  = MakeFlat(64,  90);
+            byte[] predV = MakeFlat(64,  80);
+
+            var fq = quantizer_init.BuildForQIndex(32);
+            var r = mb_encoder.EncodeMacroblockZeroMvLast(
+                src, srcU, srcV,
+                pred, predU, predV,
+                fq);
+
+            // Reconstruction should be close to source. At Q=32 the DC
+            // step on Y is ~7-8; tolerance of 16 is comfortably above
+            // that so we don't get false negatives from rounding noise.
+            for (int i = 0; i < 256; i++)
+                AssertWithinTolerance(110, r.ReconY[i], 16, "Y[" + i + "]");
+            for (int i = 0; i < 64;  i++)
+                AssertWithinTolerance(130, r.ReconU[i], 16, "U[" + i + "]");
+            for (int i = 0; i < 64;  i++)
+                AssertWithinTolerance(90,  r.ReconV[i], 16, "V[" + i + "]");
+        }
+
+        // ---------- Test 3: random source over flat prediction -> exercises coef path ----------
+
+        [Fact]
+        public void EncodeMacroblockZeroMvLast_RandomSource_NonEobTokensProduced()
+        {
+            // Deterministic xorshift to keep the test reproducible across
+            // platforms / TFMs / runtimes.
+            uint state = 0x12345678u;
+            byte Next() {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                return (byte)(state & 0xFF);
+            }
+
+            byte[] src  = new byte[256];
+            byte[] pred = MakeFlat(256, 128);
+            for (int i = 0; i < 256; i++) src[i] = Next();
+
+            byte[] srcU  = new byte[64];
+            byte[] predU = MakeFlat(64, 128);
+            for (int i = 0; i < 64; i++) srcU[i] = Next();
+
+            byte[] srcV  = new byte[64];
+            byte[] predV = MakeFlat(64, 128);
+            for (int i = 0; i < 64; i++) srcV[i] = Next();
+
+            var fq = quantizer_init.BuildForQIndex(32);
+            var r = mb_encoder.EncodeMacroblockZeroMvLast(
+                src, srcU, srcV,
+                pred, predU, predV,
+                fq);
+
+            // At least one Y block must produce more than just an EOB
+            // token (random data has non-zero AC coefficients).
+            int yBlocksWithCoefs = 0;
+            for (int i = 0; i < 16; i++)
+            {
+                if (r.YBlocks[i].Count > 1) yBlocksWithCoefs++;
+            }
+            Assert.True(yBlocksWithCoefs > 0,
+                "Expected at least one Y block with non-EOB tokens for random input.");
+
+            // Reconstruction is lossy at Q=32 on random input. Tolerance
+            // here is generous (40) because the per-pixel error from
+            // quantising broadband noise is significantly larger than a
+            // single quantizer step on a smooth signal.
+            int maxErrY = 0;
+            for (int i = 0; i < 256; i++)
+            {
+                int err = System.Math.Abs(r.ReconY[i] - src[i]);
+                if (err > maxErrY) maxErrY = err;
+            }
+            Assert.True(maxErrY < 100,
+                "Random-input Y plane recon max error " + maxErrY
+                + " is suspiciously large (> 100). The pipeline may have a sign/clip bug.");
+        }
+
+        // ---------- helpers ----------
+
+        private static byte[] MakeFlat(int len, byte v)
+        {
+            var a = new byte[len];
+            for (int i = 0; i < len; i++) a[i] = v;
+            return a;
+        }
+
+        private static void AssertWithinTolerance(int expected, byte actual, int tol, string label)
+        {
+            int err = actual - expected;
+            if (err < 0) err = -err;
+            Assert.True(err <= tol,
+                label + ": expected=" + expected + " actual=" + actual + " err=" + err
+                + " > tol=" + tol);
+        }
+    }
+}


### PR DESCRIPTION
Third in the P-frame foundation series. Adds `mb_encoder.EncodeMacroblockZeroMvLast` for **ZEROMV LAST_FRAME** inter coding — prediction = same-position 16×16 Y + 8×8 U + 8×8 V samples from the previous frame's reconstruction (motion vector = `(0, 0)`).

## Pipeline

For each MB, the path is:

1. residual = source − prediction (per-pixel)
2. forward DCT each 4×4 block (16 Y + 4 U + 4 V)
3. Walsh-Hadamard on the 16 Y DCs → Y2 block, then zero out Y AC DCs
4. quantize all 25 transformed blocks
5. tokenize with per-block above/left entropy contexts
6. inverse Walsh + inverse DCT + per-pixel add to reconstruct

**Steps 2-5 reuse the exact same primitives as `EncodeMacroblockDcPred`** — the existing tokenize / boolhuff / DCT / Walsh / quantize / quantizer_init code is untouched.

The only structurally-new pieces are:

- **`SubtractPerPixelInto(src, pred[], dst)`** — per-pixel subtract, used in step 1 instead of DC_PRED's flat-byte `SubtractFlatInto`. The DC_PRED prediction is a single computed mean per channel (3 bytes total per MB); ZEROMV's prediction is the full 16×16 + 8×8 + 8×8 = 384-byte per-MB block from the last frame.
- **`IdctAndAddBlockToPlane(dq, predPlane, predStride, ...)`** — extracts the relevant 4×4 sub-block of the per-pixel prediction plane as the IDCT add-buffer, vs DC_PRED's expand-byte-to-4×4. Same `idctllm.vp8_short_idct4x4llm_c` is invoked; the only difference is what's in the prediction buffer.

The new function takes the same optional `aboveCtx` / `leftCtx` / `result` / `scratch` pooling parameters as `EncodeMacroblockDcPred`. The frame-scope context threading rule is identical — VP8's coefficient encoding is mode-agnostic so the entropy state machine doesn't care whether a block came from intra or inter prediction.

## Tests

Three new unit tests in `test/VP8.Net.UnitTest/mb_encoder_zeromv_unittest.cs`:

- **source == prediction** (no motion, exact match) → residual is zero, every block tokenizes to a single EOB token, reconstruction equals the prediction value exactly.
- **source = prediction + small constant offset** → residual is a flat constant, encodes through the full pipeline, reconstruction matches source within the quantizer's tolerance (16 at Q=32).
- **deterministic xorshift random source over flat prediction** → at least one Y block carries non-EOB tokens (proves the coefficient encoding path is exercised), reconstruction sane bound (max err < 100 — catches sign/clip bugs).

Bit-exact-against-libvpx tests are out of scope for PR 3 — the inner DCT/Walsh/quantize/tokenize/idct primitives are already bit-exactly verified against libvpx C output in earlier PRs of the keyframe series, and the new code in this PR is just a different prediction + subtract layer over the same primitives. The 'source == prediction → all-EOB tokens + exact recon' test is the strongest correctness signal the new code can give in isolation; PR 5 will round-trip encoded inter frames through the full decoder for end-to-end verification.

Full VP8.Net suite: **123 pass, 2 pre-existing System.Drawing/GDI+ failures (Windows-only) unchanged from master, 1 skip.**

## What's NOT in this PR (subsequent PRs in the series)

| # | Title |
| - | --- |
| 4 | Per-MB inter mode + ref bits writer (`ref_frame=LAST` tree path, inter mode tree to ZEROMV) for the partition-0 bitstream |
| 5 | `frame_encoder.EncodeInterFrame` orchestration + `EncodeVideo` wire-up + full key/inter round-trip test against the existing decoder |

Attribution: Claude Opus 4.7 (model: `claude-opus-4-7`), commissioned by Aaron Clauson — per the convention from #1562.