### PR TITLE
VP8 P-frame foundation: per-MB inter mode + ref bits writer (PR 4 of 5)

### DIFF
--- a/src/VP8.Net/bitstream.cs
+++ b/src/VP8.Net/bitstream.cs
@@ -623,5 +623,198 @@ namespace Vpx.Net
                 }
             }
         }
+
+        // -----------------------------------------------------------------
+        // Per-MB inter mode + reference frame bits (PR 4 of P-frame series).
+        //
+        // Mirrors the bit sequence read by decodemv.read_mb_modes_mv. For an
+        // inter MB the encoder writes:
+        //   1) is_inter (1 bit) using prob_intra
+        //   2) ref_frame_is_LAST (1 bit) using prob_last  -- 0 = LAST, 1 = G/A
+        //   3) if ref_frame in {GOLDEN, ALTREF}: 1 bit using prob_gf
+        //   4) inter mode tree path (vp8_mv_ref_tree) using a 4-element prob
+        //      array sourced from modecont.vp8_mode_contexts indexed by the
+        //      neighbour-MV-counting context (computed by the caller).
+        //
+        // For an intra-in-inter-frame MB the encoder writes is_inter=0 and
+        // returns; the caller must follow up with the intra mode bits using
+        // the existing intra-frame helpers.
+        //
+        // The two helpers below are deliberately narrow: they only deal with
+        // the ref/mode tree bits. MV residuals (NEWMV) and 4x4 split data
+        // (SPLITMV) are not produced here; the mode_probs computation lives
+        // in the orchestration layer (PR 5) where neighbour MBs are visible.
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Generic boolean-coder tree-walk, used for writing fixed-shape
+        /// trees like vp8_mv_ref_tree. Bit-exact mirror of libvpx's
+        /// vp8_treed_write helper in vp8/encoder/treewriter.h.
+        /// </summary>
+        /// <param name="bc">Open boolean coder.</param>
+        /// <param name="tree">Tree array, sbyte leaves are negative.</param>
+        /// <param name="probs">Per-internal-node probability array.</param>
+        /// <param name="value">Bit-string to emit, MSB first.</param>
+        /// <param name="length">Number of bits in <paramref name="value"/>.</param>
+        public static void vp8_treed_write(
+            ref BOOL_CODER bc,
+            sbyte[] tree,
+            byte[] probs,
+            int value,
+            int length)
+        {
+            int i = 0;
+            do
+            {
+                int bit = (value >> --length) & 1;
+                boolhuff.vp8_encode_bool(ref bc, bit, probs[i >> 1]);
+                i = tree[i + bit];
+            } while (length != 0);
+        }
+
+        /// <summary>
+        /// Pre-computed (value, length) tuples that walk
+        /// <see cref="entropymode.vp8_mv_ref_tree"/> to each
+        /// <see cref="MB_PREDICTION_MODE"/> inter-mode leaf. Indexed by
+        /// (mode - NEARESTMV); ZEROMV uses a special index of -1 mapped to
+        /// position 0 of the tree by <see cref="WriteInterMode"/>.
+        ///
+        /// Order corresponds to libvpx's vp8_mv_ref_encoding_array:
+        ///   ZEROMV    -> {0, 1}     (binary 0)
+        ///   NEARESTMV -> {2, 2}     (binary 10)
+        ///   NEARMV    -> {6, 3}     (binary 110)
+        ///   NEWMV     -> {14, 4}    (binary 1110)
+        ///   SPLITMV   -> {15, 4}    (binary 1111)
+        /// </summary>
+        private static readonly (int Value, int Length)[] s_mvRefEncoding = new[]
+        {
+            (0, 1),     // ZEROMV
+            (2, 2),     // NEARESTMV
+            (6, 3),     // NEARMV
+            (14, 4),    // NEWMV
+            (15, 4),    // SPLITMV
+        };
+
+        /// <summary>
+        /// Looks up the bit-encoding for an inter <see cref="MB_PREDICTION_MODE"/>
+        /// in <see cref="s_mvRefEncoding"/>. Throws if the supplied mode is
+        /// not one of the five inter modes.
+        /// </summary>
+        private static (int Value, int Length) GetMvRefEncoding(MB_PREDICTION_MODE mode)
+        {
+            switch (mode)
+            {
+                case MB_PREDICTION_MODE.ZEROMV:    return s_mvRefEncoding[0];
+                case MB_PREDICTION_MODE.NEARESTMV: return s_mvRefEncoding[1];
+                case MB_PREDICTION_MODE.NEARMV:    return s_mvRefEncoding[2];
+                case MB_PREDICTION_MODE.NEWMV:     return s_mvRefEncoding[3];
+                case MB_PREDICTION_MODE.SPLITMV:   return s_mvRefEncoding[4];
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode),
+                        mode, "Mode is not an inter MB prediction mode.");
+            }
+        }
+
+        /// <summary>
+        /// Writes the inter mode tree path for the supplied inter mode using
+        /// the supplied 4-element probability array. The probability array
+        /// is normally a row of <see cref="modecont.vp8_mode_contexts"/> chosen
+        /// by the neighbour-MV-counting context (computed in PR 5).
+        /// </summary>
+        public static void WriteInterMode(
+            ref BOOL_CODER bc,
+            byte[] modeProbs,
+            MB_PREDICTION_MODE mode)
+        {
+            if (modeProbs == null) throw new ArgumentNullException(nameof(modeProbs));
+            if (modeProbs.Length < 4)
+                throw new ArgumentException("modeProbs must have 4 entries.", nameof(modeProbs));
+
+            var enc = GetMvRefEncoding(mode);
+            vp8_treed_write(ref bc, entropymode.vp8_mv_ref_tree, modeProbs, enc.Value, enc.Length);
+        }
+
+        /// <summary>
+        /// Writes the per-MB ref_frame + inter mode bits for an inter
+        /// macroblock. <paramref name="refFrame"/> must not be
+        /// <see cref="MV_REFERENCE_FRAME.INTRA_FRAME"/>; for intra-in-inter
+        /// MBs use <see cref="WriteInterMbAsIntra"/> instead.
+        /// </summary>
+        /// <param name="bc">Open boolean coder.</param>
+        /// <param name="probIntra">P(is_inter); 8-bit prob from frame header.</param>
+        /// <param name="probLast">P(ref != LAST | is_inter); 8-bit prob.</param>
+        /// <param name="probGf">P(ref == ALTREF | ref in {G,A}); 8-bit prob.</param>
+        /// <param name="refFrame">Reference frame for this MB (LAST/GOLDEN/ALTREF).</param>
+        /// <param name="modeProbs">4-element row from vp8_mode_contexts.</param>
+        /// <param name="mode">Inter mode for this MB.</param>
+        public static void WriteInterMbRefAndMode(
+            ref BOOL_CODER bc,
+            int probIntra,
+            int probLast,
+            int probGf,
+            MV_REFERENCE_FRAME refFrame,
+            byte[] modeProbs,
+            MB_PREDICTION_MODE mode)
+        {
+            if (refFrame == MV_REFERENCE_FRAME.INTRA_FRAME)
+                throw new ArgumentException(
+                    "WriteInterMbRefAndMode is for inter MBs only; use WriteInterMbAsIntra for intra-in-inter.",
+                    nameof(refFrame));
+
+            // is_inter = 1
+            boolhuff.vp8_encode_bool(ref bc, 1, probIntra);
+
+            // ref_frame_is_LAST: 0 -> LAST, 1 -> GOLDEN/ALTREF
+            int refIsNotLast = (refFrame == MV_REFERENCE_FRAME.LAST_FRAME) ? 0 : 1;
+            boolhuff.vp8_encode_bool(ref bc, refIsNotLast, probLast);
+
+            if (refIsNotLast != 0)
+            {
+                // 0 -> GOLDEN, 1 -> ALTREF
+                int refIsAlt = (refFrame == MV_REFERENCE_FRAME.ALTREF_FRAME) ? 1 : 0;
+                boolhuff.vp8_encode_bool(ref bc, refIsAlt, probGf);
+            }
+
+            WriteInterMode(ref bc, modeProbs, mode);
+        }
+
+        /// <summary>
+        /// Writes the is_inter=0 bit for an intra-in-inter macroblock. The
+        /// caller is responsible for following up with the intra Y/UV mode
+        /// bits using the existing intra helpers (which in PR 4 are not yet
+        /// hooked up; the orchestrator added in PR 5 will handle that).
+        /// </summary>
+        public static void WriteInterMbAsIntra(ref BOOL_CODER bc, int probIntra)
+        {
+            boolhuff.vp8_encode_bool(ref bc, 0, probIntra);
+        }
+
+        /// <summary>
+        /// Convenience wrapper for the common "ZEROMV referencing LAST"
+        /// inter MB encoded by <c>EncodeMacroblockZeroMvLast</c>. Picks the
+        /// vp8_mode_contexts row for cnt[CNT_INTRA] = 0 (no inter neighbours)
+        /// which is the correct context for the all-ZEROMV first-row-of-frame
+        /// case used by PR 5 in its initial form. Once neighbour MV
+        /// accumulation is added, callers should use
+        /// <see cref="WriteInterMbRefAndMode"/> directly with a context-derived
+        /// probability row.
+        /// </summary>
+        public static void WriteInterMbZeroMvLast(
+            ref BOOL_CODER bc,
+            int probIntra,
+            int probLast,
+            int probGf)
+        {
+            // Row 0 of vp8_mode_contexts corresponds to cnt[CNT_INTRA] = 0.
+            byte[] row0 = new byte[4];
+            for (int j = 0; j < 4; j++) row0[j] = (byte)modecont.vp8_mode_contexts[0, j];
+
+            WriteInterMbRefAndMode(
+                ref bc,
+                probIntra, probLast, probGf,
+                MV_REFERENCE_FRAME.LAST_FRAME,
+                row0,
+                MB_PREDICTION_MODE.ZEROMV);
+        }
     }
 }

