### PR TITLE
VP8 P-frame foundation: EncodeInterFrame orchestration + EncodeVideo wire-up (PR 5 of 5)

### DIFF
--- a/src/VP8.Net/VP8Codec.cs
+++ b/src/VP8.Net/VP8Codec.cs
@@ -112,12 +112,11 @@ namespace Vpx.Net
         /// every frame to be a keyframe; 30 (default) gives one keyframe
         /// per second at 30 fps. Range [1, int.MaxValue].
         ///
-        /// Note: as of PR 1 of the P-frame foundation series the inter
-        /// encoding path is not yet implemented, so EncodeVideo emits a
-        /// keyframe every call regardless of this setting. The value is
-        /// honoured by the internal frame counter so the keyframe-vs-
-        /// inter decision logic can be wired up in subsequent PRs
-        /// without behaviour changing here.
+        /// Inter frames between keyframes are encoded as ZEROMV
+        /// referencing LAST_FRAME (PR 5 of the P-frame foundation
+        /// series). The trade-off vs all-keyframes is dramatically lower
+        /// bitrate at the cost of error-resilience -- a lost inter frame
+        /// will desync the decoder until the next keyframe.
         /// </summary>
         public int KeyframeIntervalFrames
         {
@@ -176,13 +175,7 @@ namespace Vpx.Net
                 // - Forced keyframe (via ForceKeyFrame()): always keyframe.
                 // - Frame counter reached interval: keyframe.
                 // - First frame of stream / no valid reference: keyframe.
-                // - Otherwise: inter.
-                //
-                // Note: as of PR 1 of the P-frame foundation series the
-                // inter branch falls through to EncodeKeyframe too. PRs
-                // 2-5 build out the actual inter encoding path. The
-                // decision logic is in place here so later PRs are pure
-                // implementation flips and not interface changes.
+                // - Otherwise: inter (ZEROMV LAST_FRAME).
                 bool forceKey = _forceKeyFrame
                               || _framesSinceLastKeyframe == 0
                               || _framesSinceLastKeyframe >= _keyframeIntervalFrames;
@@ -196,11 +189,11 @@ namespace Vpx.Net
                 }
                 else
                 {
-                    // PR 1 of N: inter encoding not yet implemented;
-                    // fall through to keyframe to preserve current
-                    // behaviour. Subsequent PRs replace this call with
-                    // the real inter frame encoder.
-                    result = frame_encoder.EncodeKeyframe(_srcY, _srcU, _srcV, width, height, _baseQIndex);
+                    // Inter (P) frame: ZEROMV referencing LAST_FRAME for
+                    // every macroblock. The reference frame is the
+                    // reconstruction of the previous keyframe / inter
+                    // frame, cached on the per-thread FrameEncoderBuffers.
+                    result = frame_encoder.EncodeInterFrame(_srcY, _srcU, _srcV, width, height, _baseQIndex);
                     _framesSinceLastKeyframe++;
                 }
                 return result;

--- a/src/VP8.Net/frame_encoder.cs
+++ b/src/VP8.Net/frame_encoder.cs
@@ -559,6 +559,325 @@ namespace Vpx.Net
             return result;
         }
 
