### PR TITLE
RTP ICE: replace OS DNS fallback with real mDNS via Makaretu.Dns.Multicast

### DIFF
--- a/src/SIPSorcery/SIPSorcery.csproj
+++ b/src/SIPSorcery/SIPSorcery.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Concentus" Version="2.2.2" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageReference Include="DnsClient" Version="1.8.0" />
+    <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />

--- a/src/SIPSorcery/net/ICE/MdnsResolver.cs
+++ b/src/SIPSorcery/net/ICE/MdnsResolver.cs
@@ -61,7 +61,7 @@ namespace SIPSorcery.Net
         /// </summary>
         public static TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
-        private static readonly ILogger logger = Log.Logger;
+        private static readonly ILogger logger = LogFactory.CreateLogger<MdnsResolver>();
 
         // Single shared MulticastService instance per process. Starting
         // and stopping the service per query would re-bind the multicast

--- a/src/SIPSorcery/net/ICE/MdnsResolver.cs
+++ b/src/SIPSorcery/net/ICE/MdnsResolver.cs
@@ -51,8 +51,13 @@ namespace SIPSorcery.Net
     /// <see cref="RtpIceChannel.MdnsGetAddresses"/> /
     /// <see cref="RtpIceChannel.MdnsResolve"/> hook.
     /// </summary>
