### PR TITLE
RTCPeerConnection: close on DTLS close_notify (fixes UdpReceiver ConnectionReset spinloop)

### DIFF
--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -1853,10 +1853,24 @@ namespace SIPSorcery.Net
         {
             if (alertType == TlsAlertTypesEnum.CloseNotify)
             {
-                logger.LogDebug("SCTP closing transport as a result of DTLS close notification.");
+                logger.LogDebug("Closing peer connection as a result of DTLS close notification.");
 
-                // No point keeping the SCTP association open if there is no DTLS transport available.
-                sctp?.Close();
+                // A DTLS close_notify from the remote peer means the secure
+                // channel is gone -- the entire peer connection is no longer
+                // usable. Per the WebRTC spec the RTCDtlsTransport state moves
+                // to "closed" which propagates to the RTCPeerConnection.
+                // libwebrtc, Firefox and pion all close the whole peer
+                // connection at this point.
+                //
+                // Without this Close() call the SCTP association alone is
+                // closed but the underlying RTP/UDP socket keeps running and
+                // continues to send periodic STUN consent freshness checks +
+                // RTP/RTCP packets at the now-gone remote port. The remote
+                // OS responds with ICMP "port unreachable" for each one,
+                // which surfaces as a tight loop of
+                //   SocketException UdpReceiver.EndReceiveFrom (ConnectionReset)
+                // warnings until the application shuts itself down.
+                Close("Remote DTLS close notification received");
             }
             else
             {


### PR DESCRIPTION
When a remote peer sends a DTLS `close_notify` alert, `OnDtlsAlert` was only closing the SCTP association -- the rest of the `RTCPeerConnection` (RTP / RTCP / ICE consent freshness, the underlying UDP socket) kept running. The local stack then continued sending periodic packets to the gone-away remote port; the remote OS replied with ICMP "port unreachable" for each one; `UdpReceiver` surfaced each as a `SocketException(ConnectionReset)`, logged it, and the `finally` block immediately re-armed `BeginReceiveFrom`. End result: a tight loop of

```
[WRN] SocketException UdpReceiver.EndReceiveFrom (ConnectionReset).
      An existing connection was forcibly closed by the remote host.
```

filling the log until the application killed itself.

## Spec & comparison

Per the WebRTC spec, when the DTLS connection underlying an `RTCDtlsTransport` closes, the transport's state moves to `closed` and that propagates to the `RTCPeerConnection`. libwebrtc (`webrtc/p2p/base/dtls_transport.cc`), Firefox (`media/mtransport/transportlayerdtls.cpp`), and pion (`webrtc/dtlstransport.go`) all close the whole peer connection on a remote `close_notify`.

## Fix

In `RTCPeerConnection.OnDtlsAlert`, on `CloseNotify`, call `Close("Remote DTLS close notification received")` instead of `sctp?.Close()`. `Close()` already does the right cascade -- closes `DataChannels`, `_rtpIceChannel`, the DTLS handle, `sctp`, and the underlying `RTPSession` (including the `RTPChannel` that owns `UdpReceiver`). `UdpReceiver`'s `m_isClosed` flag flips to true, so the `ConnectionReset` `finally` block stops re-arming the receive.

## Repro

`examples/WebRTCExamples/WebRTCNostrSignalling` browser-vs-C# demo. Click the **Disconnect** button in the browser; before this fix the C# console spun on `ConnectionReset` until killed; with this fix the peer connection closes cleanly and the underlying RTP socket is released.