+        /// <summary>
+        /// Encode an I420 source frame as a VP8 inter (P) frame using
+        /// ZEROMV + LAST_FRAME for every macroblock. The reference frame
+        /// must already be cached on the per-thread <see cref="FrameEncoderBuffers"/>
+        /// via a previous call to <see cref="EncodeKeyframe"/> (or another
+        /// <see cref="EncodeInterFrame"/>).
+        ///
+        /// PR 5 of the P-frame foundation series — the orchestration layer
+        /// that ties the header writer (PR 2), the inter MB encoder (PR 3),
+        /// and the per-MB inter mode bit writer (PR 4) into a fully
+        /// decodable inter frame.
+        /// </summary>
+        /// <param name="srcY">width * height luma source bytes.</param>
+        /// <param name="srcU">(width/2) * (height/2) chroma U.</param>
+        /// <param name="srcV">(width/2) * (height/2) chroma V.</param>
+        /// <param name="width">Frame width (multiple of 16).</param>
+        /// <param name="height">Frame height (multiple of 16).</param>
+        /// <param name="qIndex">Base quantizer (0..127).</param>
+        /// <returns>The encoded VP8 inter frame bytes.</returns>
+        public static byte[] EncodeInterFrame(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex)
+        {
+            if (width <= 0 || width % 16 != 0)
+                throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
+            if (height <= 0 || height % 16 != 0)
+                throw new ArgumentException("height must be a positive multiple of 16", nameof(height));
+            if (srcY == null || srcY.Length != width * height)
+                throw new ArgumentException("srcY size mismatch");
+            int chromaW = width / 2, chromaH = height / 2;
+            if (srcU == null || srcU.Length != chromaW * chromaH)
+                throw new ArgumentException("srcU size mismatch");
+            if (srcV == null || srcV.Length != chromaW * chromaH)
+                throw new ArgumentException("srcV size mismatch");
+
+            int mbCols = width / 16;
+            int mbRows = height / 16;
+
+            FrameQuantizer fq = quantizer_init.BuildForQIndex(qIndex);
+
+            var buf = _buffers ??= new FrameEncoderBuffers();
+            buf.EnsureForFrame(width, height);
+            var scratch = buf.Scratch;
+
+            if (!buf.LastFrameValid)
+            {
+                throw new InvalidOperationException(
+                    "EncodeInterFrame requires a valid LAST_FRAME reference. Call EncodeKeyframe first.");
+            }
+
+            var cfg = new InterFrameHeaderConfig
+            {
+                BaseQindex = qIndex,
+            };
+
+            byte[] outBuf = buf.OutBuf;
+
+            // ----- Open compressed first partition (header through refresh_last_frame) -----
+            BOOL_CODER bc0 = new BOOL_CODER();
+            int partitionStart;
+            fixed (byte* p = outBuf)
+            {
+                partitionStart = bitstream.StartInterFrameHeader(p, outBuf.Length, cfg, ref bc0);
+            }
+
+            // ----- Coef-prob updates: 1056 zero flag bits (no updates) -----
+            for (int t = 0; t < entropy.BLOCK_TYPES; t++)
+                for (int b = 0; b < entropy.COEF_BANDS; b++)
+                    for (int c = 0; c < entropy.PREV_COEF_CONTEXTS; c++)
+                        for (int n = 0; n < entropy.ENTROPY_NODES; n++)
+                            boolhuff.vp8_encode_bool(ref bc0, 0,
+                                coefupdateprobs.vp8_coef_update_probs[t, b, c, n]);
+
+            // ----- Phase 1: encode all MBs into MbEncodeResults -----
+            //
+            // Same two-phase split as the keyframe path: encode every MB
+            // first so we know skip flags before writing prob_skip_false
+            // and the per-MB skip bits. For the ZEROMV-everywhere model
+            // the prediction for each MB is the same-position 16x16 Y +
+            // 8x8 U + 8x8 V samples from buf.LastFrameY/U/V.
+
+            MbEncodeResult[] mbResults = buf.MbResults;
+            bool[] mbSkip = buf.MbSkip;
+            int skipTrueCount = 0;
+            int skipFalseCount = 0;
+
+            byte[] frameAboveCtx = buf.FrameAboveCtx;
+            Array.Clear(frameAboveCtx, 0, mbCols * 9);
+
+            byte[] leftCtx = buf.LeftCtx;
+            byte[] aboveCtx = buf.AboveCtx;
+            byte[] mbY = buf.MbY;
+            byte[] mbU = buf.MbU;
+            byte[] mbV = buf.MbV;
+
+            // ZEROMV prediction reuses the per-MB scratch slots that the
+            // keyframe path used for above/left neighbour pixels — the
+            // inter encoder only needs same-position prediction so those
+            // slots are free to repurpose.
+            byte[] predY = buf.AboveY.Length >= 256 ? buf.AboveY : new byte[256];
+            byte[] predU = buf.AboveU.Length >= 64  ? buf.AboveU : new byte[64];
+            byte[] predV = buf.AboveV.Length >= 64  ? buf.AboveV : new byte[64];
+            // Above slots are 16/8/8 in the keyframe path; for inter we
+            // need 256/64/64. Allocate dedicated buffers if the existing
+            // ones aren't large enough (one-time per encoder lifetime).
+            if (predY.Length < 256) predY = new byte[256];
+            if (predU.Length < 64) predU = new byte[64];
+            if (predV.Length < 64) predV = new byte[64];
+
+            for (int mbRow = 0; mbRow < mbRows; mbRow++)
+            {
+                Array.Clear(leftCtx, 0, 9);
+
+                for (int mbCol = 0; mbCol < mbCols; mbCol++)
+                {
+                    // Source MB.
+                    ExtractPlaneInto(srcY, width,   mbCol * 16, mbRow * 16, 16, 16, mbY);
+                    ExtractPlaneInto(srcU, chromaW, mbCol * 8,  mbRow * 8,   8,  8, mbU);
+                    ExtractPlaneInto(srcV, chromaW, mbCol * 8,  mbRow * 8,   8,  8, mbV);
+
+                    // Same-position prediction from LAST_FRAME.
+                    ExtractPlaneInto(buf.LastFrameY, width,   mbCol * 16, mbRow * 16, 16, 16, predY);
+                    ExtractPlaneInto(buf.LastFrameU, chromaW, mbCol * 8,  mbRow * 8,   8,  8, predU);
+                    ExtractPlaneInto(buf.LastFrameV, chromaW, mbCol * 8,  mbRow * 8,   8,  8, predV);
+
+                    // Pull this MB column's above context.
+                    int aboveBase = mbCol * 9;
+                    for (int s = 0; s < 9; s++) aboveCtx[s] = frameAboveCtx[aboveBase + s];
+
+                    int idx = mbRow * mbCols + mbCol;
+                    var pooled = mbResults[idx];
+
+                    var r = mb_encoder.EncodeMacroblockZeroMvLast(
+                        mbY, mbU, mbV,
+                        predY, predU, predV,
+                        fq,
+                        aboveCtx, leftCtx,
+                        pooled, scratch);
+                    mbResults[idx] = r;
+
+                    bool skip = IsAllEob(r);
+                    mbSkip[idx] = skip;
+                    if (skip) skipTrueCount++; else skipFalseCount++;
+
+                    // Save mutated above context for the row below.
+                    for (int s = 0; s < 9; s++) frameAboveCtx[aboveBase + s] = aboveCtx[s];
+                }
+            }
+
+            // ----- Save reconstructed frame as next inter prediction ref -----
+            //
+            // Same per-MB stitch as the keyframe path. Future inter
+            // frames in the stream will use the bytes we write here as
+            // their LAST_FRAME prediction source.
+            for (int mbRow = 0; mbRow < mbRows; mbRow++)
+            {
+                for (int mbCol = 0; mbCol < mbCols; mbCol++)
+                {
+                    var r = mbResults[mbRow * mbCols + mbCol];
+
+                    int yBase = (mbRow * 16) * width + (mbCol * 16);
+                    for (int row = 0; row < 16; row++)
+                    {
+                        Buffer.BlockCopy(r.ReconY, row * 16,
+                            buf.LastFrameY, yBase + row * width, 16);
+                    }
+
+                    int cBase = (mbRow * 8) * chromaW + (mbCol * 8);
+                    for (int row = 0; row < 8; row++)
+                    {
+                        Buffer.BlockCopy(r.ReconU, row * 8,
+                            buf.LastFrameU, cBase + row * chromaW, 8);
+                        Buffer.BlockCopy(r.ReconV, row * 8,
+                            buf.LastFrameV, cBase + row * chromaW, 8);
+                    }
+                }
+            }
+            buf.LastFrameValid = true;
+
+            // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
+            bitstream.vp8_write_bit(ref bc0, 1);   // mb_no_skip_coeff = 1
+
+            byte probSkipFalse;
+            if (skipTrueCount == 0)
+            {
+                probSkipFalse = 0xfb;
+            }
+            else
+            {
+                int total = skipFalseCount + skipTrueCount;
+                int p = skipFalseCount * 256 / total;
+                if (p < 1) p = 1;
+                if (p > 255) p = 255;
+                probSkipFalse = (byte)p;
+            }
+            for (int b = 7; b >= 0; b--)
+                bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
+
+            // ----- Phase 2b: inter-only prob_intra / prob_last / prob_gf -----
+            //
+            // Choices for the ZEROMV-everywhere model:
+            //   prob_intra = 1   -> writing is_inter=1 costs ~0 bits.
+            //   prob_last  = 1   -> writing ref_is_LAST=0 costs ~0 bits.
+            //   prob_gf    = 128 -> never used (ref is always LAST).
+            const byte probIntra = 1;
+            const byte probLast = 1;
+            const byte probGf = 128;
+            for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probIntra >> b) & 1);
+            for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probLast >> b) & 1);
+            for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probGf >> b) & 1);
+
+            // ymode_prob update flag = 0 (use defaults).
+            bitstream.vp8_write_bit(ref bc0, 0);
+            // uv_mode_prob update flag = 0.
+            bitstream.vp8_write_bit(ref bc0, 0);
+
+            // MV context updates: for each of the two MV components
+            // (row, col) and each of MVPcount (=19) probabilities, write
+            // an "update?" flag of 0 with the default vp8_mv_update_probs.
+            // We never update MV probs because we never code MV
+            // residuals (all MBs are ZEROMV).
+            for (int comp = 0; comp < 2; comp++)
+            {
+                byte[] up = entropymv.vp8_mv_update_probs[comp].prob;
+                int mvpCount = (int)MV_ENUM.MVPcount;
+                for (int j = 0; j < mvpCount; j++)
+                {
+                    boolhuff.vp8_encode_bool(ref bc0, 0, up[j]);
+                }
+            }
+
+            // ----- Phase 2c: per-MB skip flag + ref_frame + inter mode -----
+            //
+            // The inter mode tree probabilities depend on a per-MB
+            // neighbour-MV-counting context cnt[CNT_INTRA]. The decoder
+            // (decodemv.read_mb_modes_mv) accumulates this context by
+            // walking the above, left and aboveleft neighbours: each
+            // non-intra neighbour with a zero MV adds either 2
+            // (above/left) or 1 (aboveleft) to cnt[CNT_INTRA].
+            //
+            // For an all-ZEROMV LAST_FRAME stream the cnt[CNT_INTRA]
+            // value is determined entirely by the MB's position, since
+            // every inter MB has ref_frame = LAST and mv.as_int = 0:
+            //   (0,0)        -> 0 (no inter neighbours)
+            //   (0,c) c>0    -> 2 (only left contributes)
+            //   (r,0) r>0    -> 2 (only above contributes)
+            //   (r,c) r>0,c>0 -> 5 (above+left+aboveleft all contribute: 2+2+1)
+            //
+            // We pre-build the three context rows we'll need and pick
+            // the right one per MB, then walk the inter mode tree with
+            // the decoder-matching row.
+            byte[] modeProbsRow0 = new byte[4];
+            byte[] modeProbsRow2 = new byte[4];
+            byte[] modeProbsRow5 = new byte[4];
+            for (int j = 0; j < 4; j++)
+            {
+                modeProbsRow0[j] = (byte)modecont.vp8_mode_contexts[0, j];
+                modeProbsRow2[j] = (byte)modecont.vp8_mode_contexts[2, j];
+                modeProbsRow5[j] = (byte)modecont.vp8_mode_contexts[5, j];
+            }
+
+            for (int mbRow = 0; mbRow < mbRows; mbRow++)
+            {
+                for (int mbCol = 0; mbCol < mbCols; mbCol++)
+                {
+                    int i = mbRow * mbCols + mbCol;
+
+                    // Skip flag (boolean coder, prob_skip_false).
+                    boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
+
+                    // Pick the context-correct mode prob row.
+                    byte[] modeProbs;
+                    if (mbRow == 0 && mbCol == 0)       modeProbs = modeProbsRow0;
+                    else if (mbRow == 0 || mbCol == 0)  modeProbs = modeProbsRow2;
+                    else                                modeProbs = modeProbsRow5;
+
+                    // is_inter=1, ref_is_LAST=0, ZEROMV tree path.
+                    bitstream.WriteInterMbRefAndMode(
+                        ref bc0,
+                        probIntra, probLast, probGf,
+                        MV_REFERENCE_FRAME.LAST_FRAME,
+                        modeProbs,
+                        MB_PREDICTION_MODE.ZEROMV);
+                }
+            }
+
+            // ----- Close partition 0 -----
+            int totalThroughP0;
+            fixed (byte* p = outBuf)
+            {
+                totalThroughP0 = bitstream.FinishInterFrameFirstPartition(p, cfg, ref bc0);
+            }
+
+            // ----- Open partition 1 (token partition) -----
+            BOOL_CODER bc1 = new BOOL_CODER();
+            fixed (byte* p = outBuf)
+            {
+                boolhuff.vp8_start_encode(ref bc1, p + totalThroughP0, p + outBuf.Length);
+
+                int totalMbs = mbRows * mbCols;
+                for (int i = 0; i < totalMbs; i++)
+                {
+                    if (mbSkip[i]) continue;
+
+                    var r = mbResults[i];
+                    bitstream.vp8_pack_tokens(ref bc1, r.Y2Block);
+                    for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc1, r.YBlocks[b]);
+                    for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.UBlocks[b]);
+                    for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.VBlocks[b]);
+                }
+
+                boolhuff.vp8_stop_encode(ref bc1);
+            }
+
+            int totalBytes = totalThroughP0 + (int)bc1.pos;
+            byte[] result = new byte[totalBytes];
+            Array.Copy(outBuf, result, totalBytes);
+            return result;
+        }
+
         // ----- helpers -----
 
         /// <summary>