-    internal static class MdnsResolver
+    internal sealed class MdnsResolver
     {
+        // Helper-only class with all static members; prevent instantiation.
+        // Cannot be 'static class' because LogFactory.CreateLogger<T>()
+        // requires T to be a non-static type (CS0718).
+        private MdnsResolver() { }
+
         /// <summary>
         /// Default time to wait for any answer to arrive after the query
         /// is sent. mDNS responses on a healthy LAN typically arrive in

--- a/src/SIPSorcery/net/ICE/MdnsResolver.cs
+++ b/src/SIPSorcery/net/ICE/MdnsResolver.cs
@@ -1,0 +1,191 @@
+//-----------------------------------------------------------------------------
+// Filename: MdnsResolver.cs
+//
+// Description: Multicast DNS (RFC 6762) hostname resolver used by
+// RtpIceChannel to look up the .local hostnames Chrome (and other WebRTC
+// stacks) publish as ICE candidates for privacy reasons.
+//
+// .NET's Dns.GetHostAddressesAsync does not reliably do mDNS on most
+// platforms -- on Windows it depends on whether the OS-level mDNS resolver
+// is enabled and whether the multicast packet round-trips through the
+// firewall in time. The previous fallback in RtpIceChannel.ResolveMdnsName
+// surfaced this as
+//
+//   System.Net.Sockets.SocketException (11001): No such host is known.
+//
+// every time a Chrome peer was used, breaking browser-vs-SIPSorcery
+// WebRTC interop on most Windows installs.
+//
+// This class wraps Makaretu.Dns.Multicast (RFC 6762 mDNS over UDP/5353
+// multicast) into a small static helper that does an actual mDNS query
+// for the requested hostname and returns whatever A / AAAA answers
+// arrive within a bounded timeout. The MulticastService instance is
+// cached for the lifetime of the process to avoid the per-query cost of
+// rejoining the multicast group on every NIC.
+//
+// Author(s):
+// Aaron Clauson (aaron@sipsorcery.com) + Claude Opus 4.7.
+//
+// History:
+// 03 May 2026  Claude          Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Makaretu.Dns;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Sys;
+
+namespace SIPSorcery.Net
+{
+    /// <summary>
+    /// Resolves multicast-DNS (.local) hostnames via Makaretu.Dns.Multicast.
+    /// Used by <see cref="RtpIceChannel"/> as the default fallback when the
+    /// caller has not supplied its own
+    /// <see cref="RtpIceChannel.MdnsGetAddresses"/> /
+    /// <see cref="RtpIceChannel.MdnsResolve"/> hook.
+    /// </summary>
+    internal static class MdnsResolver
+    {
+        /// <summary>
+        /// Default time to wait for any answer to arrive after the query
+        /// is sent. mDNS responses on a healthy LAN typically arrive in
+        /// under 100 ms; the longer timeout covers congested wifi and
+        /// virtual NIC weirdness.
+        /// </summary>
+        public static TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromSeconds(2);
+
+        private static readonly ILogger logger = Log.Logger;
+
+        // Single shared MulticastService instance per process. Starting
+        // and stopping the service per query would re-bind the multicast
+        // group on every NIC every time -- wasteful and also racey on
+        // Windows where the rebind can take a few hundred ms.
+        private static readonly object s_lock = new object();
+        private static MulticastService s_mdns;
+        private static bool s_startFailed;
+
+        private static MulticastService GetService()
+        {
+            if (s_mdns != null || s_startFailed) return s_mdns;
+            lock (s_lock)
+            {
+                if (s_mdns != null || s_startFailed) return s_mdns;
+                try
+                {
+                    var mdns = new MulticastService();
+                    mdns.Start();
+                    s_mdns = mdns;
+                }
+                catch (Exception ex)
+                {
+                    s_startFailed = true;
+                    logger.LogWarning(ex, "Failed to start mDNS MulticastService; .local hostname resolution will not work.");
+                }
+                return s_mdns;
+            }
+        }
+
+        /// <summary>
+        /// Send an mDNS query for the supplied hostname (typically
+        /// "&lt;guid&gt;.local") and return whatever A and AAAA answers
+        /// arrive within <see cref="DefaultTimeout"/>. Returns an empty
+        /// array on timeout.
+        /// </summary>
+        public static async Task<IPAddress[]> ResolveAsync(string hostname, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(hostname))
+            {
+                return Array.Empty<IPAddress>();
+            }
+
+            var mdns = GetService();
+            if (mdns == null)
+            {
+                return Array.Empty<IPAddress>();
+            }
+
+            var addresses = new List<IPAddress>();
+            var addressesLock = new object();
+            var answered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var trimmedHostname = hostname.TrimEnd('.');
+
+            EventHandler<MessageEventArgs> handler = (s, e) =>
+            {
+                try
+                {
+                    foreach (var rr in e.Message.Answers)
+                    {
+                        var name = rr.Name?.ToString()?.TrimEnd('.');
+                        if (!string.Equals(name, trimmedHostname, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        IPAddress addr = null;
+                        if (rr is ARecord a) addr = a.Address;
+                        else if (rr is AAAARecord aaaa) addr = aaaa.Address;
+
+                        if (addr != null)
+                        {
+                            lock (addressesLock)
+                            {
+                                if (!addresses.Contains(addr))
+                                {
+                                    addresses.Add(addr);
+                                }
+                            }
+                        }
+                    }
+
+                    lock (addressesLock)
+                    {
+                        if (addresses.Count > 0)
+                        {
+                            answered.TrySetResult(true);
+                        }
+                    }
+                }
+                catch
+                {
+                    // Swallow handler exceptions -- the timeout below is the
+                    // backstop and we don't want one bad RR to take down the
+                    // shared multicast service.
+                }
+            };
+
+            mdns.AnswerReceived += handler;
+            try
+            {
+                // Issue queries for both A and AAAA. ANY would be tidier but
+                // some peers respond only to specific types.
+                try { mdns.SendQuery(hostname, type: DnsType.A); } catch { /* socket race */ }
+                try { mdns.SendQuery(hostname, type: DnsType.AAAA); } catch { /* socket race */ }
+
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                {
+                    cts.CancelAfter(DefaultTimeout);
+                    using (cts.Token.Register(() => answered.TrySetResult(false)))
+                    {
+                        await answered.Task.ConfigureAwait(false);
+                    }
+                }
+            }
+            finally
+            {
+                mdns.AnswerReceived -= handler;
+            }
+
+            lock (addressesLock)
+            {
+                return addresses.ToArray();
+            }
+        }
+    }
+}

--- a/src/SIPSorcery/net/ICE/RtpIceChannel.cs
+++ b/src/SIPSorcery/net/ICE/RtpIceChannel.cs
@@ -2542,28 +2542,28 @@ namespace SIPSorcery.Net
             }
 
 
+            // Default fallback: do an actual mDNS query via Makaretu.Dns.Multicast.
+            // Dns.GetHostAddressesAsync delegates to the OS resolver which on Windows
+            // does not reliably handle .local lookups (depends on whether the OS-level
+            // mDNS resolver is enabled, the multicast packet round-trips through the
+            // firewall in time, etc.). Without a real mDNS query Chrome-published
+            // .local candidates almost never resolve and ICE never gets to a
+            // succeeded pair.
             IPAddress[] addresses;
             try
             {
-                addresses = await Dns.GetHostAddressesAsync(candidate.address).ConfigureAwait(false);
+                addresses = await MdnsResolver.ResolveAsync(candidate.address).ConfigureAwait(false);
             }
-            catch (SocketException e)
+            catch (Exception e)
             {
                 logger.LogError(e, "Error resolving mDNS hostname {Name}", candidate.address);
-                return Array.Empty<IPAddress>();
-            }
-            catch (ArgumentException e)
-            {
-                logger.LogError(e, "Unsupported mDNS hostname {Name}", candidate.address);
                 return Array.Empty<IPAddress>();
             }
 
             if (addresses.Length == 0)
             {
-                logger.LogWarning("RTP ICE channel has no MDNS resolver set, and the system can not resolve remote candidate with MDNS hostname {CandidateAddress}.", candidate.address);
-                // Supporting MDNS lookups means an additional nuget dependency. Hopefully
-                // support is coming to .Net Core soon (AC 12 Jun 2020).
-                OnIceCandidateError?.Invoke(candidate, $"Remote ICE candidate has an unsupported MDNS hostname {candidate.address}.");
+                logger.LogWarning("RTP ICE channel mDNS resolver returned no answers for {CandidateAddress} within the timeout.", candidate.address);
+                OnIceCandidateError?.Invoke(candidate, $"mDNS hostname {candidate.address} did not resolve within the query timeout.");
             }
             return addresses;
         }


