### PR TITLE
VP8: fix cross-thread inter-frame encoding (regression from #1591)

### DIFF
--- a/src/VP8.Net/VP8Codec.cs
+++ b/src/VP8.Net/VP8Codec.cs
@@ -64,6 +64,13 @@ namespace Vpx.Net
 
         private int _baseQIndex = DEFAULT_BASE_QINDEX;
 
+        // Per-codec-instance scratch buffers used by frame_encoder. Holds
+        // the LAST_FRAME reference between key/inter calls; instance-scoped
+        // (vs ThreadStatic) so that calls dispatched onto different
+        // thread-pool threads -- a Timer callback in particular -- still
+        // share the same reference frame.
+        private readonly FrameEncoderBuffers _frameBuffers = new FrameEncoderBuffers();
+
         /// <summary>
         /// VP8 base quantizer index used for every frame. Range [0, 127];
         /// 0 is highest quality / largest frames, 127 is lowest quality /
@@ -184,7 +191,7 @@ namespace Vpx.Net
                 byte[] result;
                 if (forceKey)
                 {
-                    result = frame_encoder.EncodeKeyframe(_srcY, _srcU, _srcV, width, height, _baseQIndex);
+                    result = frame_encoder.EncodeKeyframeWithBuffers(_srcY, _srcU, _srcV, width, height, _baseQIndex, _frameBuffers);
                     _framesSinceLastKeyframe = 1;
                 }
                 else
@@ -193,7 +200,7 @@ namespace Vpx.Net
                     // every macroblock. The reference frame is the
                     // reconstruction of the previous keyframe / inter
                     // frame, cached on the per-thread FrameEncoderBuffers.
-                    result = frame_encoder.EncodeInterFrame(_srcY, _srcU, _srcV, width, height, _baseQIndex);
+                    result = frame_encoder.EncodeInterFrameWithBuffers(_srcY, _srcU, _srcV, width, height, _baseQIndex, _frameBuffers);
                     _framesSinceLastKeyframe++;
                 }
                 return result;

--- a/src/VP8.Net/frame_encoder.cs
+++ b/src/VP8.Net/frame_encoder.cs
@@ -245,9 +245,10 @@ namespace Vpx.Net
         /// <param name="height">Frame height in pixels (multiple of 16).</param>
         /// <param name="qIndex">VP8 base quantizer (0 = lossless-ish, 127 = very lossy).</param>
         /// <returns>The encoded VP8 frame bytes.</returns>