--- a/test/VP8.Net.UnitTest/encode_inter_frame_unittest.cs
+++ b/test/VP8.Net.UnitTest/encode_inter_frame_unittest.cs
@@ -1,0 +1,302 @@
+﻿﻿//-----------------------------------------------------------------------------
+// Filename: encode_inter_frame_unittest.cs
+//
+// Description: Round-trip tests for the VP8 inter (P) frame encoder
+// added in PR 5 of the P-frame foundation series. Each test encodes a
+// keyframe followed by one or more inter frames and decodes the
+// sequence back through the existing C# VP8 decoder, verifying the
+// decoded pixels are close to (or, in the all-zero-residual case,
+// exactly equal to) the source pixels.
+//
+// The tests cover:
+//   - A static-source sequence (key + 4 inter frames of the same
+//     content) -- inter frames should be tiny because every MB has
+//     zero residual.
+//   - A moving content sequence (key + a couple of inter frames
+//     where the source content changes between frames) -- inter
+//     frames have non-zero residuals which must round-trip through
+//     the encoder/decoder pipeline.
+//   - VP8Codec end-to-end: KeyframeIntervalFrames=4 with a 6-frame
+//     sequence; the codec emits keyframes at frames 1 and 5 and
+//     inter frames in between, and every decoded frame matches its
+//     source within a small per-pixel tolerance.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 28 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class encode_inter_frame_unittest
+    {
+        [Fact]
+        public void EncodeInterFrame_StaticSourceRoundTripsExactly()
+        {
+            // Static-source case: when the inter source equals the
+            // already-encoded reference, every MB's residual is zero,
+            // so every quantized coefficient is zero, every MB is
+            // marked skippable, and the decoded frame equals the
+            // reconstructed reference (which itself equals the
+            // keyframe-decoded output). Result: an exact pixel match
+            // through the full encode->decode round trip.
+            const int width = 32, height = 32;
+            const int qIndex = 32;
+
+            byte[] yuv = MakeFlatI420(width, height, 120, 128, 128);
+            var (y, u, v) = SplitI420(yuv, width, height);
+
+            var ctx = OpenDecoder();
+
+            // Frame 1 = keyframe.
+            byte[] kf = frame_encoder.EncodeKeyframe(y, u, v, width, height, qIndex);
+            byte[] keyDecoded = DecodeOne(ctx, kf, width, height);
+
+            // Frame 2..5 = inter frames over the same source. Decoded
+            // outputs should equal the keyframe's decoded output.
+            for (int i = 0; i < 4; i++)
+            {
+                byte[] interFrame = frame_encoder.EncodeInterFrame(y, u, v, width, height, qIndex);
+                Assert.True(interFrame.Length > 0);
+                // For a static (residual=0) source, the inter frame's
+                // payload is dominated by the per-MB skip flags and
+                // mode tree bits -- no token coefficients at all. It
+                // must be no larger than the corresponding keyframe.
+                Assert.True(interFrame.Length <= kf.Length + 4,
+                    "static inter frame (" + interFrame.Length + ") should not exceed keyframe size (" + kf.Length + ")");
+
+                byte[] decoded = DecodeOne(ctx, interFrame, width, height);
+                AssertExact(keyDecoded, decoded);
+            }
+        }
+
+        [Theory]
+        [InlineData(4,  50.0)]
+        [InlineData(16, 45.0)]
+        [InlineData(32, 35.0)]
+        public void EncodeInterFrame_ChangingSourceRoundTripsWithinTolerance(int qIndex, double minPsnrDb)
+        {
+            // Moving-content case: the inter source is a shifted
+            // version of the keyframe source. The encoder produces a
+            // non-zero residual; the decoder applies it on top of its
+            // copy of LAST_FRAME and should reconstruct a frame close
+            // to the inter source. Higher Q -> more quantization
+            // noise -> lower PSNR threshold.
+            const int width = 64, height = 32;
+
+            byte[] keyYuv   = MakeGradientI420(width, height, frame: 0);
+            byte[] interYuv = MakeGradientI420(width, height, frame: 1);
+
+            var (yK, uK, vK) = SplitI420(keyYuv,   width, height);
+            var (yI, uI, vI) = SplitI420(interYuv, width, height);
+
+            var ctx = OpenDecoder();
+
+            byte[] kf = frame_encoder.EncodeKeyframe(yK, uK, vK, width, height, qIndex);
+            byte[] decKey = DecodeOne(ctx, kf, width, height);
+
+            byte[] inter = frame_encoder.EncodeInterFrame(yI, uI, vI, width, height, qIndex);
+            byte[] decInter = DecodeOne(ctx, inter, width, height);
+
+            // Decoded inter frame closely matches the inter source.
+            AssertWithinPSNR(interYuv, decInter, minPsnrDb);
+
+            // Sanity: the decoded inter is closer to the inter source
+            // than the keyframe reconstruction is. This is the load-
+            // bearing inter-vs-intra check -- if the residual were
+            // being dropped or misencoded, dec_inter would equal
+            // dec_key and this assertion would fail.
+            double psnrInterVsInterSrc = ComputePSNR(interYuv, decInter);
+            double psnrKeyVsInterSrc   = ComputePSNR(interYuv, decKey);
+            Assert.True(psnrInterVsInterSrc > psnrKeyVsInterSrc + 5.0,
+                "inter encoding should bring the decoded frame substantially closer to the inter source than the reference. psnrInter=" +
+                psnrInterVsInterSrc.ToString("F2") + " psnrKey=" + psnrKeyVsInterSrc.ToString("F2"));
+        }
+
+        [Fact]
+        public void VP8Codec_EmitsInterFramesBetweenKeyframes()
+        {
+            // VP8Codec.EncodeVideo with KeyframeIntervalFrames=4 should
+            // emit keyframes at frames 1 and 5 of a 6-frame stream and
+            // inter frames in between. Verify the cadence by parsing
+            // the 3-byte frame tag of each emitted frame
+            // (key_frame_flag is bit 0 of byte 0).
+            const int width = 32, height = 32;
+            const int qIndex = 32;
+
+            var codec = new VP8Codec
+            {
+                BaseQIndex = qIndex,
+                KeyframeIntervalFrames = 4,
+            };
+
+            byte[] yuv = MakeFlatI420(width, height, 100, 128, 128);
+
+            int[] expectedFrameType = { 0, 1, 1, 1, 0, 1 };  // 0 = key, 1 = inter
+            for (int frame = 0; frame < expectedFrameType.Length; frame++)
+            {
+                byte[] enc = codec.EncodeVideo(width, height, yuv,
+                    SIPSorceryMedia.Abstractions.VideoPixelFormatsEnum.I420,
+                    SIPSorceryMedia.Abstractions.VideoCodecsEnum.VP8);
+                Assert.NotNull(enc);
+                Assert.True(enc.Length > 3);
+                int keyFrameFlag = enc[0] & 0x1;
+                Assert.Equal(expectedFrameType[frame], keyFrameFlag);
+            }
+        }
+
+        [Fact]
+        public void VP8Codec_KeyframeAndInterRoundTripThroughDecoder()
+        {
+            // End-to-end: a 6-frame static-source sequence with
+            // KeyframeIntervalFrames=4 should decode every frame
+            // exactly to the same bytes (by construction the source
+            // doesn't change between frames, so every inter frame is
+            // all-skip and equal to the keyframe reconstruction).
+            const int width = 32, height = 32;
+            const int qIndex = 32;
+
+            var codec = new VP8Codec
+            {
+                BaseQIndex = qIndex,
+                KeyframeIntervalFrames = 4,
+            };
+
+            byte[] yuv = MakeFlatI420(width, height, 100, 128, 128);
+            var ctx = OpenDecoder();
+
+            byte[] firstDecoded = null;
+            for (int frame = 0; frame < 6; frame++)
+            {
+                byte[] enc = codec.EncodeVideo(width, height, yuv,
+                    SIPSorceryMedia.Abstractions.VideoPixelFormatsEnum.I420,
+                    SIPSorceryMedia.Abstractions.VideoCodecsEnum.VP8);
+                byte[] dec = DecodeOne(ctx, enc, width, height);
+                if (firstDecoded == null) firstDecoded = dec;
+                else AssertExact(firstDecoded, dec);
+            }
+        }
+
+        // ---------- helpers ----------
+
+        private static vpx_codec_ctx_t OpenDecoder()
+        {
+            var ctx = new vpx_codec_ctx_t();
+            var algo = vp8_dx.vpx_codec_vp8_dx();
+            var cfg = new vpx_codec_dec_cfg_t { threads = 1 };
+            var initRes = vpx_decoder.vpx_codec_dec_init(ctx, algo, cfg, 0);
+            Assert.Equal(vpx_codec_err_t.VPX_CODEC_OK, initRes);
+            return ctx;
+        }
+
+        private static byte[] DecodeOne(vpx_codec_ctx_t ctx, byte[] frame, int width, int height)
+        {
+            fixed (byte* pFrame = frame)
+            {
+                var decRes = vpx_decoder.vpx_codec_decode(ctx, pFrame, (uint)frame.Length, IntPtr.Zero, 0);
+                Assert.Equal(vpx_codec_err_t.VPX_CODEC_OK, decRes);
+            }
+
+            IntPtr iter = IntPtr.Zero;
+            var img = vpx_decoder.vpx_codec_get_frame(ctx, iter);
+            Assert.NotNull(img);
+            Assert.Equal((uint)width,  img.d_w);
+            Assert.Equal((uint)height, img.d_h);
+
+            int sz = width * height;
+            int csz = (width / 2) * (height / 2);
+            byte[] outYuv = new byte[sz + 2 * csz];
+
+            for (int row = 0; row < height; row++)
+            {
+                Marshal.Copy((IntPtr)(img.planes[0] + row * img.stride[0]), outYuv, row * width, width);
+                if (row < height / 2)
+                {
+                    Marshal.Copy((IntPtr)(img.planes[1] + row * img.stride[1]), outYuv, sz + row * (width / 2), width / 2);
+                    Marshal.Copy((IntPtr)(img.planes[2] + row * img.stride[2]), outYuv, sz + csz + row * (width / 2), width / 2);
+                }
+            }
+            return outYuv;
+        }
+
+        private static byte[] MakeFlatI420(int width, int height, byte y, byte u, byte v)
+        {
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var b = new byte[ySize + 2 * cSize];
+            for (int i = 0; i < ySize; i++) b[i] = y;
+            for (int i = 0; i < cSize; i++) b[ySize + i] = u;
+            for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = v;
+            return b;
+        }
+
+        private static byte[] MakeGradientI420(int width, int height, int frame)
+        {
+            // A gentle horizontal gradient in Y, shifted by 4 pixels per
+            // frame. UV are flat 128. The shift is small enough to
+            // produce a non-trivial but bounded inter residual at any Q.
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var b = new byte[ySize + 2 * cSize];
+            int shift = (frame * 4) % width;
+            for (int row = 0; row < height; row++)
+                for (int col = 0; col < width; col++)
+                {
+                    int x = (col + shift) % width;
+                    b[row * width + col] = (byte)(40 + (x * 180) / width);
+                }
+            for (int i = 0; i < cSize; i++) b[ySize + i] = 128;
+            for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = 128;
+            return b;
+        }
+
+        private static (byte[] Y, byte[] U, byte[] V) SplitI420(byte[] yuv, int w, int h)
+        {
+            int ySize = w * h, cSize = (w / 2) * (h / 2);
+            var y = new byte[ySize]; var u = new byte[cSize]; var v = new byte[cSize];
+            Buffer.BlockCopy(yuv, 0, y, 0, ySize);
+            Buffer.BlockCopy(yuv, ySize, u, 0, cSize);
+            Buffer.BlockCopy(yuv, ySize + cSize, v, 0, cSize);
+            return (y, u, v);
+        }
+
+        private static void AssertExact(byte[] expected, byte[] actual)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.True(expected[i] == actual[i],
+                    "byte " + i + " differs: expected=" + expected[i] + " actual=" + actual[i]);
+            }
+        }
+
+        private static double ComputePSNR(byte[] expected, byte[] actual)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            double sse = 0.0;
+            for (int i = 0; i < expected.Length; i++)
+            {
+                int d = expected[i] - actual[i];
+                sse += d * d;
+            }
+            double mse = sse / expected.Length;
+            return (mse == 0.0) ? double.PositiveInfinity : 10.0 * Math.Log10(255.0 * 255.0 / mse);
+        }
+
+        private static void AssertWithinPSNR(byte[] expected, byte[] actual, double minPsnrDb)
+        {
+            double psnr = ComputePSNR(expected, actual);
+            Assert.True(psnr >= minPsnrDb,
+                "PSNR " + psnr.ToString("F2") + " dB below required " + minPsnrDb.ToString("F2") + " dB");
+        }
+    }
+}