### PR DESCRIPTION
Fixes the longstanding issue where Chrome-published `.local` ICE candidates almost never resolve on Windows, leaving WebRTC browser-vs-SIPSorcery sessions stuck in `checking` with:

```
[ERR] Error resolving mDNS hostname <guid>.local
System.Net.Sockets.SocketException (11001): No such host is known.
```

## Background

Chrome publishes ICE candidates as `<guid>.local` mDNS names by default ([privacy mitigation](https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-mdns-ice-candidates), `chrome://flags/#enable-webrtc-hide-local-ips-with-mdns`). `RtpIceChannel.ResolveMdnsName` previously fell back to `Dns.GetHostAddressesAsync`, which delegates to the OS resolver. On Windows the OS resolver does NOT reliably do mDNS — whether it works depends on the OS-level mDNS resolver (Win10 1803+) or Bonjour being enabled, the multicast packet round-tripping through the firewall in time, and which adapters are bound. The original 2020 author comment in the file (`"Hopefully support is coming to .Net Core soon"`) anticipated exactly this.

## Fix

Add `Makaretu.Dns.Multicast` 0.27.0 (a small RFC 6762 mDNS implementation over UDP/5353 multicast) and a new internal `MdnsResolver` helper that:

- Lazily starts a single shared `MulticastService` per process so the multicast-group binding doesn't churn on every query.
- Sends both an A and an AAAA query for the hostname.
- Collects answers via the `AnswerReceived` event (filtering by name, accepting both A and AAAA records).
- Returns whatever arrives within a 2 s timeout (configurable via `MdnsResolver.DefaultTimeout`); empty array on timeout.
- Logs and falls through gracefully if `MulticastService.Start()` fails (e.g. blocked by firewall) — the existing `OnIceCandidateError` event still fires for the candidate.

The user-supplied `MdnsGetAddresses` / `MdnsResolve` hooks on `RtpIceChannel` still take precedence; this only changes the no-hook fallback.

## Files

- `src/SIPSorcery/SIPSorcery.csproj` — add `Makaretu.Dns.Multicast` 0.27.0 dependency.
- `src/SIPSorcery/net/ICE/MdnsResolver.cs` — new (~190 lines) internal helper.
- `src/SIPSorcery/net/ICE/RtpIceChannel.cs` — `ResolveMdnsName` no-hook fallback now calls `MdnsResolver.ResolveAsync` instead of `Dns.GetHostAddressesAsync`.

## Compatibility

`Makaretu.Dns.Multicast` 0.27.0 supports `netstandard2.0` and `net461`, which covers all of SIPSorcery's TFMs (`netstandard2.0`, `netstandard2.1`, `netcoreapp3.1`, `net462`, `net5.0`, `net6.0`, `net8.0`, `net9.0`, `net10.0`).

## Testing

Reproduced via the WebRTCNostrSignalling demo (PR #1606): with the previous code Chrome-as-offerer fails ICE because the C# answerer can't resolve any of Chrome's `.local` candidates. With this PR applied the mDNS query succeeds and ICE proceeds to `connected`.

The sandbox couldn't fit a full SIPSorcery build alongside the SDK, so the API usage was cross-checked against [`net-mdns`'s `MulticastService.cs`](https://github.com/richardschneider/net-mdns/blob/master/src/MulticastService.cs) directly.