-        public static byte[] EncodeKeyframe(byte[] srcY, byte[] srcU, byte[] srcV,
-            int width, int height, int qIndex)
+        internal static byte[] EncodeKeyframeWithBuffers(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex, FrameEncoderBuffers buffers)
         {
+            if (buffers == null) throw new System.ArgumentNullException(nameof(buffers));
             if (width <= 0 || width % 16 != 0)
                 throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
             if (height <= 0 || height % 16 != 0)
@@ -266,9 +267,8 @@ namespace Vpx.Net
             // Build the quantizer for this Q index.
             FrameQuantizer fq = quantizer_init.BuildForQIndex(qIndex);
 
-            // Pull per-thread scratch buffers (allocated lazily on first
-            // call, resized only on dimension changes).
-            var buf = _buffers ??= new FrameEncoderBuffers();
+            // Use the caller-supplied per-codec scratch buffers.
+            var buf = buffers;
             buf.EnsureForFrame(width, height);
             var scratch = buf.Scratch;
 
@@ -578,9 +578,10 @@ namespace Vpx.Net
         /// <param name="height">Frame height (multiple of 16).</param>
         /// <param name="qIndex">Base quantizer (0..127).</param>
         /// <returns>The encoded VP8 inter frame bytes.</returns>
-        public static byte[] EncodeInterFrame(byte[] srcY, byte[] srcU, byte[] srcV,
-            int width, int height, int qIndex)
+        internal static byte[] EncodeInterFrameWithBuffers(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex, FrameEncoderBuffers buffers)
         {
+            if (buffers == null) throw new System.ArgumentNullException(nameof(buffers));
             if (width <= 0 || width % 16 != 0)
                 throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
             if (height <= 0 || height % 16 != 0)
@@ -598,7 +599,7 @@ namespace Vpx.Net
 
             FrameQuantizer fq = quantizer_init.BuildForQIndex(qIndex);
 
-            var buf = _buffers ??= new FrameEncoderBuffers();
+            var buf = buffers;
             buf.EnsureForFrame(width, height);
             var scratch = buf.Scratch;
 
@@ -876,6 +877,43 @@ namespace Vpx.Net
             byte[] result = new byte[totalBytes];
             Array.Copy(outBuf, result, totalBytes);
             return result;
+        }
+
+        /// <summary>
+        /// Convenience wrapper for callers that don't want to manage their
+        /// own <see cref="FrameEncoderBuffers"/>. Uses a per-thread
+        /// instance allocated lazily on first call.
+        ///
+        /// IMPORTANT: this wrapper is unsuitable for codecs that emit
+        /// inter frames between keyframes -- if the keyframe call lands
+        /// on one thread and the next inter call lands on another (e.g.
+        /// when invoked from a Timer callback), the second thread's
+        /// buffers will not have a valid LAST_FRAME reference and the
+        /// inter call will throw. Use the <see cref="VP8Codec"/> entry
+        /// point in that case; it owns a single per-codec
+        /// <see cref="FrameEncoderBuffers"/> guarded by a lock.
+        /// </summary>
+        public static byte[] EncodeKeyframe(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex)
+        {
+            return EncodeKeyframeWithBuffers(srcY, srcU, srcV, width, height, qIndex,
+                _buffers ??= new FrameEncoderBuffers());
+        }
+
+        /// <summary>
+        /// Convenience wrapper for callers that don't want to manage their
+        /// own <see cref="FrameEncoderBuffers"/>. Uses a per-thread
+        /// instance allocated lazily on first call.
+        ///
+        /// IMPORTANT: see the warning on <see cref="EncodeKeyframe"/>
+        /// regarding cross-thread invocation. <see cref="VP8Codec"/> is
+        /// the production-correct entry point.
+        /// </summary>
+        public static byte[] EncodeInterFrame(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex)
+        {
+            return EncodeInterFrameWithBuffers(srcY, srcU, srcV, width, height, qIndex,
+                _buffers ??= new FrameEncoderBuffers());
         }
 
         // ----- helpers -----

--- a/test/VP8.Net.UnitTest/encode_inter_frame_unittest.cs
+++ b/test/VP8.Net.UnitTest/encode_inter_frame_unittest.cs
@@ -186,6 +186,77 @@ namespace Vpx.Net.UnitTest
             }
         }
 
+
+        [Fact]
+        public void VP8Codec_KeyAndInterDispatchedAcrossThreads()
+        {
+            // Reproducer for the bug encountered in the
+            // WebRTCGetStartedVP8Net example: VideoTestPatternSource
+            // dispatches each frame onto a Timer callback, which the
+            // .NET thread pool is free to run on different worker
+            // threads each tick. With the previous ThreadStatic
+            // FrameEncoderBuffers each thread had its own LastFrameY
+            // reference; if the keyframe ran on thread A and the next
+            // inter call ran on thread B, B's buffers had no valid
+            // reference and EncodeInterFrame would throw.
+            //
+            // This test forces calls onto distinct threads via
+            // Task.Factory.StartNew(LongRunning) and verifies the
+            // codec encodes both a keyframe and a subsequent inter
+            // frame without throwing. The single per-codec
+            // FrameEncoderBuffers (guarded by the codec's _encoderLock)
+            // is what makes this work.
+            const int width = 32, height = 32;
+
+            var codec = new VP8Codec
+            {
+                BaseQIndex = 32,
+                KeyframeIntervalFrames = 4,
+            };
+
+            byte[] yuv = new byte[width * height + 2 * (width / 2) * (height / 2)];
+            for (int i = 0; i < width * height; i++) yuv[i] = 100;
+            for (int i = width * height; i < yuv.Length; i++) yuv[i] = 128;
+
+            int keyframeThreadId = -1;
+            int interFrameThreadId = -1;
+
+            // Frame 1 -- keyframe, on a fresh long-running thread.
+            byte[] kf = System.Threading.Tasks.Task.Factory.StartNew(() =>
+            {
+                keyframeThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+                return codec.EncodeVideo(width, height, yuv,
+                    SIPSorceryMedia.Abstractions.VideoPixelFormatsEnum.I420,
+                    SIPSorceryMedia.Abstractions.VideoCodecsEnum.VP8);
+            }, System.Threading.Tasks.TaskCreationOptions.LongRunning).Result;
+
+            Assert.NotNull(kf);
+            Assert.True(kf.Length > 3);
+            Assert.Equal(0, kf[0] & 0x1);  // key_frame_flag = 0 for keyframe
+
+            // Frame 2 -- inter, on a *different* long-running thread.
+            // With the old ThreadStatic buffers this would throw
+            // InvalidOperationException("EncodeInterFrame requires a
+            // valid LAST_FRAME reference") because the new thread's
+            // buffers are empty.
+            byte[] inter = System.Threading.Tasks.Task.Factory.StartNew(() =>
+            {
+                interFrameThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+                return codec.EncodeVideo(width, height, yuv,
+                    SIPSorceryMedia.Abstractions.VideoPixelFormatsEnum.I420,
+                    SIPSorceryMedia.Abstractions.VideoCodecsEnum.VP8);
+            }, System.Threading.Tasks.TaskCreationOptions.LongRunning).Result;
+
+            Assert.NotNull(inter);
+            Assert.True(inter.Length > 3);
+            Assert.Equal(1, inter[0] & 0x1);  // key_frame_flag = 1 for inter
+
+            // Sanity: the two calls really did run on different threads
+            // (otherwise the test reduces to the single-thread case
+            // which we already cover).
+            Assert.NotEqual(keyframeThreadId, interFrameThreadId);
+        }
+
         // ---------- helpers ----------
 
         private static vpx_codec_ctx_t OpenDecoder()