### PR DESCRIPTION
**The final PR in the P-frame foundation series.** Adds `frame_encoder.EncodeInterFrame` and wires it into `VP8Codec.EncodeVideo` so the codec emits real, decodable inter (P) frames between keyframes.

## What this PR adds

### `frame_encoder.EncodeInterFrame`

Same two-phase split as `EncodeKeyframe`:

- **Phase 1**: encode every MB via `mb_encoder.EncodeMacroblockZeroMvLast` using same-position prediction from `buf.LastFrameY/U/V`, propagating cross-MB entropy contexts.
- **Phase 1.5**: stitch the per-MB reconstructions into `buf.LastFrameY/U/V` as the next frame's reference.
- **Phase 2**: write the inter-frame header tail (`mb_no_skip_coeff`, `prob_skip_false`, `prob_intra`/`prob_last`/`prob_gf`, `ymode`/`uv_mode` update flags, MV context update flags) and per-MB skip + ref + inter-mode bits.
- **Phase 3**: write the token partition.

### Per-MB inter mode context (the load-bearing detail)

The decoder (`decodemv.read_mb_modes_mv`) computes a `cnt[CNT_INTRA]` from the inter state of the above/left/aboveleft neighbours and uses it to pick a row of `vp8_mode_contexts`. For an all-ZEROMV LAST_FRAME stream this is determined entirely by MB position:

