### PR TITLE
Filter non-STUN packets by selected ICE pair source (fixes #1559)

### DIFF
--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -1311,6 +1311,34 @@ namespace SIPSorcery.Net
 
             if (buffer?.Length > 0)
             {
+                // ICE source-address filter (issue #1559). Non-STUN packets are
+                // only forwarded to DTLS / RTP if their source matches the
+                // currently nominated ICE candidate pair's remote endpoint.
+                // Mirrors what libwebrtc does in
+                // webrtc/p2p/base/connection.cc (Connection::OnReadPacket only
+                // signals when the packet is from remote_candidate_.address())
+                // and what pion does in pion/ice/agent.go (handleInbound
+                // silently drops non-STUN packets that don't originate from
+                // the selected pair).
+                //
+                // Without this filter an attacker who can guess the local
+                // port can flood DTLS ClientHello packets to interfere with
+                // a genuine handshake. STUN packets are filtered out earlier
+                // in the RTP channel and aren't subject to this check
+                // (consent freshness / ICE restart / new pair nomination
+                // still happen via the STUN path).
+                if (!IsFromSelectedIceCandidate(remoteEP))
+                {
+                    if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                    {
+                        var nominatedEP = _rtpIceChannel?.NominatedEntry?.RemoteCandidate?.DestinationEndPoint;
+                        logger.LogDebug(
+                            "Dropped {ByteCount} byte non-STUN packet from {RemoteEndPoint}; nominated ICE remote is {NominatedEndPoint} (issue #1559).",
+                            buffer.Length, remoteEP, nominatedEP);
+                    }
+                    return;
+                }
+
                 try
                 {
                     if (buffer?.Length > RTPHeader.MIN_HEADER_LEN && buffer[0] >= 128 && buffer[0] <= 191)
@@ -1336,6 +1364,31 @@ namespace SIPSorcery.Net
                     logger.LogError(excp, "Exception RTCPeerConnection.OnRTPDataReceived {ErrorMessage}", excp.Message);
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="remoteEP"/> matches the address +
+        /// port of the currently nominated ICE candidate pair's remote
+        /// candidate. Returns false when no pair has been nominated yet, or
+        /// when the source endpoint does not match.
+        ///
+        /// Used by <see cref="OnRTPDataReceived"/> to filter incoming
+        /// non-STUN traffic, mirroring the source-check libwebrtc and pion
+        /// apply at the ICE layer (issue #1559).
+        ///
+        /// For TURN-relayed candidates the receive path in
+        /// <see cref="RTPChannel"/> already rewrites the remote endpoint
+        /// from the TURN server's address to the peer's apparent address
+        /// (XOR-PEER-ADDRESS in the Data indication), so the comparison
+        /// here works the same way for host and relay pairs.
+        /// </summary>
+        internal bool IsFromSelectedIceCandidate(IPEndPoint remoteEP)
+        {
+            if (remoteEP == null) return false;
+            var nominatedEP = _rtpIceChannel?.NominatedEntry?.RemoteCandidate?.DestinationEndPoint;
+            if (nominatedEP == null) return false;
+            return nominatedEP.Port == remoteEP.Port
+                && nominatedEP.Address.Equals(remoteEP.Address);
         }
 
         /// <summary>

--- a/test/unit/net/WebRTC/RTCPeerConnectionIceSourceFilterUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionIceSourceFilterUnitTest.cs
@@ -1,0 +1,168 @@
+//-----------------------------------------------------------------------------
+// Filename: RTCPeerConnectionIceSourceFilterUnitTest.cs
+//
+// Description: Regression tests for the ICE source-address filter applied
+// to non-STUN packets received on an RTCPeerConnection
+// (issue #1559 -- DTLS handshake DoS via off-path packet injection).
+//
+// The filter mirrors what libwebrtc and pion both do at the ICE layer:
+// after a candidate pair has been nominated, only forward non-STUN
+// packets up the stack if their source address+port matches the selected
+// pair's remote endpoint.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 29 Apr 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Net;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class RTCPeerConnectionIceSourceFilterUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public RTCPeerConnectionIceSourceFilterUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Before any ICE candidate pair has been nominated there is no
+        /// "selected" remote to compare against. The filter must reject
+        /// every non-STUN packet -- DTLS isn't expected to start until
+        /// after nomination, and this is the conservative behaviour
+        /// libwebrtc and pion both apply.
+        /// </summary>
+        [Fact]
+        public void IsFromSelectedIceCandidate_NoNominatedEntry_ReturnsFalse()
+        {
+            var pc = new RTCPeerConnection(null);
+            var anyEP = new IPEndPoint(IPAddress.Parse("198.51.100.10"), 50000);
+
+            Assert.False(pc.IsFromSelectedIceCandidate(anyEP),
+                "with no NominatedEntry the filter must reject all sources");
+        }
+
+        /// <summary>
+        /// After nomination, packets from the selected pair's remote
+        /// endpoint must be accepted.
+        /// </summary>
+        [Fact]
+        public void IsFromSelectedIceCandidate_MatchingSource_ReturnsTrue()
+        {
+            var pc = new RTCPeerConnection(null);
+            var remoteEP = new IPEndPoint(IPAddress.Parse("203.0.113.5"), 51820);
+            InjectNominatedRemoteEndpoint(pc, remoteEP);
+
+            Assert.True(pc.IsFromSelectedIceCandidate(remoteEP),
+                "matching source must pass the filter");
+        }
+
+        /// <summary>
+        /// After nomination, packets from a different IP address than the
+        /// nominated pair's remote endpoint must be rejected. This is the
+        /// load-bearing case for issue #1559 -- an attacker on a different
+        /// IP than the genuine peer cannot inject DTLS handshake packets.
+        /// </summary>
+        [Fact]
+        public void IsFromSelectedIceCandidate_DifferentAddress_ReturnsFalse()
+        {
+            var pc = new RTCPeerConnection(null);
+            var nominatedEP = new IPEndPoint(IPAddress.Parse("203.0.113.5"), 51820);
+            var attackerEP  = new IPEndPoint(IPAddress.Parse("198.51.100.99"), 51820);
+            InjectNominatedRemoteEndpoint(pc, nominatedEP);
+
+            Assert.False(pc.IsFromSelectedIceCandidate(attackerEP),
+                "off-path source address must be rejected (issue #1559)");
+        }
+
+        /// <summary>
+        /// After nomination, packets from the right IP but the wrong
+        /// port must be rejected. The wrong-port case covers an attacker
+        /// who has spoofed the genuine peer's IP but is using a different
+        /// source port.
+        /// </summary>
+        [Fact]
+        public void IsFromSelectedIceCandidate_DifferentPort_ReturnsFalse()
+        {
+            var pc = new RTCPeerConnection(null);
+            var nominatedEP = new IPEndPoint(IPAddress.Parse("203.0.113.5"), 51820);
+            var wrongPortEP = new IPEndPoint(IPAddress.Parse("203.0.113.5"), 51821);
+            InjectNominatedRemoteEndpoint(pc, nominatedEP);
+
+            Assert.False(pc.IsFromSelectedIceCandidate(wrongPortEP),
+                "wrong source port must be rejected (issue #1559)");
+        }
+
+        /// <summary>
+        /// A null remote endpoint is treated as "no source", which is
+        /// rejected.
+        /// </summary>
+        [Fact]
+        public void IsFromSelectedIceCandidate_NullRemoteEndpoint_ReturnsFalse()
+        {
+            var pc = new RTCPeerConnection(null);
+            var nominatedEP = new IPEndPoint(IPAddress.Parse("203.0.113.5"), 51820);
+            InjectNominatedRemoteEndpoint(pc, nominatedEP);
+
+            Assert.False(pc.IsFromSelectedIceCandidate(null));
+        }
+
+        // ---------- helpers ----------
+
+        /// <summary>
+        /// Reaches into the RTCPeerConnection's private RtpIceChannel
+        /// instance and sets a fake NominatedEntry whose RemoteCandidate's
+        /// DestinationEndPoint matches <paramref name="remoteEP"/>. Used
+        /// by the tests to put the connection into a "post-nomination"
+        /// state without running a real ICE handshake.
+        /// </summary>
+        private static void InjectNominatedRemoteEndpoint(RTCPeerConnection pc, IPEndPoint remoteEP)
+        {
+            var iceChannelField = typeof(RTCPeerConnection).GetField(
+                "_rtpIceChannel",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(iceChannelField);
+
+            var iceChannel = iceChannelField.GetValue(pc);
+            Assert.NotNull(iceChannel);
+
+            // Build a fake remote candidate whose DestinationEndPoint matches
+            // the supplied remote EP.
+            var remoteCandidate = new RTCIceCandidate(
+                RTCIceProtocol.udp,
+                remoteEP.Address,
+                (ushort)remoteEP.Port,
+                RTCIceCandidateType.host);
+            remoteCandidate.SetDestinationEndPoint(remoteEP);
+
+            // Use any plausible local candidate -- only the remote side is
+            // compared by the filter.
+            var localCandidate = new RTCIceCandidate(
+                RTCIceProtocol.udp,
+                IPAddress.Loopback,
+                (ushort)1234,
+                RTCIceCandidateType.host);
+
+            var entry = new ChecklistEntry(localCandidate, remoteCandidate, isLocalController: true);
+
+            // NominatedEntry has a private setter -- assign via reflection.
+            var nominatedProp = typeof(RtpIceChannel).GetProperty(
+                "NominatedEntry",
+                BindingFlags.Instance | BindingFlags.Public);
+            Assert.NotNull(nominatedProp);
+            nominatedProp.SetValue(iceChannel, entry);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1559 -- DTLS handshake DoS via off-path packet injection.

## The bug

Once a peer's local UDP port was known to an attacker (and these are trivial to enumerate -- they're advertised in the offer SDP and visible in the network capture of any prior connection), the attacker could flood DTLS ClientHello packets at the port and the RTCPeerConnection's receive path would forward them to the DTLS transport unconditionally. A single well-timed injected ClientHello is enough to make the genuine handshake fail or get reset.

## The fix

Mirror what libwebrtc and pion both do at the ICE layer: drop any non-STUN packet whose source address+port doesn't match the currently nominated ICE candidate pair's remote endpoint.

  * libwebrtc -- webrtc/p2p/base/connection.cc: Connection::OnReadPacket only signals SignalReadPacket when the packet originates from remote_candidate_.address().
  * pion -- pion/ice/agent.go: Agent.handleInbound silently drops non-STUN packets that don't originate from the selected pair.

Concretely:

  * Added RTCPeerConnection.IsFromSelectedIceCandidate(IPEndPoint). Returns true iff the supplied source endpoint matches _rtpIceChannel.NominatedEntry.RemoteCandidate.DestinationEndPoint. Returns false when no pair has been nominated yet (the conservative behaviour libwebrtc and pion both apply -- DTLS isn't expected to start until after nomination, so any non-STUN packet arriving before nomination is anomalous and dropped).
  * RTCPeerConnection.OnRTPDataReceived now consults this helper before dispatching to RTP/RTCP or DTLS. Non-matching packets are dropped silently in production (logged at Debug level when enabled) -- this matches libwebrtc / pion which treat the drop as a normal-traffic-shape filter rather than a security event.

For TURN-relayed pairs the existing receive path in RTPChannel already rewrites the remote endpoint from the TURN server's address to the peer's apparent address (via the Data indication's XOR-PEER-ADDRESS attribute), so the comparison works the same way for host and relay pairs without any extra special-casing.

## Regression test

test/unit/net/WebRTC/RTCPeerConnectionIceSourceFilterUnitTest.cs adds five Facts:

  * IsFromSelectedIceCandidate_NoNominatedEntry_ReturnsFalse
  * IsFromSelectedIceCandidate_MatchingSource_ReturnsTrue
  * IsFromSelectedIceCandidate_DifferentAddress_ReturnsFalse (the load-bearing case for #1559 -- attacker on a different IP)
  * IsFromSelectedIceCandidate_DifferentPort_ReturnsFalse (attacker who has spoofed the peer's IP but with a different source port)
  * IsFromSelectedIceCandidate_NullRemoteEndpoint_ReturnsFalse

The tests use reflection to inject a fake NominatedEntry on the RtpIceChannel rather than running a real ICE handshake, keeping them fast and deterministic.

## Compatibility

No public API change. Existing legitimate traffic flows continue to work because the ICE channel only fires OnRTPDataReceived after a candidate pair has been nominated and the source matches that pair. ICE restart is still supported -- a new nomination updates NominatedEntry and the filter follows along.

Credit: thanks to @songxpu for reporting the issue.