### PR DESCRIPTION
Fixes a crash in `WebRTCGetStartedVP8Net` introduced by #1591:

```
System.InvalidOperationException: EncodeInterFrame requires a valid LAST_FRAME reference. Call EncodeKeyframe first.
   at Vpx.Net.frame_encoder.EncodeInterFrame(...)
   at Vpx.Net.VP8Codec.EncodeVideo(...)
   at SIPSorcery.Media.VideoTestPatternSource.GenerateTestPattern(...)
```

## Root cause

`frame_encoder._buffers` was `[ThreadStatic]`. The WebRTC example dispatches each frame off a `Timer` callback, which the .NET thread pool runs on whichever worker thread is free. The keyframe ran on thread A, populating A's `_buffers.LastFrameY/U/V`. The next inter call ran on thread B, whose `_buffers` was a fresh instance with `LastFrameValid = false`, and `EncodeInterFrame` threw.

The `[ThreadStatic]` pattern was fine for the keyframe-only era (every call recomputes everything from scratch), but inter frames carry state across calls (the LAST_FRAME reference), so it stops working as soon as inter encoding is enabled.

## Fix

Lift the `FrameEncoderBuffers` from a `ThreadStatic` on `frame_encoder` to a per-instance field on `VP8Codec` (`_frameBuffers`), shared across all calls into the same codec instance and serialised by the existing `_encoderLock`.

Mechanically:

- Added internal `frame_encoder.EncodeKeyframeWithBuffers` and `EncodeInterFrameWithBuffers` that take an explicit `FrameEncoderBuffers` parameter.
- The public `EncodeKeyframe` / `EncodeInterFrame` are now thin wrappers around the `*WithBuffers` variants that allocate a per-thread instance lazily on first call. They keep their old behaviour and have an XML doc warning that cross-thread inter-frame use is unsafe.
- `VP8Codec` gained a `private readonly FrameEncoderBuffers _frameBuffers` field, instantiated in the codec ctor and passed to the `*WithBuffers` entry points. This survives across calls regardless of which thread-pool thread runs the next `EncodeVideo` invocation.

## Regression test

`VP8Codec_KeyAndInterDispatchedAcrossThreads` (in `encode_inter_frame_unittest.cs`) uses `Task.Factory.StartNew(LongRunning)` to force the keyframe and the following inter call onto distinct threads, asserts both frames encode (and that the second frame's `key_frame_flag` is 1, i.e. it really did take the inter branch), and asserts the two `ManagedThreadId`s are actually different (so the test isn't a no-op when the scheduler coalesces both calls onto the same worker).

Full `Vp8.Net.slnf` suite: 158 passed, 1 skipped, 2 pre-existing GDI+/Windows-only failures unrelated to this PR.