| Position | cnt | Row of `vp8_mode_contexts` |
|---|---|---|
| `(0, 0)` | 0 | row 0 (no inter neighbours) |
| `(0, c)` for `c > 0` | 2 | row 2 (only left contributes) |
| `(r, 0)` for `r > 0` | 2 | row 2 (only above contributes) |
| `(r, c)` for `r,c > 0` | 5 | row 5 (above+left+aboveleft contribute: 2+2+1) |

Without this match the decoder reads the inter mode bits with a different probability than the encoder wrote them with, the boolean coder desyncs, and subsequent MBs decode as garbage. (I caught this by dumping per-MB reconstructed pixels and finding MB 2 of row 0 came out as a flat DC_PRED -- the decoder had silently fallen through to intra mode.)

### `VP8Codec.EncodeVideo`

The inter branch now calls `EncodeInterFrame` instead of falling through to `EncodeKeyframe`. The `KeyframeIntervalFrames` XML doc has been updated.

## Tests (`test/VP8.Net.UnitTest/encode_inter_frame_unittest.cs`, 6 tests, all passing)

- **`EncodeInterFrame_StaticSourceRoundTripsExactly`**: encode keyframe, then 4 inter frames over the same source. All-skip; decoded bytes match the keyframe's decoded output exactly.
- **`EncodeInterFrame_ChangingSourceRoundTripsWithinTolerance(Q=4/16/32)`** (Theory): inter source is a 4-pixel horizontal shift of the keyframe source. Decoded inter PSNR vs source: Q=4 > 50 dB, Q=16 > 45 dB, Q=32 > 35 dB. Plus a sanity check that the decoded inter is at least 5 dB closer to the inter source than the keyframe reconstruction is -- catches the residual being silently dropped.
- **`VP8Codec_EmitsInterFramesBetweenKeyframes`**: `KeyframeIntervalFrames=4` over a 6-frame stream produces frame tags with `key_frame_flag = 1` at frames 1 and 5 and 0 elsewhere.
- **`VP8Codec_KeyframeAndInterRoundTripThroughDecoder`**: end-to-end with `KeyframeIntervalFrames=4` over a static-source 6-frame stream; every decoded frame matches the first decoded frame exactly.

Full `Vp8.Net.slnf` suite: 157 passed, 1 skipped, 2 pre-existing GDI+/Windows-only failures unrelated to this PR.

## What this PR does NOT do

- **Real motion estimation** -- every inter MB is ZEROMV. NEWMV with motion vector search is the next thing on the roadmap.
- **GOLDEN / ALTREF references** -- only LAST_FRAME is supported.
- **SPLITMV** (4x4 sub-MB partitions) -- not encoded.
- **Loop filter** -- still off (FilterLevel = 0).

After this lands the codec produces real, decodable inter frames between keyframes. The compression benefit is greatest for slowly-changing content.

## Series complete

- [x] PR 1 -- Reference frame storage + key/inter cadence (#1586)
- [x] PR 2 -- Inter (P-frame) header writer (#1587)
- [x] PR 3 -- ZEROMV inter MB encoder (#1588)
- [x] PR 4 -- Per-MB inter mode + ref bits writer (#1589)
- [x] PR 5 -- `EncodeInterFrame` orchestration + `EncodeVideo` wire-up (this PR)