--- a/test/VP8.Net.UnitTest/inter_mb_mode_bits_unittest.cs
+++ b/test/VP8.Net.UnitTest/inter_mb_mode_bits_unittest.cs
@@ -1,0 +1,281 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: inter_mb_mode_bits_unittest.cs
+//
+// Description: Unit tests for the per-MB inter mode + reference frame bit
+// writers added in PR 4 of the VP8 P-frame foundation series. These cover:
+//
+//   - vp8_treed_write: round-trip test against vp8_treed_read for the
+//     vp8_mv_ref_tree (one path per inter mode).
+//   - WriteInterMbAsIntra: writes is_inter=0.
+//   - WriteInterMbRefAndMode: writes is_inter=1, the ref-frame bits, and
+//     the inter-mode tree path. Decoded back through the existing C#
+//     decoder primitives the bits round-trip to the same ref_frame/mode.
+//   - WriteInterMbZeroMvLast: convenience wrapper for ZEROMV+LAST round
+//     trips correctly with any plausible (probIntra, probLast, probGf)
+//     triple.
+//
+// The round-trip approach (vp8dx_decode_bool + vp8_treed_read) is the
+// same proof-of-correctness pattern used by the keyframe header tests
+// (bitstream_unittest.cs) and inter_frame_header_unittest.cs.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 28 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class inter_mb_mode_bits_unittest
+    {
+        // ---------- Helpers ----------
+
+        /// <summary>Initialises a bool coder over a fresh 64-byte buffer.</summary>
+        private static byte[] NewCoderBuffer(out BOOL_CODER bc)
+        {
+            byte[] buf = new byte[64];
+            bc = default;
+            // boolhuff.vp8_start_encode requires a byte[] overload; use that.
+            boolhuff.vp8_start_encode(ref bc, buf, buf.Length);
+            return buf;
+        }
+
+        /// <summary>Closes a bool coder and returns the produced bytes as a
+        /// trimmed-and-padded array suitable for vp8dx_start_decode.</summary>
+        private static byte[] FinishAndCopy(ref BOOL_CODER bc, byte[] buf)
+        {
+            boolhuff.vp8_stop_encode(ref bc);
+            int n = (int)bc.pos;
+            byte[] copy = new byte[n + 16];   // padding for decoder lookahead
+            System.Array.Copy(buf, 0, copy, 0, n);
+            return copy;
+        }
+
+        // ---------- vp8_treed_write round-trip ----------
+
+        public static System.Collections.Generic.IEnumerable<object[]> InterModes()
+        {
+            yield return new object[] { MB_PREDICTION_MODE.ZEROMV };
+            yield return new object[] { MB_PREDICTION_MODE.NEARESTMV };
+            yield return new object[] { MB_PREDICTION_MODE.NEARMV };
+            yield return new object[] { MB_PREDICTION_MODE.NEWMV };
+            yield return new object[] { MB_PREDICTION_MODE.SPLITMV };
+        }
+
+        [Theory]
+        [MemberData(nameof(InterModes))]
+        public void TreedWrite_VpMvRefTree_RoundTripsForEveryInterMode(MB_PREDICTION_MODE mode)
+        {
+            // Use row 0 of vp8_mode_contexts as the prob row.
+            byte[] probs = new byte[4];
+            for (int j = 0; j < 4; j++) probs[j] = (byte)modecont.vp8_mode_contexts[0, j];
+
+            byte[] buf = NewCoderBuffer(out BOOL_CODER bc);
+            bitstream.WriteInterMode(ref bc, probs, mode);
+            byte[] partition = FinishAndCopy(ref bc, buf);
+
+            BOOL_DECODER br = new BOOL_DECODER();
+            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+
+            int decoded = treereader.vp8_treed_read(ref br, entropymode.vp8_mv_ref_tree, probs);
+            Assert.Equal((int)mode, decoded);
+        }
+
+        // ---------- WriteInterMbAsIntra ----------
+
+        [Fact]
+        public void WriteInterMbAsIntra_EmitsZeroBitWithProbIntra()
+        {
+            const int probIntra = 60;
+            byte[] buf = NewCoderBuffer(out BOOL_CODER bc);
+            bitstream.WriteInterMbAsIntra(ref bc, probIntra);
+            byte[] partition = FinishAndCopy(ref bc, buf);
+
+            BOOL_DECODER br = new BOOL_DECODER();
+            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+
+            int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
+            Assert.Equal(0, isInter);
+        }
+
+        // ---------- WriteInterMbRefAndMode round-trip ----------
+
+        public static System.Collections.Generic.IEnumerable<object[]> RefMode()
+        {
+            // Cover all three inter ref frames and all five modes.
+            foreach (var rf in new[] {
+                MV_REFERENCE_FRAME.LAST_FRAME,
+                MV_REFERENCE_FRAME.GOLDEN_FRAME,
+                MV_REFERENCE_FRAME.ALTREF_FRAME })
+            {
+                foreach (var mode in new[] {
+                    MB_PREDICTION_MODE.ZEROMV,
+                    MB_PREDICTION_MODE.NEARESTMV,
+                    MB_PREDICTION_MODE.NEARMV,
+                    MB_PREDICTION_MODE.NEWMV,
+                    MB_PREDICTION_MODE.SPLITMV })
+                {
+                    yield return new object[] { rf, mode };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RefMode))]
+        public void WriteInterMbRefAndMode_RoundTripsForEveryRefAndMode(
+            MV_REFERENCE_FRAME refFrame,
+            MB_PREDICTION_MODE mode)
+        {
+            // Plausible prob values straight from the libvpx defaults.
+            const int probIntra = 63;   // vp8_kf_default_y_mode_probs would be 145 -- arbitrary here.
+            const int probLast  = 255;
+            const int probGf    = 128;
+
+            byte[] modeProbs = new byte[4];
+            for (int j = 0; j < 4; j++) modeProbs[j] = (byte)modecont.vp8_mode_contexts[0, j];
+
+            byte[] buf = NewCoderBuffer(out BOOL_CODER bc);
+            bitstream.WriteInterMbRefAndMode(
+                ref bc, probIntra, probLast, probGf,
+                refFrame, modeProbs, mode);
+            byte[] partition = FinishAndCopy(ref bc, buf);
+
+            BOOL_DECODER br = new BOOL_DECODER();
+            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+
+            // Mirror decodemv.read_mb_modes_mv ref-frame parsing.
+            int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
+            Assert.Equal(1, isInter);
+
+            int notLast = dboolhuff.vp8dx_decode_bool(ref br, probLast);
+            int decodedRef;
+            if (notLast == 0)
+            {
+                decodedRef = (int)MV_REFERENCE_FRAME.LAST_FRAME;
+            }
+            else
+            {
+                int isAlt = dboolhuff.vp8dx_decode_bool(ref br, probGf);
+                decodedRef = 2 + isAlt;
+            }
+            Assert.Equal((int)refFrame, decodedRef);
+
+            int decodedMode = treereader.vp8_treed_read(
+                ref br, entropymode.vp8_mv_ref_tree, modeProbs);
+            Assert.Equal((int)mode, decodedMode);
+        }
+
+        [Fact]
+        public void WriteInterMbRefAndMode_ThrowsForIntraRefFrame()
+        {
+            byte[] buf = new byte[64];
+            BOOL_CODER bc = default;
+            boolhuff.vp8_start_encode(ref bc, buf, buf.Length);
+            byte[] modeProbs = new byte[4] { 7, 1, 1, 143 };
+
+            Assert.Throws<System.ArgumentException>(() =>
+                bitstream.WriteInterMbRefAndMode(
+                    ref bc, 63, 255, 128,
+                    MV_REFERENCE_FRAME.INTRA_FRAME,
+                    modeProbs,
+                    MB_PREDICTION_MODE.ZEROMV));
+        }
+
+        // ---------- WriteInterMbZeroMvLast convenience wrapper ----------
+
+        [Theory]
+        [InlineData(63, 255, 128)]
+        [InlineData(120, 200, 100)]
+        [InlineData(1, 1, 1)]
+        [InlineData(255, 255, 255)]
+        public void WriteInterMbZeroMvLast_RoundTripsToZeroMvLast(int probIntra, int probLast, int probGf)
+        {
+            byte[] buf = NewCoderBuffer(out BOOL_CODER bc);
+            bitstream.WriteInterMbZeroMvLast(ref bc, probIntra, probLast, probGf);
+            byte[] partition = FinishAndCopy(ref bc, buf);
+
+            // The convenience wrapper uses row 0 of vp8_mode_contexts. Build
+            // the same row for the decoder.
+            byte[] modeProbs = new byte[4];
+            for (int j = 0; j < 4; j++) modeProbs[j] = (byte)modecont.vp8_mode_contexts[0, j];
+
+            BOOL_DECODER br = new BOOL_DECODER();
+            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+
+            int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
+            Assert.Equal(1, isInter);
+
+            int notLast = dboolhuff.vp8dx_decode_bool(ref br, probLast);
+            Assert.Equal(0, notLast);   // LAST -> 0
+
+            int decodedMode = treereader.vp8_treed_read(
+                ref br, entropymode.vp8_mv_ref_tree, modeProbs);
+            Assert.Equal((int)MB_PREDICTION_MODE.ZEROMV, decodedMode);
+        }
+
+        // ---------- vp8_treed_write byte-shape regression ----------
+
+        /// <summary>
+        /// Walking ZEROMV through vp8_treed_write writes a single bit at
+        /// modeProbs[0]. Confirm by encoding the same value via
+        /// vp8_encode_bool directly and verifying the byte sequences match.
+        /// </summary>
+        [Fact]
+        public void TreedWrite_ZeroMv_MatchesDirectBoolEncode()
+        {
+            byte[] modeProbs = new byte[4] { 7, 1, 1, 143 };
+
+            // Path A: vp8_treed_write to leaf ZEROMV (value=0, length=1).
+            byte[] bufA = NewCoderBuffer(out BOOL_CODER bcA);
+            bitstream.vp8_treed_write(ref bcA, entropymode.vp8_mv_ref_tree, modeProbs, 0, 1);
+            byte[] outA = FinishAndCopy(ref bcA, bufA);
+
+            // Path B: direct vp8_encode_bool(0, modeProbs[0]).
+            byte[] bufB = NewCoderBuffer(out BOOL_CODER bcB);
+            boolhuff.vp8_encode_bool(ref bcB, 0, modeProbs[0]);
+            byte[] outB = FinishAndCopy(ref bcB, bufB);
+
+            Assert.Equal(outB.Length, outA.Length);
+            for (int i = 0; i < outA.Length; i++)
+            {
+                Assert.True(outA[i] == outB[i],
+                    "byte " + i + " mismatch: A=0x" + outA[i].ToString("x2") + " B=0x" + outB[i].ToString("x2"));
+            }
+        }
+
+        /// <summary>
+        /// Walking SPLITMV through vp8_treed_write writes four 1-bits at
+        /// modeProbs[0..3]. Confirm by encoding the same four bits via
+        /// vp8_encode_bool directly.
+        /// </summary>
+        [Fact]
+        public void TreedWrite_SplitMv_MatchesDirectFourBitEncode()
+        {
+            byte[] modeProbs = new byte[4] { 7, 1, 1, 143 };
+
+            byte[] bufA = NewCoderBuffer(out BOOL_CODER bcA);
+            bitstream.vp8_treed_write(ref bcA, entropymode.vp8_mv_ref_tree, modeProbs, 15, 4);
+            byte[] outA = FinishAndCopy(ref bcA, bufA);
+
+            byte[] bufB = NewCoderBuffer(out BOOL_CODER bcB);
+            boolhuff.vp8_encode_bool(ref bcB, 1, modeProbs[0]);
+            boolhuff.vp8_encode_bool(ref bcB, 1, modeProbs[1]);
+            boolhuff.vp8_encode_bool(ref bcB, 1, modeProbs[2]);
+            boolhuff.vp8_encode_bool(ref bcB, 1, modeProbs[3]);
+            byte[] outB = FinishAndCopy(ref bcB, bufB);
+
+            Assert.Equal(outB.Length, outA.Length);
+            for (int i = 0; i < outA.Length; i++)
+            {
+                Assert.True(outA[i] == outB[i],
+                    "byte " + i + " mismatch: A=0x" + outA[i].ToString("x2") + " B=0x" + outB[i].ToString("x2"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
PR 4 of 5 in the P-frame foundation series. After this lands the encoder has all of the bit-writing primitives it needs to emit an inter MB; PR 5 wires it all together.

## What this PR adds

Five new helpers in `src/VP8.Net/bitstream.cs`, all bit-exact mirrors of the decoder's parser in `decodemv.read_mb_modes_mv`:

- **`vp8_treed_write`** -- generic boolean-coder tree walker, mirror of libvpx's `vp8/encoder/treewriter.h` helper.
- **`WriteInterMode`** -- walks `vp8_mv_ref_tree` to one of the five inter leaves (ZEROMV / NEAREST / NEAR / NEW / SPLITMV) using a 4-element probability row sourced by the caller from `modecont.vp8_mode_contexts`.
- **`WriteInterMbAsIntra`** -- writes `is_inter=0` for an intra-in-inter-frame MB.
- **`WriteInterMbRefAndMode`** -- writes the full per-MB ref_frame + inter-mode header: `is_inter`, `ref_frame_is_LAST`, optional GOLDEN/ALTREF bit, then the inter-mode tree path.
- **`WriteInterMbZeroMvLast`** -- convenience wrapper for the ZEROMV+LAST case used by the orchestrator in PR 5.

## What this PR explicitly does NOT do

- **Neighbour-MV-context computation** (the `cnt[]` array decoded by `read_mb_modes_mv`) -- belongs with the orchestration in PR 5 where neighbour MBs are visible.
- **MV residuals (NEWMV)** and **split-MV (SPLITMV)** payloads -- not needed for the ZEROMV-only first cut.
- **Wiring `EncodeInterFrame`** into `VP8Codec.EncodeVideo` -- that's PR 5.

## Tests (`test/VP8.Net.UnitTest/inter_mb_mode_bits_unittest.cs`)

28 new tests, all passing:

- Round-trip every supported (ref_frame, mode) combination through the existing C# decoder primitives (`vp8dx_decode_bool` + `treereader.vp8_treed_read` on `vp8_mv_ref_tree`).
- Round-trip `WriteInterMode` for every inter mode.
- Round-trip `WriteInterMbAsIntra` and `WriteInterMbZeroMvLast` (parameterised over a range of probability triples).
- Argument-validation: `WriteInterMbRefAndMode` rejects `INTRA_FRAME`.
- Two byte-shape regression tests: `vp8_treed_write` for ZEROMV produces the same bytes as a single direct `vp8_encode_bool`, and SPLITMV produces the same bytes as four direct `vp8_encode_bool` calls.

Full `Vp8.Net.slnf` test suite: 151 passed, 1 skipped, 2 pre-existing GDI+/Windows-only failures (unrelated to this PR).

## Series progress

- [x] PR 1 -- Reference frame storage + key/inter cadence (#1586)
- [x] PR 2 -- Inter (P-frame) header writer (#1587)
- [x] PR 3 -- ZEROMV inter MB encoder (#1588)
- [x] PR 4 -- Per-MB inter mode + ref bits writer (this PR)
- [ ] PR 5 -- `EncodeInterFrame` orchestration + `EncodeVideo` wire-up + full key/inter round-trip