### PR TITLE
VideoTestPatternSource: fix event-invoke race in GenerateTestPattern (NullReferenceException)

### DIFF
--- a/src/SIPSorcery/app/Media/Sources/VideoTestPatternSource.cs
+++ b/src/SIPSorcery/app/Media/Sources/VideoTestPatternSource.cs
@@ -248,7 +248,12 @@ namespace SIPSorcery.Media
                         {
                             uint fps = (_frameSpacing > 0) ? 1000 / (uint)_frameSpacing : DEFAULT_FRAMES_PER_SECOND;
                             uint durationRtpTS = VIDEO_SAMPLING_RATE / fps;
-                            OnVideoSourceEncodedSample.Invoke(durationRtpTS, encodedBuffer);
+                            // Use ?.Invoke so the null-check and the call are
+                            // a single atomic delegate read. Without this a
+                            // subscriber unsubscribing on another thread
+                            // between the outer null-check and this Invoke
+                            // produced a NullReferenceException.
+                            OnVideoSourceEncodedSample?.Invoke(durationRtpTS, encodedBuffer);
                         }
                     }
 


### PR DESCRIPTION
## Crash

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at SIPSorcery.Media.VideoTestPatternSource.GenerateTestPattern(...)
      in VideoTestPatternSource.cs:line 251
```

Line 251 was using the unsafe two-read pattern:

```csharp
if (_videoEncoder != null
    && OnVideoSourceEncodedSample != null     // read 1
    && !_formatManager.SelectedFormat.IsEmpty())
{
    ...
    OnVideoSourceEncodedSample.Invoke(...);   // read 2
}
```

Between the outer null-check and the `.Invoke` a subscriber on another thread can unsubscribe with `-=`, leaving the field null. The next read of the field returns null and `.Invoke` throws.

## Reproducer

`examples/WebRTCExamples/WebRTCNostrSignalling` -- after the remote peer (browser) closes the connection, the example app detaches its `pc.SendVideo` handler from `OnVideoSourceEncodedSample`. If the timer thread is mid-tick between the null-check and the `Invoke`, it crashes (full stack in #1606 thread).

## Fix

Use `?.Invoke` so the null-check and the call are a single atomic delegate read. Matches the pattern already used at line 271 (`OnVideoSourceRawSample`) and in `AudioExtrasSource.cs:575` (`OnAudioSourceEncodedSample`).