### PR TITLE
VP8 encoder: pipeline-gated SIMD, pack fast path, pooled output, multi-partition tokens, benchmarks

### DIFF
--- a/.github/workflows/vp8-encoder-ci.yml
+++ b/.github/workflows/vp8-encoder-ci.yml
@@ -2,8 +2,6 @@
 # Excludes:
 # - Two tests that require System.Drawing/GDI+ to write BMP artifacts; migrate those to
 #   ImageSharp (or similar) to run the full suite here.
-# - encode_profiler_unittest: enables global EncodeProfiler during a full parallel run and can
-#   abort the test host on CI; run that class locally or in a dedicated job if needed.
 name: vp8-encoder
 
 on:
@@ -31,4 +29,4 @@ jobs:
       - name: Test
         run: |
           dotnet test test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj -c Release -f net10.0 --no-restore --verbosity normal \
-            --filter 'FullyQualifiedName!=Vpx.Net.UnitTest.VP8CodecUnitTest.DecodeKeyFrame&FullyQualifiedName!=Vpx.Net.UnitTest.vpx_decoder_unittest.DecodeKeyFrameFromFileTest&FullyQualifiedName!~Vpx.Net.UnitTest.encode_profiler_unittest'
+            --filter 'FullyQualifiedName!=Vpx.Net.UnitTest.VP8CodecUnitTest.DecodeKeyFrame&FullyQualifiedName!=Vpx.Net.UnitTest.vpx_decoder_unittest.DecodeKeyFrameFromFileTest'

--- a/.github/workflows/vp8-encoder-ci.yml
+++ b/.github/workflows/vp8-encoder-ci.yml
@@ -1,6 +1,9 @@
 # VP8 encoder + decoder unit tests on all host OS images.
-# Excludes two tests that require System.Drawing/GDI+ to write BMP artifacts; migrate those to
-# ImageSharp (or similar) to run the full suite here.
+# Excludes:
+# - Two tests that require System.Drawing/GDI+ to write BMP artifacts; migrate those to
+#   ImageSharp (or similar) to run the full suite here.
+# - encode_profiler_unittest: enables global EncodeProfiler during a full parallel run and can
+#   abort the test host on CI; run that class locally or in a dedicated job if needed.
 name: vp8-encoder
 
 on:
@@ -28,4 +31,4 @@ jobs:
       - name: Test
         run: |
           dotnet test test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj -c Release -f net10.0 --no-restore --verbosity normal \
-            --filter 'FullyQualifiedName!=Vpx.Net.UnitTest.VP8CodecUnitTest.DecodeKeyFrame&FullyQualifiedName!=Vpx.Net.UnitTest.vpx_decoder_unittest.DecodeKeyFrameFromFileTest'
+            --filter 'FullyQualifiedName!=Vpx.Net.UnitTest.VP8CodecUnitTest.DecodeKeyFrame&FullyQualifiedName!=Vpx.Net.UnitTest.vpx_decoder_unittest.DecodeKeyFrameFromFileTest&FullyQualifiedName!~Vpx.Net.UnitTest.encode_profiler_unittest'

--- a/.github/workflows/vp8-encoder-ci.yml
+++ b/.github/workflows/vp8-encoder-ci.yml
@@ -1,0 +1,31 @@
+# VP8 encoder + decoder unit tests on all host OS images.
+# Excludes two tests that require System.Drawing/GDI+ to write BMP artifacts; migrate those to
+# ImageSharp (or similar) to run the full suite here.
+name: vp8-encoder
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  vp8-unit-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Restore
+        run: dotnet restore test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj
+      - name: Test
+        run: |
+          dotnet test test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj -c Release -f net10.0 --no-restore --verbosity normal \
+            --filter 'FullyQualifiedName!=Vpx.Net.UnitTest.VP8CodecUnitTest.DecodeKeyFrame&FullyQualifiedName!=Vpx.Net.UnitTest.vpx_decoder_unittest.DecodeKeyFrameFromFileTest'

--- a/SIPSorcery.VP8.slnf
+++ b/SIPSorcery.VP8.slnf
@@ -3,7 +3,8 @@
     "path": "SIPSorcery.slnx",
     "projects": [
       "src\\SIPSorcery.VP8\\SIPSorcery.VP8.csproj",
-      "test\\SIPSorcery.VP8.UnitTest\\SIPSorcery.VP8.UnitTest.csproj"
+      "test\\SIPSorcery.VP8.UnitTest\\SIPSorcery.VP8.UnitTest.csproj",
+      "test\\SIPSorcery.VP8.Benchmarks\\SIPSorcery.VP8.Benchmarks.csproj"
     ]
   }
 }

--- a/SIPSorcery.slnx
+++ b/SIPSorcery.slnx
@@ -16,6 +16,7 @@
     <Project Path="test/SIPSorcery.OpenAI.Realtime.UnitTest/SIPSorcery.OpenAI.Realtime.UnitTests.csproj" />
     <Project Path="test/SIPSorcery.VP8.TestVectors/SIPSorcery.VP8.TestVectors.csproj" />
     <Project Path="test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj" />
+    <Project Path="test/SIPSorcery.VP8.Benchmarks/SIPSorcery.VP8.Benchmarks.csproj" />
     <Project Path="test/SIPSorceryMedia.Abstractions.UnitTest/SIPSorceryMedia.Abstractions.UnitTest.csproj" />
     <Project Path="test/unit/SIPSorcery.UnitTests.csproj" />
     <Project Path="test/VideoCaptureTest/VideoCaptureTest.csproj" />

--- a/src/SIPSorcery.VP8/DcPredSumKernels.cs
+++ b/src/SIPSorcery.VP8/DcPredSumKernels.cs
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------------------------
+// SIMD byte-sum reductions used by the encoder's DC_PRED helpers
+// (DcPred16x16 / DcPred8x8 in mb_encoder).
+//
+// Sse2: PSADBW on (v, 0) gives two int16 partial sums in lanes 0 and 4 of
+// a Vector128<ushort>; their sum equals the 16-byte sum.
+// AdvSimd: ZeroExtendWidening{Lower,Upper} + AddAcross.
+//
+// These tiny reduces (3 calls/MB) are not a major perf target but match the
+// plan's Tier 6 polish layer.
+//
+// Author: Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    internal static unsafe class DcPredSumKernels
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Sum16(byte* p)
+        {
+            if (Sse2.IsSupported)
+            {
+                var v = Sse2.LoadVector128(p);
+                var sad = Sse2.SumAbsoluteDifferences(v, Vector128<byte>.Zero);
+                return sad.GetElement(0) + sad.GetElement(4);
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                var v = AdvSimd.LoadVector128(p);
+                var lo = AdvSimd.ZeroExtendWideningLower(v.GetLower());
+                var hi = AdvSimd.ZeroExtendWideningLower(v.GetUpper());
+                var sum = AdvSimd.Add(lo, hi);
+                return AdvSimd.Arm64.AddAcross(sum).ToScalar();
+            }
+
+            int s = 0;
+            for (int i = 0; i < 16; i++) s += p[i];
+            return s;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Sum8(byte* p)
+        {
+            if (Sse2.IsSupported)
+            {
+                // Load 8 bytes into the low qword; PSADBW vs zero leaves the sum in lane 0.
+                var v = Sse2.LoadScalarVector128((long*)p).AsByte();
+                var sad = Sse2.SumAbsoluteDifferences(v, Vector128<byte>.Zero);
+                return sad.GetElement(0);
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                var v = AdvSimd.LoadVector64(p);
+                var widened = AdvSimd.ZeroExtendWideningLower(v);
+                return AdvSimd.Arm64.AddAcross(widened).ToScalar();
+            }
+
+            int s = 0;
+            for (int i = 0; i < 8; i++) s += p[i];
+            return s;
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/EncodeProfiler.cs
+++ b/src/SIPSorcery.VP8/EncodeProfiler.cs
@@ -1,0 +1,141 @@
+//-----------------------------------------------------------------------------
+// Optional high-resolution phase timers for encoder diagnostics. When
+// <see cref="Enabled"/> is true, scoped regions attribute wall-clock time
+// to broad buckets (DCT, quantize, tokenize, etc.). Zero overhead when disabled.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace Vpx.Net
+{
+    /// <summary>Encode hot-path phase buckets for <see cref="EncodeProfiler"/>.</summary>
+    public enum Vp8EncodeProfilePhase
+    {
+        SimdMemOps,
+        Fdct,
+        Walsh,
+        Quantize,
+        Tokenize,
+        Reconstruct,
+        PackTokens,
+        StitchLastFrame,
+        /// <summary>Keyframe or inter: first-partition header plus 1056 coef-update flags (before MB phase 1).</summary>
+        FirstPartitionHeader,
+        /// <summary>Per-MB scalar context shuffle (9-byte above load/store) and EOB skip checks only — does not double-count <see cref="SimdMemOps"/>.</summary>
+        Phase1MbScalarCtx,
+        /// <summary>Phase-2 bit writing in partition 0 after phase 1 (skip probs, KF/inter modes, etc.) before token partition.</summary>
+        Phase2FirstPartitionBits,
+    }
+
+    /// <summary>
+    /// Thread-local (static) encode timings. Enable around a keyed encode, then read
+    /// <see cref="GetReport"/> or individual tick fields for BenchmarkDotNet / diagnostics.
+    /// </summary>
+    public static class EncodeProfiler
+    {
+        // ThreadStatic so BenchmarkDotNet host / parallel jobs cannot corrupt a single encode's totals.
+        [ThreadStatic] private static long tSimdMemOps;
+        [ThreadStatic] private static long tFdct;
+        [ThreadStatic] private static long tWalsh;
+        [ThreadStatic] private static long tQuantize;
+        [ThreadStatic] private static long tTokenize;
+        [ThreadStatic] private static long tReconstruct;
+        [ThreadStatic] private static long tPack;
+        [ThreadStatic] private static long tStitch;
+        [ThreadStatic] private static long tFirstPartHdr;
+        [ThreadStatic] private static long tPhase1ScalarCtx;
+        [ThreadStatic] private static long tPhase2FirstPart;
+
+        /// <summary>When false (default), <see cref="Scope"/> no-ops.</summary>
+        public static bool Enabled { get; set; }
+
+        public static void Reset()
+        {
+            tSimdMemOps = tFdct = tWalsh = tQuantize = tTokenize = tReconstruct = tPack = tStitch = 0;
+            tFirstPartHdr = tPhase1ScalarCtx = tPhase2FirstPart = 0;
+        }
+
+        public readonly struct Scope : IDisposable
+        {
+            private readonly Vp8EncodeProfilePhase _phase;
+            private readonly long _t0;
+
+            public Scope(Vp8EncodeProfilePhase phase)
+            {
+                _phase = phase;
+                if (!Enabled)
+                {
+                    _t0 = 0;
+                    return;
+                }
+
+                _t0 = Stopwatch.GetTimestamp();
+            }
+
+            public void Dispose()
+            {
+                if (_t0 == 0) return;
+                long dt = Stopwatch.GetTimestamp() - _t0;
+                Add(_phase, dt);
+            }
+        }
+
+        private static void Add(Vp8EncodeProfilePhase phase, long ticks)
+        {
+            switch (phase)
+            {
+                case Vp8EncodeProfilePhase.SimdMemOps: tSimdMemOps += ticks; break;
+                case Vp8EncodeProfilePhase.Fdct: tFdct += ticks; break;
+                case Vp8EncodeProfilePhase.Walsh: tWalsh += ticks; break;
+                case Vp8EncodeProfilePhase.Quantize: tQuantize += ticks; break;
+                case Vp8EncodeProfilePhase.Tokenize: tTokenize += ticks; break;
+                case Vp8EncodeProfilePhase.Reconstruct: tReconstruct += ticks; break;
+                case Vp8EncodeProfilePhase.PackTokens: tPack += ticks; break;
+                case Vp8EncodeProfilePhase.StitchLastFrame: tStitch += ticks; break;
+                case Vp8EncodeProfilePhase.FirstPartitionHeader: tFirstPartHdr += ticks; break;
+                case Vp8EncodeProfilePhase.Phase1MbScalarCtx: tPhase1ScalarCtx += ticks; break;
+                case Vp8EncodeProfilePhase.Phase2FirstPartitionBits: tPhase2FirstPart += ticks; break;
+            }
+        }
+
+        /// <summary>Sum of all profiled bucket ticks (current thread). Nested MB work can make this exceed wall-clock.</summary>
+        public static long GetScopedTotalTicks() =>
+            tSimdMemOps + tFdct + tWalsh + tQuantize + tTokenize + tReconstruct + tPack + tStitch
+            + tFirstPartHdr + tPhase1ScalarCtx + tPhase2FirstPart;
+
+        /// <summary>One-line wall-clock vs scoped-sum (scoped may exceed wall when buckets overlap, e.g. SimdMemOps inside other work).</summary>
+        public static string FormatWallClockCompare(double wallMilliseconds)
+        {
+            double scopedMs = GetScopedTotalTicks() * 1000.0 / Stopwatch.Frequency;
+            return $"Wall-clock: {wallMilliseconds:F3} ms | Scoped sum: {scopedMs:F3} ms | Delta: {wallMilliseconds - scopedMs:F3} ms (negative => overlapping scopes or unscoped work)";
+        }
+
+        /// <summary>Human-readable breakdown; ticks are Stopwatch raw units (current thread only).</summary>
+        public static string GetReport()
+        {
+            long total = GetScopedTotalTicks();
+            double ToMs(long t) => t * 1000.0 / Stopwatch.Frequency;
+            var sb = new StringBuilder(384);
+            sb.AppendLine($"Vp8EncodeProfiler (scoped sum {ToMs(total):F3} ms — sum of buckets; can exceed wall if scopes overlap)");
+            void Line(string name, long t)
+            {
+                if (total <= 0) sb.AppendLine($"  {name,-22} {ToMs(t):F3} ms");
+                else sb.AppendLine($"  {name,-22} {ToMs(t):F3} ms  ({100.0 * t / total:F1}%)");
+            }
+            Line("FirstPartitionHeader", tFirstPartHdr);
+            Line("Phase1MbScalarCtx", tPhase1ScalarCtx);
+            Line("Phase2FirstPartitionBits", tPhase2FirstPart);
+            Line("SimdMemOps", tSimdMemOps);
+            Line("Fdct", tFdct);
+            Line("Walsh", tWalsh);
+            Line("Quantize", tQuantize);
+            Line("Tokenize", tTokenize);
+            Line("Reconstruct", tReconstruct);
+            Line("PackTokens", tPack);
+            Line("StitchLastFrame", tStitch);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/EncodeProfiler.cs
+++ b/src/SIPSorcery.VP8/EncodeProfiler.cs
@@ -48,8 +48,16 @@ namespace Vpx.Net
         [ThreadStatic] private static long tPhase1ScalarCtx;
         [ThreadStatic] private static long tPhase2FirstPart;
 
-        /// <summary>When false (default), <see cref="Scope"/> no-ops.</summary>
-        public static bool Enabled { get; set; }
+        [ThreadStatic] private static bool tEnabled;
+
+        /// <summary>When false (default), <see cref="Scope"/> no-ops on this thread.</summary>
+        /// <remarks>Thread-local so parallel unit tests (or parallel encodes) do not inherit
+        /// profiling from another thread.</remarks>
+        public static bool Enabled
+        {
+            get => tEnabled;
+            set => tEnabled = value;
+        }
 
         public static void Reset()
         {

--- a/src/SIPSorcery.VP8/EncoderMemoryOps.cs
+++ b/src/SIPSorcery.VP8/EncoderMemoryOps.cs
@@ -1,0 +1,121 @@
+//-----------------------------------------------------------------------------
+// Pluggable copy / residual helpers for the VP8 frame encoder. Two
+// implementations (legacy nested loops vs span + SIMD) are swapped via
+// IVp8FrameEncodePipeline — no per-MB feature flags.
+//-----------------------------------------------------------------------------
+
+using System;
+
+namespace Vpx.Net
+{
+    internal interface IEncoderMemoryOps
+    {
+        /// <summary>
+        /// Pipeline-level capability flag. When false (Legacy pipeline),
+        /// every SIMD encoder kernel dispatcher in mb_encoder.cs falls
+        /// back to the scalar reference (fdct/idct/walsh/quantize/dcpred)
+        /// regardless of whether the host CPU supports the SIMD path.
+        /// When true (Optimized pipeline) the SIMD modules are used when
+        /// their CPU-feature gate is also satisfied.
+        /// </summary>
+        bool UseSimdEncoderKernels { get; }
+
+        void CopyPlaneRect(byte[] src, int baseOffset, int srcStride, int x, int y, int w, int h, byte[] dst);
+
+        void CopyRowAt(byte[] src, int offset, int count, byte[] dst);
+
+        void CopyColumn(byte[] src, int srcStride, int columnIndex, int firstRow, int rows, byte[] dst);
+
+        void CopyRowFrom2d(byte[] src, int srcStride, int srcRow, int srcCol, byte[] dst, int dstOffset, int count);
+
+        void SubtractFlat(byte[] src, byte pred, short[] dst);
+
+        void SubtractPerPixel(byte[] src, byte[] pred, short[] dst);
+    }
+
+    internal sealed class LegacyEncoderMemoryOps : IEncoderMemoryOps
+    {
+        public static readonly LegacyEncoderMemoryOps Instance = new LegacyEncoderMemoryOps();
+
+        private LegacyEncoderMemoryOps() { }
+
+        public bool UseSimdEncoderKernels => false;
+
+        public void CopyPlaneRect(byte[] src, int baseOffset, int srcStride, int x, int y, int w, int h, byte[] dst)
+        {
+            for (int r = 0; r < h; r++)
+            for (int c = 0; c < w; c++)
+                dst[r * w + c] = src[baseOffset + (y + r) * srcStride + (x + c)];
+        }
+
+        public void CopyRowAt(byte[] src, int offset, int count, byte[] dst)
+        {
+            for (int i = 0; i < count; i++) dst[i] = src[offset + i];
+        }
+
+        public void CopyColumn(byte[] src, int srcStride, int columnIndex, int firstRow, int rows, byte[] dst)
+        {
+            for (int r = 0; r < rows; r++) dst[r] = src[(firstRow + r) * srcStride + columnIndex];
+        }
+
+        public void CopyRowFrom2d(byte[] src, int srcStride, int srcRow, int srcCol, byte[] dst, int dstOffset, int count)
+        {
+            for (int i = 0; i < count; i++) dst[dstOffset + i] = src[srcRow * srcStride + srcCol + i];
+        }
+
+        public void SubtractFlat(byte[] src, byte pred, short[] dst)
+        {
+            for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred);
+        }
+
+        public void SubtractPerPixel(byte[] src, byte[] pred, short[] dst)
+        {
+            for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred[i]);
+        }
+    }
+
+    internal sealed class SpanSimdEncoderMemoryOps : IEncoderMemoryOps
+    {
+        public static readonly SpanSimdEncoderMemoryOps Instance = new SpanSimdEncoderMemoryOps();
+
+        private SpanSimdEncoderMemoryOps() { }
+
+        public bool UseSimdEncoderKernels => true;
+
+        public void CopyPlaneRect(byte[] src, int baseOffset, int srcStride, int x, int y, int w, int h, byte[] dst)
+        {
+            using var _ = new EncodeProfiler.Scope(Vp8EncodeProfilePhase.SimdMemOps);
+            EncoderSimdKernels.CopyPlaneRectSpan(src, baseOffset, srcStride, x, y, w, h, dst);
+        }
+
+        public void CopyRowAt(byte[] src, int offset, int count, byte[] dst)
+        {
+            using var _ = new EncodeProfiler.Scope(Vp8EncodeProfilePhase.SimdMemOps);
+            EncoderSimdKernels.CopySpan(src, offset, dst, 0, count);
+        }
+
+        public void CopyColumn(byte[] src, int srcStride, int columnIndex, int firstRow, int rows, byte[] dst)
+        {
+            using var _ = new EncodeProfiler.Scope(Vp8EncodeProfilePhase.SimdMemOps);
+            EncoderSimdKernels.CopyColumn(src, srcStride, columnIndex, firstRow, rows, dst);
+        }
+
+        public void CopyRowFrom2d(byte[] src, int srcStride, int srcRow, int srcCol, byte[] dst, int dstOffset, int count)
+        {
+            using var _ = new EncodeProfiler.Scope(Vp8EncodeProfilePhase.SimdMemOps);
+            EncoderSimdKernels.CopySpan(src, srcRow * srcStride + srcCol, dst, dstOffset, count);
+        }
+
+        public void SubtractFlat(byte[] src, byte pred, short[] dst)
+        {
+            using var _ = new EncodeProfiler.Scope(Vp8EncodeProfilePhase.SimdMemOps);
+            EncoderSimdKernels.SubtractFlatToShort(src, pred, dst);
+        }
+
+        public void SubtractPerPixel(byte[] src, byte[] pred, short[] dst)
+        {
+            using var _ = new EncodeProfiler.Scope(Vp8EncodeProfilePhase.SimdMemOps);
+            EncoderSimdKernels.SubtractPerPixelToShort(src, pred, dst);
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/EncoderSimdKernels.cs
+++ b/src/SIPSorcery.VP8/EncoderSimdKernels.cs
@@ -1,0 +1,191 @@
+//-----------------------------------------------------------------------------
+// Span-based block copies and SIMD byte→short residual kernels for the
+// optimized VP8 encoder path. Bit-identical to scalar (src[i]-pred[i]):
+// x86/x64: AVX2 (256-bit load + dual SSE2 widen/sub) then SSE2; ARM: AdvSimd;
+// otherwise scalar.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    internal static class EncoderSimdKernels
+    {
+        public static void CopyPlaneRectSpan(byte[] src, int baseOffset, int srcStride, int x, int y, int w, int h, byte[] dst)
+        {
+            for (int r = 0; r < h; r++)
+            {
+                int rowStart = baseOffset + (y + r) * srcStride + x;
+                src.AsSpan(rowStart, w).CopyTo(dst.AsSpan(r * w, w));
+            }
+        }
+
+        public static void CopySpan(byte[] src, int srcOffset, byte[] dst, int dstOffset, int count)
+        {
+            src.AsSpan(srcOffset, count).CopyTo(dst.AsSpan(dstOffset, count));
+        }
+
+        public static void CopyColumn(byte[] src, int srcStride, int columnIndex, int firstRow, int rows, byte[] dst)
+        {
+            for (int r = 0; r < rows; r++)
+                dst[r] = src[(firstRow + r) * srcStride + columnIndex];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SubtractFlatSse2Widen16(Vector128<byte> b, Vector128<byte> pLo, Vector128<byte> pHi, ref short dr)
+        {
+            var z = Vector128<byte>.Zero;
+            var lo = Sse2.UnpackLow(b, z);
+            var hi = Sse2.UnpackHigh(b, z);
+            var dLo = Sse2.Subtract(lo, pLo);
+            var dHi = Sse2.Subtract(hi, pHi);
+            Vector128.StoreUnsafe(dLo.AsInt16(), ref dr);
+            Vector128.StoreUnsafe(dHi.AsInt16(), ref Unsafe.Add(ref dr, 8));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SubtractPerPixelSse2Widen16(Vector128<byte> a, Vector128<byte> b, Vector128<byte> z, ref short dr)
+        {
+            var aLo = Sse2.UnpackLow(a, z);
+            var aHi = Sse2.UnpackHigh(a, z);
+            var bLo = Sse2.UnpackLow(b, z);
+            var bHi = Sse2.UnpackHigh(b, z);
+            var dLo = Sse2.Subtract(aLo, bLo);
+            var dHi = Sse2.Subtract(aHi, bHi);
+            Vector128.StoreUnsafe(dLo.AsInt16(), ref dr);
+            Vector128.StoreUnsafe(dHi.AsInt16(), ref Unsafe.Add(ref dr, 8));
+        }
+
+        public static void SubtractFlatToShort(byte[] src, byte pred, short[] dst)
+        {
+            int n = src.Length;
+            int i = 0;
+            if (Avx2.IsSupported)
+            {
+                var predWide = Vector128.Create(pred);
+                var z128 = Vector128<byte>.Zero;
+                var pLo = Sse2.UnpackLow(predWide, z128);
+                var pHi = Sse2.UnpackHigh(predWide, z128);
+                for (; i + 32 <= n; i += 32)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    var v32 = Vector256.LoadUnsafe(ref sr);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    SubtractFlatSse2Widen16(v32.GetLower(), pLo, pHi, ref dr);
+                    SubtractFlatSse2Widen16(v32.GetUpper(), pLo, pHi, ref Unsafe.Add(ref dr, 16));
+                }
+                for (; i + 16 <= n; i += 16)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    var b = Vector128.LoadUnsafe(ref sr);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    SubtractFlatSse2Widen16(b, pLo, pHi, ref dr);
+                }
+            }
+            else if (Sse2.IsSupported)
+            {
+                var predWide = Vector128.Create(pred);
+                var z = Vector128<byte>.Zero;
+                var pLo = Sse2.UnpackLow(predWide, z);
+                var pHi = Sse2.UnpackHigh(predWide, z);
+                for (; i + 16 <= n; i += 16)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    var b = Vector128.LoadUnsafe(ref sr);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    SubtractFlatSse2Widen16(b, pLo, pHi, ref dr);
+                }
+            }
+            else if (AdvSimd.IsSupported)
+            {
+                var predS = Vector128.Create((short)pred);
+                for (; i + 16 <= n; i += 16)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    var bytes = Vector128.LoadUnsafe(ref sr);
+                    var uLo = AdvSimd.ZeroExtendWideningLower(bytes.GetLower());
+                    var uHi = AdvSimd.ZeroExtendWideningUpper(bytes);
+                    var sLo = uLo.AsInt16();
+                    var sHi = uHi.AsInt16();
+                    var dLo = AdvSimd.Subtract(sLo, predS);
+                    var dHi = AdvSimd.Subtract(sHi, predS);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    Vector128.StoreUnsafe(dLo, ref dr);
+                    Vector128.StoreUnsafe(dHi, ref Unsafe.Add(ref dr, 8));
+                }
+            }
+
+            for (; i < n; i++)
+                dst[i] = (short)(src[i] - pred);
+        }
+
+        public static void SubtractPerPixelToShort(byte[] src, byte[] pred, short[] dst)
+        {
+            int n = src.Length;
+            int i = 0;
+            if (Avx2.IsSupported)
+            {
+                var z = Vector128<byte>.Zero;
+                for (; i + 32 <= n; i += 32)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    ref byte pr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(pred), i);
+                    var a32 = Vector256.LoadUnsafe(ref sr);
+                    var b32 = Vector256.LoadUnsafe(ref pr);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    SubtractPerPixelSse2Widen16(a32.GetLower(), b32.GetLower(), z, ref dr);
+                    SubtractPerPixelSse2Widen16(a32.GetUpper(), b32.GetUpper(), z, ref Unsafe.Add(ref dr, 16));
+                }
+                for (; i + 16 <= n; i += 16)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    ref byte pr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(pred), i);
+                    var a = Vector128.LoadUnsafe(ref sr);
+                    var b = Vector128.LoadUnsafe(ref pr);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    SubtractPerPixelSse2Widen16(a, b, z, ref dr);
+                }
+            }
+            else if (Sse2.IsSupported)
+            {
+                var z = Vector128<byte>.Zero;
+                for (; i + 16 <= n; i += 16)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    ref byte pr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(pred), i);
+                    var a = Vector128.LoadUnsafe(ref sr);
+                    var b = Vector128.LoadUnsafe(ref pr);
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    SubtractPerPixelSse2Widen16(a, b, z, ref dr);
+                }
+            }
+            else if (AdvSimd.IsSupported)
+            {
+                for (; i + 16 <= n; i += 16)
+                {
+                    ref byte sr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), i);
+                    ref byte pr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(pred), i);
+                    var va = Vector128.LoadUnsafe(ref sr);
+                    var vb = Vector128.LoadUnsafe(ref pr);
+                    var uALo = AdvSimd.ZeroExtendWideningLower(va.GetLower());
+                    var uAHi = AdvSimd.ZeroExtendWideningUpper(va);
+                    var uBLo = AdvSimd.ZeroExtendWideningLower(vb.GetLower());
+                    var uBHi = AdvSimd.ZeroExtendWideningUpper(vb);
+                    var dLo = AdvSimd.Subtract(uALo.AsInt16(), uBLo.AsInt16());
+                    var dHi = AdvSimd.Subtract(uAHi.AsInt16(), uBHi.AsInt16());
+                    ref short dr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(dst), i);
+                    Vector128.StoreUnsafe(dLo, ref dr);
+                    Vector128.StoreUnsafe(dHi, ref Unsafe.Add(ref dr, 8));
+                }
+            }
+
+            for (; i < n; i++)
+                dst[i] = (short)(src[i] - pred[i]);
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/FdctEncoderSimd.cs
+++ b/src/SIPSorcery.VP8/FdctEncoderSimd.cs
@@ -1,0 +1,514 @@
+//-----------------------------------------------------------------------------
+// Filename: FdctEncoderSimd.cs
+//
+// Description: Encoder-only SIMD implementations of the VP8 4x4 and batched
+// 8x4 forward DCT. These are bit-exact with the scalar reference in dct.cs
+// (vp8_short_fdct4x4_c) and are dispatched from the Optimized pipeline only;
+// the Legacy pipeline must continue to call dct.vp8_short_fdct4x4_c which
+// remains a pure scalar implementation.
+//
+// SIMD: x86 SSE4.1 path (true 4-way 4x4 fdct with two-stage in-register
+// transposes; 8x4 form processes both 4x4 halves of an 8x4 strip in one
+// shot using the full 128-bit width). ARM AdvSimd path mirrors the same
+// shape using Zip/Unzip primitives. Sse41 is used for PMULLD; Sse2-only
+// hosts fall back to scalar.
+//
+// Numeric assumption: int16 inputs/outputs throughout; intermediate
+// q-pair sums and differences are widened to int32 to keep parity with
+// the scalar reference for residual magnitudes near 512.
+//
+// Author(s):
+// Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
+//
+// History:
+// 05 May 2026  Claude          Extracted from dct.cs so the scalar reference
+//                              is unconditionally used by the Legacy pipeline.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    internal static unsafe class FdctEncoderSimd
+    {
+        /// <summary>True when a SIMD FDCT path is available on the current host.
+        /// Sse41 is required because the column pass uses PMULLD via
+        /// <see cref="Sse41.MultiplyLow(Vector128{int}, Vector128{int})"/>.</summary>
+        public static bool IsSupported => Sse41.IsSupported || AdvSimd.Arm64.IsSupported;
+
+        /// <summary>SIMD 4x4 forward DCT. Bit-exact with
+        /// <see cref="dct.vp8_short_fdct4x4_c"/>. Falls back to the scalar
+        /// reference when no SIMD path is available.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Fdct4x4(short* input, short* output, int pitch)
+        {
+            if (Sse41.IsSupported)
+            {
+                Fdct4x4Sse2(input, output, pitch);
+                return;
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                Fdct4x4AdvSimd(input, output, pitch);
+                return;
+            }
+
+            dct.vp8_short_fdct4x4_c(input, output, pitch);
+        }
+
+        /// <summary>SIMD batched 8x4 forward DCT. Writes the LEFT 4x4
+        /// (columns 0..3) into <paramref name="outLeft"/> (16 shorts) and the
+        /// RIGHT 4x4 (columns 4..7) into <paramref name="outRight"/> (16
+        /// shorts). Bit-exact with two side-by-side
+        /// <see cref="dct.vp8_short_fdct4x4_c"/> calls.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Fdct8x4Split(short* input, short* outLeft, short* outRight, int pitch)
+        {
+            if (Sse41.IsSupported)
+            {
+                Fdct8x4Sse2(input, outLeft, outRight, pitch);
+                return;
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                Fdct8x4AdvSimd(input, outLeft, outRight, pitch);
+                return;
+            }
+
+            dct.vp8_short_fdct4x4_c(input, outLeft, pitch);
+            dct.vp8_short_fdct4x4_c(input + 4, outRight, pitch);
+        }
+
+        // ---------------------------------------------------------------------
+        // SSE2/SSE4.1 - true 4-way 4x4 fdct
+        // ---------------------------------------------------------------------
+
+        /// <summary>SSE2/SSE4.1 4x4 forward DCT. Loads four rows, transposes,
+        /// does the row-pass arithmetic with all four rows in parallel (lo 4
+        /// lanes used), transposes again, runs the column pass in parallel,
+        /// then writes the row-major 16-short output.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Fdct4x4Sse2(short* input, short* output, int pitch)
+        {
+            int stride = pitch / 2;
+
+            var r0 = Sse2.LoadScalarVector128((double*)(input + 0 * stride)).AsInt16();
+            var r1 = Sse2.LoadScalarVector128((double*)(input + 1 * stride)).AsInt16();
+            var r2 = Sse2.LoadScalarVector128((double*)(input + 2 * stride)).AsInt16();
+            var r3 = Sse2.LoadScalarVector128((double*)(input + 3 * stride)).AsInt16();
+
+            r0 = Sse2.ShiftLeftLogical(r0, 3);
+            r1 = Sse2.ShiftLeftLogical(r1, 3);
+            r2 = Sse2.ShiftLeftLogical(r2, 3);
+            r3 = Sse2.ShiftLeftLogical(r3, 3);
+
+            var ab = Sse2.UnpackLow(r0, r1);
+            var cd = Sse2.UnpackLow(r2, r3);
+            var c01 = Sse2.UnpackLow(ab.AsInt32(), cd.AsInt32()).AsInt16();
+            var c23 = Sse2.UnpackHigh(ab.AsInt32(), cd.AsInt32()).AsInt16();
+
+            var c0 = c01;
+            var c1v = Sse2.UnpackHigh(c01.AsInt64(), Vector128<long>.Zero).AsInt16();
+            var c2 = c23;
+            var c3v = Sse2.UnpackHigh(c23.AsInt64(), Vector128<long>.Zero).AsInt16();
+
+            var a1 = Sse2.Add(c0, c3v);
+            var b1 = Sse2.Add(c1v, c2);
+            var c1d = Sse2.Subtract(c1v, c2);
+            var d1 = Sse2.Subtract(c0, c3v);
+
+            var res0 = Sse2.Add(a1, b1);
+            var res2 = Sse2.Subtract(a1, b1);
+
+            var cdInter = Sse2.UnpackLow(c1d, d1);
+            var k_2217_5352 = Vector128.Create((short)2217, 5352, 2217, 5352, 2217, 5352, 2217, 5352);
+            var k_neg5352_2217 = Vector128.Create((short)-5352, 2217, -5352, 2217, -5352, 2217, -5352, 2217);
+
+            var res1Int = Sse2.MultiplyAddAdjacent(cdInter, k_2217_5352);
+            res1Int = Sse2.Add(res1Int, Vector128.Create(14500));
+            res1Int = Sse2.ShiftRightArithmetic(res1Int, 12);
+
+            var res3Int = Sse2.MultiplyAddAdjacent(cdInter, k_neg5352_2217);
+            res3Int = Sse2.Add(res3Int, Vector128.Create(7500));
+            res3Int = Sse2.ShiftRightArithmetic(res3Int, 12);
+
+            var packed13 = Sse2.PackSignedSaturate(res1Int, res3Int);
+            var res1 = packed13;
+            var res3 = Sse2.UnpackHigh(packed13.AsInt64(), Vector128<long>.Zero).AsInt16();
+
+            var ab2 = Sse2.UnpackLow(res0, res1);
+            var cd2 = Sse2.UnpackLow(res2, res3);
+            var q01 = Sse2.UnpackLow(ab2.AsInt32(), cd2.AsInt32()).AsInt16();
+            var q23 = Sse2.UnpackHigh(ab2.AsInt32(), cd2.AsInt32()).AsInt16();
+
+            // q-pair sums/differences can exceed int16 when |residual| ≈ 512;
+            // widen to int32 to keep bit-exactness with the scalar reference.
+            var q0 = Sse2.ShiftRightArithmetic(Sse2.UnpackLow(q01, q01).AsInt32(), 16);
+            var q1 = Sse2.ShiftRightArithmetic(Sse2.UnpackHigh(q01, q01).AsInt32(), 16);
+            var q2 = Sse2.ShiftRightArithmetic(Sse2.UnpackLow(q23, q23).AsInt32(), 16);
+            var q3 = Sse2.ShiftRightArithmetic(Sse2.UnpackHigh(q23, q23).AsInt32(), 16);
+
+            var a1c = Sse2.Add(q0, q3);
+            var b1c = Sse2.Add(q1, q2);
+            var c1c = Sse2.Subtract(q1, q2);
+            var d1c = Sse2.Subtract(q0, q3);
+
+            var sevenI32 = Vector128.Create(7);
+            var f0Int = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Add(a1c, b1c), sevenI32), 4);
+            var f2Int = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Subtract(a1c, b1c), sevenI32), 4);
+
+            var k2217i = Vector128.Create(2217);
+            var k5352i = Vector128.Create(5352);
+
+            var f1Int = Sse2.Add(Sse41.MultiplyLow(c1c, k2217i), Sse41.MultiplyLow(d1c, k5352i));
+            f1Int = Sse2.ShiftRightArithmetic(Sse2.Add(f1Int, Vector128.Create(12000)), 16);
+            var d1cZero = Sse2.CompareEqual(d1c, Vector128<int>.Zero);
+            f1Int = Sse2.Add(f1Int, Sse2.AndNot(d1cZero, Vector128.Create(1)));
+
+            var f3Int = Sse2.Subtract(Sse41.MultiplyLow(d1c, k2217i), Sse41.MultiplyLow(c1c, k5352i));
+            f3Int = Sse2.ShiftRightArithmetic(Sse2.Add(f3Int, Vector128.Create(51000)), 16);
+
+            // Output values fit in int16 by construction; saturation is a no-op.
+            Sse2.Store(output + 0, Sse2.PackSignedSaturate(f0Int, f1Int));
+            Sse2.Store(output + 8, Sse2.PackSignedSaturate(f2Int, f3Int));
+        }
+
+        /// <summary>SSE2/SSE4.1 batched 8x4 forward DCT - processes the LEFT
+        /// and RIGHT 4x4 sub-blocks of an 8x4 input strip in one shot, using
+        /// all 8 lanes of each Vector128.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Fdct8x4Sse2(short* input, short* outLeft, short* outRight, int pitch)
+        {
+            int stride = pitch / 2;
+
+            var r0 = Sse2.LoadVector128(input + 0 * stride);
+            var r1 = Sse2.LoadVector128(input + 1 * stride);
+            var r2 = Sse2.LoadVector128(input + 2 * stride);
+            var r3 = Sse2.LoadVector128(input + 3 * stride);
+
+            r0 = Sse2.ShiftLeftLogical(r0, 3);
+            r1 = Sse2.ShiftLeftLogical(r1, 3);
+            r2 = Sse2.ShiftLeftLogical(r2, 3);
+            r3 = Sse2.ShiftLeftLogical(r3, 3);
+
+            var abL = Sse2.UnpackLow(r0, r1);
+            var abR = Sse2.UnpackHigh(r0, r1);
+            var cdL = Sse2.UnpackLow(r2, r3);
+            var cdR = Sse2.UnpackHigh(r2, r3);
+            var lL01 = Sse2.UnpackLow(abL.AsInt32(), cdL.AsInt32()).AsInt16();
+            var lL23 = Sse2.UnpackHigh(abL.AsInt32(), cdL.AsInt32()).AsInt16();
+            var lR01 = Sse2.UnpackLow(abR.AsInt32(), cdR.AsInt32()).AsInt16();
+            var lR23 = Sse2.UnpackHigh(abR.AsInt32(), cdR.AsInt32()).AsInt16();
+            var c0 = Sse2.UnpackLow(lL01.AsInt64(), lR01.AsInt64()).AsInt16();
+            var c1 = Sse2.UnpackHigh(lL01.AsInt64(), lR01.AsInt64()).AsInt16();
+            var c2 = Sse2.UnpackLow(lL23.AsInt64(), lR23.AsInt64()).AsInt16();
+            var c3 = Sse2.UnpackHigh(lL23.AsInt64(), lR23.AsInt64()).AsInt16();
+
+            var a1 = Sse2.Add(c0, c3);
+            var b1 = Sse2.Add(c1, c2);
+            var c1d = Sse2.Subtract(c1, c2);
+            var d1 = Sse2.Subtract(c0, c3);
+
+            var res0 = Sse2.Add(a1, b1);
+            var res2 = Sse2.Subtract(a1, b1);
+
+            var k_2217_5352 = Vector128.Create((short)2217, 5352, 2217, 5352, 2217, 5352, 2217, 5352);
+            var k_neg5352_2217 = Vector128.Create((short)-5352, 2217, -5352, 2217, -5352, 2217, -5352, 2217);
+
+            var cdLo = Sse2.UnpackLow(c1d, d1);
+            var cdHi = Sse2.UnpackHigh(c1d, d1);
+
+            var res1Lo = Sse2.MultiplyAddAdjacent(cdLo, k_2217_5352);
+            var res1Hi = Sse2.MultiplyAddAdjacent(cdHi, k_2217_5352);
+            var c14500 = Vector128.Create(14500);
+            res1Lo = Sse2.ShiftRightArithmetic(Sse2.Add(res1Lo, c14500), 12);
+            res1Hi = Sse2.ShiftRightArithmetic(Sse2.Add(res1Hi, c14500), 12);
+
+            var res3Lo = Sse2.MultiplyAddAdjacent(cdLo, k_neg5352_2217);
+            var res3Hi = Sse2.MultiplyAddAdjacent(cdHi, k_neg5352_2217);
+            var c7500 = Vector128.Create(7500);
+            res3Lo = Sse2.ShiftRightArithmetic(Sse2.Add(res3Lo, c7500), 12);
+            res3Hi = Sse2.ShiftRightArithmetic(Sse2.Add(res3Hi, c7500), 12);
+
+            var res1 = Sse2.PackSignedSaturate(res1Lo, res1Hi);
+            var res3 = Sse2.PackSignedSaturate(res3Lo, res3Hi);
+
+            var u01L = Sse2.UnpackLow(res0, res1);
+            var u01R = Sse2.UnpackHigh(res0, res1);
+            var u23L = Sse2.UnpackLow(res2, res3);
+            var u23R = Sse2.UnpackHigh(res2, res3);
+            var qLL01 = Sse2.UnpackLow(u01L.AsInt32(), u23L.AsInt32()).AsInt16();
+            var qLL23 = Sse2.UnpackHigh(u01L.AsInt32(), u23L.AsInt32()).AsInt16();
+            var qLR01 = Sse2.UnpackLow(u01R.AsInt32(), u23R.AsInt32()).AsInt16();
+            var qLR23 = Sse2.UnpackHigh(u01R.AsInt32(), u23R.AsInt32()).AsInt16();
+            var q0 = Sse2.UnpackLow(qLL01.AsInt64(), qLR01.AsInt64()).AsInt16();
+            var q1 = Sse2.UnpackHigh(qLL01.AsInt64(), qLR01.AsInt64()).AsInt16();
+            var q2 = Sse2.UnpackLow(qLL23.AsInt64(), qLR23.AsInt64()).AsInt16();
+            var q3 = Sse2.UnpackHigh(qLL23.AsInt64(), qLR23.AsInt64()).AsInt16();
+
+            var q0Lo = Sse2.ShiftRightArithmetic(Sse2.UnpackLow(q0, q0).AsInt32(), 16);
+            var q0Hi = Sse2.ShiftRightArithmetic(Sse2.UnpackHigh(q0, q0).AsInt32(), 16);
+            var q1Lo = Sse2.ShiftRightArithmetic(Sse2.UnpackLow(q1, q1).AsInt32(), 16);
+            var q1Hi = Sse2.ShiftRightArithmetic(Sse2.UnpackHigh(q1, q1).AsInt32(), 16);
+            var q2Lo = Sse2.ShiftRightArithmetic(Sse2.UnpackLow(q2, q2).AsInt32(), 16);
+            var q2Hi = Sse2.ShiftRightArithmetic(Sse2.UnpackHigh(q2, q2).AsInt32(), 16);
+            var q3Lo = Sse2.ShiftRightArithmetic(Sse2.UnpackLow(q3, q3).AsInt32(), 16);
+            var q3Hi = Sse2.ShiftRightArithmetic(Sse2.UnpackHigh(q3, q3).AsInt32(), 16);
+
+            var k2217i = Vector128.Create(2217);
+            var k5352i = Vector128.Create(5352);
+            var sevenI32 = Vector128.Create(7);
+            var c12000 = Vector128.Create(12000);
+            var c51000 = Vector128.Create(51000);
+            var one = Vector128.Create(1);
+
+            var a1cL = Sse2.Add(q0Lo, q3Lo);
+            var b1cL = Sse2.Add(q1Lo, q2Lo);
+            var c1cL = Sse2.Subtract(q1Lo, q2Lo);
+            var d1cL = Sse2.Subtract(q0Lo, q3Lo);
+            var f0L = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Add(a1cL, b1cL), sevenI32), 4);
+            var f2L = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Subtract(a1cL, b1cL), sevenI32), 4);
+            var f1L = Sse2.Add(Sse41.MultiplyLow(c1cL, k2217i), Sse41.MultiplyLow(d1cL, k5352i));
+            f1L = Sse2.ShiftRightArithmetic(Sse2.Add(f1L, c12000), 16);
+            f1L = Sse2.Add(f1L, Sse2.AndNot(Sse2.CompareEqual(d1cL, Vector128<int>.Zero), one));
+            var f3L = Sse2.Subtract(Sse41.MultiplyLow(d1cL, k2217i), Sse41.MultiplyLow(c1cL, k5352i));
+            f3L = Sse2.ShiftRightArithmetic(Sse2.Add(f3L, c51000), 16);
+
+            var a1cR = Sse2.Add(q0Hi, q3Hi);
+            var b1cR = Sse2.Add(q1Hi, q2Hi);
+            var c1cR = Sse2.Subtract(q1Hi, q2Hi);
+            var d1cR = Sse2.Subtract(q0Hi, q3Hi);
+            var f0R = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Add(a1cR, b1cR), sevenI32), 4);
+            var f2R = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Subtract(a1cR, b1cR), sevenI32), 4);
+            var f1R = Sse2.Add(Sse41.MultiplyLow(c1cR, k2217i), Sse41.MultiplyLow(d1cR, k5352i));
+            f1R = Sse2.ShiftRightArithmetic(Sse2.Add(f1R, c12000), 16);
+            f1R = Sse2.Add(f1R, Sse2.AndNot(Sse2.CompareEqual(d1cR, Vector128<int>.Zero), one));
+            var f3R = Sse2.Subtract(Sse41.MultiplyLow(d1cR, k2217i), Sse41.MultiplyLow(c1cR, k5352i));
+            f3R = Sse2.ShiftRightArithmetic(Sse2.Add(f3R, c51000), 16);
+
+            Sse2.Store(outLeft + 0, Sse2.PackSignedSaturate(f0L, f1L));
+            Sse2.Store(outLeft + 8, Sse2.PackSignedSaturate(f2L, f3L));
+            Sse2.Store(outRight + 0, Sse2.PackSignedSaturate(f0R, f1R));
+            Sse2.Store(outRight + 8, Sse2.PackSignedSaturate(f2R, f3R));
+        }
+
+        // ---------------------------------------------------------------------
+        // ARM AdvSimd - true 4-way 4x4 fdct
+        // ---------------------------------------------------------------------
+
+        /// <summary>AdvSimd 4x4 forward DCT mirroring <see cref="Fdct4x4Sse2"/>.
+        /// Uses Zip primitives for the int16 transposes and widening multiplies
+        /// for the (c*2217 + d*5352) terms.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Fdct4x4AdvSimd(short* input, short* output, int pitch)
+        {
+            int stride = pitch / 2;
+
+            var r0 = Vector128.Create(AdvSimd.LoadVector64(input + 0 * stride), Vector64<short>.Zero);
+            var r1 = Vector128.Create(AdvSimd.LoadVector64(input + 1 * stride), Vector64<short>.Zero);
+            var r2 = Vector128.Create(AdvSimd.LoadVector64(input + 2 * stride), Vector64<short>.Zero);
+            var r3 = Vector128.Create(AdvSimd.LoadVector64(input + 3 * stride), Vector64<short>.Zero);
+
+            r0 = AdvSimd.ShiftLeftLogical(r0, 3);
+            r1 = AdvSimd.ShiftLeftLogical(r1, 3);
+            r2 = AdvSimd.ShiftLeftLogical(r2, 3);
+            r3 = AdvSimd.ShiftLeftLogical(r3, 3);
+
+            var ab = AdvSimd.Arm64.ZipLow(r0, r1);
+            var cd = AdvSimd.Arm64.ZipLow(r2, r3);
+            var c01 = AdvSimd.Arm64.ZipLow(ab.AsInt32(), cd.AsInt32()).AsInt16();
+            var c23 = AdvSimd.Arm64.ZipHigh(ab.AsInt32(), cd.AsInt32()).AsInt16();
+
+            var c0 = c01;
+            var c1v = Vector128.Create(c01.GetUpper(), Vector64<short>.Zero);
+            var c2 = c23;
+            var c3v = Vector128.Create(c23.GetUpper(), Vector64<short>.Zero);
+
+            var a1 = AdvSimd.Add(c0, c3v);
+            var b1 = AdvSimd.Add(c1v, c2);
+            var c1d = AdvSimd.Subtract(c1v, c2);
+            var d1 = AdvSimd.Subtract(c0, c3v);
+
+            var res0 = AdvSimd.Add(a1, b1);
+            var res2 = AdvSimd.Subtract(a1, b1);
+
+            var k2217 = Vector128.Create(2217);
+            var k5352 = Vector128.Create(5352);
+            var cInt32 = AdvSimd.SignExtendWideningLower(c1d.GetLower());
+            var dInt32 = AdvSimd.SignExtendWideningLower(d1.GetLower());
+
+            var res1Int = AdvSimd.Add(AdvSimd.Multiply(cInt32, k2217), AdvSimd.Multiply(dInt32, k5352));
+            res1Int = AdvSimd.Add(res1Int, Vector128.Create(14500));
+            res1Int = AdvSimd.ShiftRightArithmetic(res1Int, 12);
+
+            var res3Int = AdvSimd.Subtract(AdvSimd.Multiply(dInt32, k2217), AdvSimd.Multiply(cInt32, k5352));
+            res3Int = AdvSimd.Add(res3Int, Vector128.Create(7500));
+            res3Int = AdvSimd.ShiftRightArithmetic(res3Int, 12);
+
+            var res1 = Vector128.Create(AdvSimd.ExtractNarrowingLower(res1Int), Vector64<short>.Zero);
+            var res3 = Vector128.Create(AdvSimd.ExtractNarrowingLower(res3Int), Vector64<short>.Zero);
+
+            var ab2 = AdvSimd.Arm64.ZipLow(res0, res1);
+            var cd2 = AdvSimd.Arm64.ZipLow(res2, res3);
+            var q01 = AdvSimd.Arm64.ZipLow(ab2.AsInt32(), cd2.AsInt32()).AsInt16();
+            var q23 = AdvSimd.Arm64.ZipHigh(ab2.AsInt32(), cd2.AsInt32()).AsInt16();
+
+            var q0 = AdvSimd.SignExtendWideningLower(q01.GetLower());
+            var q1 = AdvSimd.SignExtendWideningUpper(q01);
+            var q2 = AdvSimd.SignExtendWideningLower(q23.GetLower());
+            var q3 = AdvSimd.SignExtendWideningUpper(q23);
+
+            var a1c = AdvSimd.Add(q0, q3);
+            var b1c = AdvSimd.Add(q1, q2);
+            var c1c = AdvSimd.Subtract(q1, q2);
+            var d1c = AdvSimd.Subtract(q0, q3);
+
+            var sevenI32 = Vector128.Create(7);
+            var f0Int = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Add(a1c, b1c), sevenI32), 4);
+            var f2Int = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Subtract(a1c, b1c), sevenI32), 4);
+
+            var f1Int = AdvSimd.Add(AdvSimd.Multiply(c1c, k2217), AdvSimd.Multiply(d1c, k5352));
+            f1Int = AdvSimd.Add(f1Int, Vector128.Create(12000));
+            f1Int = AdvSimd.ShiftRightArithmetic(f1Int, 16);
+            var dZero = AdvSimd.CompareEqual(d1c, Vector128<int>.Zero);
+            f1Int = AdvSimd.Add(f1Int, AdvSimd.BitwiseClear(Vector128.Create(1), dZero));
+
+            var f3Int = AdvSimd.Subtract(AdvSimd.Multiply(d1c, k2217), AdvSimd.Multiply(c1c, k5352));
+            f3Int = AdvSimd.Add(f3Int, Vector128.Create(51000));
+            f3Int = AdvSimd.ShiftRightArithmetic(f3Int, 16);
+
+            AdvSimd.Store(output + 0,
+                Vector128.Create(AdvSimd.ExtractNarrowingLower(f0Int), AdvSimd.ExtractNarrowingLower(f1Int)));
+            AdvSimd.Store(output + 8,
+                Vector128.Create(AdvSimd.ExtractNarrowingLower(f2Int), AdvSimd.ExtractNarrowingLower(f3Int)));
+        }
+
+        /// <summary>AdvSimd batched 8x4 fdct - same shape as <see cref="Fdct8x4Sse2"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Fdct8x4AdvSimd(short* input, short* outLeft, short* outRight, int pitch)
+        {
+            int stride = pitch / 2;
+
+            var r0 = AdvSimd.LoadVector128(input + 0 * stride);
+            var r1 = AdvSimd.LoadVector128(input + 1 * stride);
+            var r2 = AdvSimd.LoadVector128(input + 2 * stride);
+            var r3 = AdvSimd.LoadVector128(input + 3 * stride);
+
+            r0 = AdvSimd.ShiftLeftLogical(r0, 3);
+            r1 = AdvSimd.ShiftLeftLogical(r1, 3);
+            r2 = AdvSimd.ShiftLeftLogical(r2, 3);
+            r3 = AdvSimd.ShiftLeftLogical(r3, 3);
+
+            var abL = AdvSimd.Arm64.ZipLow(r0, r1);
+            var abR = AdvSimd.Arm64.ZipHigh(r0, r1);
+            var cdL = AdvSimd.Arm64.ZipLow(r2, r3);
+            var cdR = AdvSimd.Arm64.ZipHigh(r2, r3);
+            var lL01 = AdvSimd.Arm64.ZipLow(abL.AsInt32(), cdL.AsInt32()).AsInt16();
+            var lL23 = AdvSimd.Arm64.ZipHigh(abL.AsInt32(), cdL.AsInt32()).AsInt16();
+            var lR01 = AdvSimd.Arm64.ZipLow(abR.AsInt32(), cdR.AsInt32()).AsInt16();
+            var lR23 = AdvSimd.Arm64.ZipHigh(abR.AsInt32(), cdR.AsInt32()).AsInt16();
+            var c0 = AdvSimd.Arm64.ZipLow(lL01.AsInt64(), lR01.AsInt64()).AsInt16();
+            var c1 = AdvSimd.Arm64.ZipHigh(lL01.AsInt64(), lR01.AsInt64()).AsInt16();
+            var c2 = AdvSimd.Arm64.ZipLow(lL23.AsInt64(), lR23.AsInt64()).AsInt16();
+            var c3 = AdvSimd.Arm64.ZipHigh(lL23.AsInt64(), lR23.AsInt64()).AsInt16();
+
+            var a1 = AdvSimd.Add(c0, c3);
+            var b1 = AdvSimd.Add(c1, c2);
+            var c1d = AdvSimd.Subtract(c1, c2);
+            var d1 = AdvSimd.Subtract(c0, c3);
+
+            var res0 = AdvSimd.Add(a1, b1);
+            var res2 = AdvSimd.Subtract(a1, b1);
+
+            var k2217 = Vector128.Create(2217);
+            var k5352 = Vector128.Create(5352);
+
+            var cLo = AdvSimd.SignExtendWideningLower(c1d.GetLower());
+            var cHi = AdvSimd.SignExtendWideningUpper(c1d);
+            var dLo = AdvSimd.SignExtendWideningLower(d1.GetLower());
+            var dHi = AdvSimd.SignExtendWideningUpper(d1);
+
+            var c14500 = Vector128.Create(14500);
+            var c7500 = Vector128.Create(7500);
+
+            var res1Lo = AdvSimd.Add(AdvSimd.Multiply(cLo, k2217), AdvSimd.Multiply(dLo, k5352));
+            res1Lo = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(res1Lo, c14500), 12);
+            var res1Hi = AdvSimd.Add(AdvSimd.Multiply(cHi, k2217), AdvSimd.Multiply(dHi, k5352));
+            res1Hi = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(res1Hi, c14500), 12);
+
+            var res3Lo = AdvSimd.Subtract(AdvSimd.Multiply(dLo, k2217), AdvSimd.Multiply(cLo, k5352));
+            res3Lo = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(res3Lo, c7500), 12);
+            var res3Hi = AdvSimd.Subtract(AdvSimd.Multiply(dHi, k2217), AdvSimd.Multiply(cHi, k5352));
+            res3Hi = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(res3Hi, c7500), 12);
+
+            var res1 = Vector128.Create(AdvSimd.ExtractNarrowingLower(res1Lo), AdvSimd.ExtractNarrowingLower(res1Hi));
+            var res3 = Vector128.Create(AdvSimd.ExtractNarrowingLower(res3Lo), AdvSimd.ExtractNarrowingLower(res3Hi));
+
+            var u01L = AdvSimd.Arm64.ZipLow(res0, res1);
+            var u01R = AdvSimd.Arm64.ZipHigh(res0, res1);
+            var u23L = AdvSimd.Arm64.ZipLow(res2, res3);
+            var u23R = AdvSimd.Arm64.ZipHigh(res2, res3);
+            var qLL01 = AdvSimd.Arm64.ZipLow(u01L.AsInt32(), u23L.AsInt32()).AsInt16();
+            var qLL23 = AdvSimd.Arm64.ZipHigh(u01L.AsInt32(), u23L.AsInt32()).AsInt16();
+            var qLR01 = AdvSimd.Arm64.ZipLow(u01R.AsInt32(), u23R.AsInt32()).AsInt16();
+            var qLR23 = AdvSimd.Arm64.ZipHigh(u01R.AsInt32(), u23R.AsInt32()).AsInt16();
+            var q0 = AdvSimd.Arm64.ZipLow(qLL01.AsInt64(), qLR01.AsInt64()).AsInt16();
+            var q1 = AdvSimd.Arm64.ZipHigh(qLL01.AsInt64(), qLR01.AsInt64()).AsInt16();
+            var q2 = AdvSimd.Arm64.ZipLow(qLL23.AsInt64(), qLR23.AsInt64()).AsInt16();
+            var q3 = AdvSimd.Arm64.ZipHigh(qLL23.AsInt64(), qLR23.AsInt64()).AsInt16();
+
+            var q0L = AdvSimd.SignExtendWideningLower(q0.GetLower());
+            var q0R = AdvSimd.SignExtendWideningUpper(q0);
+            var q1L = AdvSimd.SignExtendWideningLower(q1.GetLower());
+            var q1R = AdvSimd.SignExtendWideningUpper(q1);
+            var q2L = AdvSimd.SignExtendWideningLower(q2.GetLower());
+            var q2R = AdvSimd.SignExtendWideningUpper(q2);
+            var q3L = AdvSimd.SignExtendWideningLower(q3.GetLower());
+            var q3R = AdvSimd.SignExtendWideningUpper(q3);
+
+            var sevenI32 = Vector128.Create(7);
+            var c12000 = Vector128.Create(12000);
+            var c51000 = Vector128.Create(51000);
+            var one = Vector128.Create(1);
+
+            var a1cL = AdvSimd.Add(q0L, q3L);
+            var b1cL = AdvSimd.Add(q1L, q2L);
+            var c1cL = AdvSimd.Subtract(q1L, q2L);
+            var d1cL = AdvSimd.Subtract(q0L, q3L);
+            var f0L = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Add(a1cL, b1cL), sevenI32), 4);
+            var f2L = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Subtract(a1cL, b1cL), sevenI32), 4);
+            var f1L = AdvSimd.Add(AdvSimd.Multiply(c1cL, k2217), AdvSimd.Multiply(d1cL, k5352));
+            f1L = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(f1L, c12000), 16);
+            f1L = AdvSimd.Add(f1L, AdvSimd.BitwiseClear(one, AdvSimd.CompareEqual(d1cL, Vector128<int>.Zero)));
+            var f3L = AdvSimd.Subtract(AdvSimd.Multiply(d1cL, k2217), AdvSimd.Multiply(c1cL, k5352));
+            f3L = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(f3L, c51000), 16);
+
+            var a1cR = AdvSimd.Add(q0R, q3R);
+            var b1cR = AdvSimd.Add(q1R, q2R);
+            var c1cR = AdvSimd.Subtract(q1R, q2R);
+            var d1cR = AdvSimd.Subtract(q0R, q3R);
+            var f0R = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Add(a1cR, b1cR), sevenI32), 4);
+            var f2R = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Subtract(a1cR, b1cR), sevenI32), 4);
+            var f1R = AdvSimd.Add(AdvSimd.Multiply(c1cR, k2217), AdvSimd.Multiply(d1cR, k5352));
+            f1R = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(f1R, c12000), 16);
+            f1R = AdvSimd.Add(f1R, AdvSimd.BitwiseClear(one, AdvSimd.CompareEqual(d1cR, Vector128<int>.Zero)));
+            var f3R = AdvSimd.Subtract(AdvSimd.Multiply(d1cR, k2217), AdvSimd.Multiply(c1cR, k5352));
+            f3R = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(f3R, c51000), 16);
+
+            AdvSimd.Store(outLeft + 0,
+                Vector128.Create(AdvSimd.ExtractNarrowingLower(f0L), AdvSimd.ExtractNarrowingLower(f1L)));
+            AdvSimd.Store(outLeft + 8,
+                Vector128.Create(AdvSimd.ExtractNarrowingLower(f2L), AdvSimd.ExtractNarrowingLower(f3L)));
+            AdvSimd.Store(outRight + 0,
+                Vector128.Create(AdvSimd.ExtractNarrowingLower(f0R), AdvSimd.ExtractNarrowingLower(f1R)));
+            AdvSimd.Store(outRight + 8,
+                Vector128.Create(AdvSimd.ExtractNarrowingLower(f2R), AdvSimd.ExtractNarrowingLower(f3R)));
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/IdctEncoderSimd.cs
+++ b/src/SIPSorcery.VP8/IdctEncoderSimd.cs
@@ -1,0 +1,347 @@
+//-----------------------------------------------------------------------------
+// Encoder-side SIMD fast path for the 4x4 inverse DCT + flat or per-pixel
+// prediction add + [0,255] clamp + strided byte store. Bit-exact with
+// idctllm.vp8_short_idct4x4llm_c followed by a scalar add-and-clamp.
+//
+// The decoder keeps using vp8_short_idct4x4llm_c. Only the encoder's
+// reconstruct loop (~24 calls per macroblock) opts into this path.
+//
+// Author: Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    internal static unsafe class IdctEncoderSimd
+    {
+        private const int cospi8sqrt2minus1 = 20091;
+        private const int sinpi8sqrt2 = 35468;
+
+        /// <summary>True when one of the SIMD paths is available and will produce
+        /// bit-identical results to the scalar reference. Callers can avoid the
+        /// 4x4 stack pred buffer when this is true.</summary>
+        public static bool IsSupported => Sse41.IsSupported || AdvSimd.Arm64.IsSupported;
+
+        /// <summary>4x4 inverse DCT + flat-byte prediction add + clamp + store.
+        /// Equivalent to <see cref="idctllm.vp8_short_idct4x4llm_c"/> with a
+        /// pred buffer of all <paramref name="pred"/>. Used by DC_PRED / TM_PRED-style
+        /// modes where the prediction is uniform over the 4x4.</summary>
+        public static void Idct4x4AddFlat(short* input, byte pred, byte* dst, int dstStride)
+        {
+            if (Sse41.IsSupported)
+            {
+                Idct4x4AddSse41(input, predFlat: pred, predPlane: null, predStride: 0, dst, dstStride);
+                return;
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                Idct4x4AddAdvSimd(input, predFlat: pred, predPlane: null, predStride: 0, dst, dstStride);
+                return;
+            }
+
+            ScalarFallback(input, pred, predPlane: null, predStride: 0, dst, dstStride);
+        }
+
+        /// <summary>4x4 inverse DCT + per-pixel prediction add + clamp + store.</summary>
+        public static void Idct4x4AddBlock(short* input, byte* pred, int predStride, byte* dst, int dstStride)
+        {
+            if (Sse41.IsSupported)
+            {
+                Idct4x4AddSse41(input, predFlat: 0, predPlane: pred, predStride, dst, dstStride);
+                return;
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                Idct4x4AddAdvSimd(input, predFlat: 0, predPlane: pred, predStride, dst, dstStride);
+                return;
+            }
+
+            ScalarFallback(input, predFlat: 0, predPlane: pred, predStride, dst, dstStride);
+        }
+
+        // ---------------------------------------------------------------------
+        // SSE4.1 - true 4-way 4x4 inverse DCT + add + clamp + store
+        // ---------------------------------------------------------------------
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Idct4x4AddSse41(short* input, byte predFlat, byte* predPlane, int predStride, byte* dst, int dstStride)
+        {
+            // Load 4 rows of input (4 shorts each in lo 4 int16 lanes), widen to int32.
+            var r0 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 0)).AsInt16());
+            var r1 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 4)).AsInt16());
+            var r2 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 8)).AsInt16());
+            var r3 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 12)).AsInt16());
+
+            // First pass: lane-wise across rows (each lane = column of input).
+            // op[shortpitch * 0] = a1 + d1 -> mid row 0
+            // op[shortpitch * 1] = b1 + c1 -> mid row 1
+            // op[shortpitch * 2] = b1 - c1 -> mid row 2
+            // op[shortpitch * 3] = a1 - d1 -> mid row 3
+            IdctPassSse41(r0, r1, r2, r3, addRound: 0, shift: 0,
+                          out var m0, out var m1, out var m2, out var m3);
+
+            // Transpose 4x4 (int32 form): row-vectors -> column-vectors (lane = row).
+            Transpose4x4Sse2(m0, m1, m2, m3, out var t0, out var t1, out var t2, out var t3);
+
+            // Second pass: lane-wise across what are now intermediate rows (each lane = row of intermediate).
+            // op[c] = (... + 4) >> 3.
+            IdctPassSse41(t0, t1, t2, t3, addRound: 4, shift: 3,
+                          out var oc0, out var oc1, out var oc2, out var oc3);
+
+            // Transpose back: column-vectors -> row-vectors (lane = column).
+            Transpose4x4Sse2(oc0, oc1, oc2, oc3, out var or0, out var or1, out var or2, out var or3);
+
+            // Load prediction as 4 int32 rows and add.
+            Vector128<int> p0, p1, p2, p3;
+            if (predPlane == null)
+            {
+                var pf = Vector128.Create((int)predFlat);
+                p0 = pf; p1 = pf; p2 = pf; p3 = pf;
+            }
+            else
+            {
+                p0 = LoadPredRowSse41(predPlane + 0 * predStride);
+                p1 = LoadPredRowSse41(predPlane + 1 * predStride);
+                p2 = LoadPredRowSse41(predPlane + 2 * predStride);
+                p3 = LoadPredRowSse41(predPlane + 3 * predStride);
+            }
+
+            or0 = Sse2.Add(or0, p0);
+            or1 = Sse2.Add(or1, p1);
+            or2 = Sse2.Add(or2, p2);
+            or3 = Sse2.Add(or3, p3);
+
+            // Pack int32 -> int16 -> uint8 with saturation = clamp to [0, 255].
+            // Pair rows for fewer packs: r01 = [r0|r1] in int16, then PackUnsignedSaturate to uint8.
+            var s01 = Sse2.PackSignedSaturate(or0, or1);   // 8 int16 = [or0 (4), or1 (4)]
+            var s23 = Sse2.PackSignedSaturate(or2, or3);
+            var b0123 = Sse2.PackUnsignedSaturate(s01, s23);  // 16 uint8 = rows 0,1,2,3 (4 bytes each)
+
+            // Store 4 bytes per row at stride. b0123 lanes 0..3 = row 0, 4..7 = row 1, 8..11 = row 2, 12..15 = row 3.
+            // 4 byte stores; on M1 fewer instructions vs scalar copy.
+            *(int*)(dst + 0 * dstStride) = b0123.AsInt32().GetElement(0);
+            *(int*)(dst + 1 * dstStride) = b0123.AsInt32().GetElement(1);
+            *(int*)(dst + 2 * dstStride) = b0123.AsInt32().GetElement(2);
+            *(int*)(dst + 3 * dstStride) = b0123.AsInt32().GetElement(3);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<int> LoadPredRowSse41(byte* row)
+        {
+            // Load 4 bytes -> Vector128<int> with one byte sign-extended (zero-extended) per lane.
+            // SSE4.1: Pmovzxbd
+            int packed = *(int*)row;
+            return Sse41.ConvertToVector128Int32(Vector128.CreateScalar(packed).AsByte());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void IdctPassSse41(
+            Vector128<int> r0, Vector128<int> r1, Vector128<int> r2, Vector128<int> r3,
+            int addRound, int shift,
+            out Vector128<int> o0, out Vector128<int> o1, out Vector128<int> o2, out Vector128<int> o3)
+        {
+            var k_sin = Vector128.Create(sinpi8sqrt2);
+            var k_cosm1 = Vector128.Create(cospi8sqrt2minus1);
+
+            var a1 = Sse2.Add(r0, r2);
+            var b1 = Sse2.Subtract(r0, r2);
+
+            var t1a = Sse2.ShiftRightArithmetic(Sse41.MultiplyLow(r1, k_sin), 16);
+            var t2a = Sse2.Add(r3, Sse2.ShiftRightArithmetic(Sse41.MultiplyLow(r3, k_cosm1), 16));
+            var c1 = Sse2.Subtract(t1a, t2a);
+
+            var t1b = Sse2.Add(r1, Sse2.ShiftRightArithmetic(Sse41.MultiplyLow(r1, k_cosm1), 16));
+            var t2b = Sse2.ShiftRightArithmetic(Sse41.MultiplyLow(r3, k_sin), 16);
+            var d1 = Sse2.Add(t1b, t2b);
+
+            if (shift == 0)
+            {
+                o0 = Sse2.Add(a1, d1);
+                o1 = Sse2.Add(b1, c1);
+                o2 = Sse2.Subtract(b1, c1);
+                o3 = Sse2.Subtract(a1, d1);
+            }
+            else
+            {
+                var round = Vector128.Create(addRound);
+                byte sh = (byte)shift;
+                o0 = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Add(a1, d1), round), sh);
+                o1 = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Add(b1, c1), round), sh);
+                o2 = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Subtract(b1, c1), round), sh);
+                o3 = Sse2.ShiftRightArithmetic(Sse2.Add(Sse2.Subtract(a1, d1), round), sh);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Transpose4x4Sse2(
+            Vector128<int> r0, Vector128<int> r1, Vector128<int> r2, Vector128<int> r3,
+            out Vector128<int> o0, out Vector128<int> o1, out Vector128<int> o2, out Vector128<int> o3)
+        {
+            var t01_lo = Sse2.UnpackLow(r0, r1);    // [r0[0], r1[0], r0[1], r1[1]]
+            var t01_hi = Sse2.UnpackHigh(r0, r1);   // [r0[2], r1[2], r0[3], r1[3]]
+            var t23_lo = Sse2.UnpackLow(r2, r3);
+            var t23_hi = Sse2.UnpackHigh(r2, r3);
+
+            o0 = Sse2.UnpackLow(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();    // col 0 = [r0[0], r1[0], r2[0], r3[0]]
+            o1 = Sse2.UnpackHigh(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();   // col 1
+            o2 = Sse2.UnpackLow(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();    // col 2
+            o3 = Sse2.UnpackHigh(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();   // col 3
+        }
+
+        // ---------------------------------------------------------------------
+        // ARM AdvSimd
+        // ---------------------------------------------------------------------
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Idct4x4AddAdvSimd(short* input, byte predFlat, byte* predPlane, int predStride, byte* dst, int dstStride)
+        {
+            var r0 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 0));
+            var r1 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 4));
+            var r2 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 8));
+            var r3 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 12));
+
+            IdctPassAdvSimd(r0, r1, r2, r3, addRound: 0, shift: 0,
+                            out var m0, out var m1, out var m2, out var m3);
+
+            Transpose4x4AdvSimd(m0, m1, m2, m3, out var t0, out var t1, out var t2, out var t3);
+
+            IdctPassAdvSimd(t0, t1, t2, t3, addRound: 4, shift: 3,
+                            out var oc0, out var oc1, out var oc2, out var oc3);
+
+            Transpose4x4AdvSimd(oc0, oc1, oc2, oc3, out var or0, out var or1, out var or2, out var or3);
+
+            Vector128<int> p0, p1, p2, p3;
+            if (predPlane == null)
+            {
+                var pf = Vector128.Create((int)predFlat);
+                p0 = pf; p1 = pf; p2 = pf; p3 = pf;
+            }
+            else
+            {
+                p0 = LoadPredRowAdvSimd(predPlane + 0 * predStride);
+                p1 = LoadPredRowAdvSimd(predPlane + 1 * predStride);
+                p2 = LoadPredRowAdvSimd(predPlane + 2 * predStride);
+                p3 = LoadPredRowAdvSimd(predPlane + 3 * predStride);
+            }
+
+            or0 = AdvSimd.Add(or0, p0);
+            or1 = AdvSimd.Add(or1, p1);
+            or2 = AdvSimd.Add(or2, p2);
+            or3 = AdvSimd.Add(or3, p3);
+
+            // Saturating narrow int32 -> uint8: int32 -> int16 with signed-saturation,
+            // then int16 -> uint8 with unsigned-saturation = clamp [0, 255].
+            var s0 = AdvSimd.ExtractNarrowingSaturateLower(or0);   // 4 int16
+            var s1 = AdvSimd.ExtractNarrowingSaturateLower(or1);
+            var s2 = AdvSimd.ExtractNarrowingSaturateLower(or2);
+            var s3 = AdvSimd.ExtractNarrowingSaturateLower(or3);
+
+            var s01 = Vector128.Create(s0, s1);   // 8 int16 = rows 0,1
+            var s23 = Vector128.Create(s2, s3);   // 8 int16 = rows 2,3
+
+            var b01 = AdvSimd.ExtractNarrowingSaturateUnsignedLower(s01);   // 8 uint8 = rows 0,1
+            var b23 = AdvSimd.ExtractNarrowingSaturateUnsignedLower(s23);
+
+            // Store 4 bytes per row.
+            *(int*)(dst + 0 * dstStride) = b01.AsInt32().GetElement(0);
+            *(int*)(dst + 1 * dstStride) = b01.AsInt32().GetElement(1);
+            *(int*)(dst + 2 * dstStride) = b23.AsInt32().GetElement(0);
+            *(int*)(dst + 3 * dstStride) = b23.AsInt32().GetElement(1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<int> LoadPredRowAdvSimd(byte* row)
+        {
+            int packed = *(int*)row;
+            var asBytes = Vector64.CreateScalar(packed).AsByte();
+            // Zero-extend 4 bytes -> 4 int16 -> 4 int32.
+            var asShorts = AdvSimd.ZeroExtendWideningLower(asBytes);
+            return AdvSimd.ZeroExtendWideningLower(asShorts.GetLower()).AsInt32();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void IdctPassAdvSimd(
+            Vector128<int> r0, Vector128<int> r1, Vector128<int> r2, Vector128<int> r3,
+            int addRound, int shift,
+            out Vector128<int> o0, out Vector128<int> o1, out Vector128<int> o2, out Vector128<int> o3)
+        {
+            var k_sin = Vector128.Create(sinpi8sqrt2);
+            var k_cosm1 = Vector128.Create(cospi8sqrt2minus1);
+
+            var a1 = AdvSimd.Add(r0, r2);
+            var b1 = AdvSimd.Subtract(r0, r2);
+
+            var t1a = AdvSimd.ShiftRightArithmetic(AdvSimd.Multiply(r1, k_sin), 16);
+            var t2a = AdvSimd.Add(r3, AdvSimd.ShiftRightArithmetic(AdvSimd.Multiply(r3, k_cosm1), 16));
+            var c1 = AdvSimd.Subtract(t1a, t2a);
+
+            var t1b = AdvSimd.Add(r1, AdvSimd.ShiftRightArithmetic(AdvSimd.Multiply(r1, k_cosm1), 16));
+            var t2b = AdvSimd.ShiftRightArithmetic(AdvSimd.Multiply(r3, k_sin), 16);
+            var d1 = AdvSimd.Add(t1b, t2b);
+
+            if (shift == 0)
+            {
+                o0 = AdvSimd.Add(a1, d1);
+                o1 = AdvSimd.Add(b1, c1);
+                o2 = AdvSimd.Subtract(b1, c1);
+                o3 = AdvSimd.Subtract(a1, d1);
+            }
+            else
+            {
+                var round = Vector128.Create(addRound);
+                o0 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Add(a1, d1), round), (byte)shift);
+                o1 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Add(b1, c1), round), (byte)shift);
+                o2 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Subtract(b1, c1), round), (byte)shift);
+                o3 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(AdvSimd.Subtract(a1, d1), round), (byte)shift);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Transpose4x4AdvSimd(
+            Vector128<int> r0, Vector128<int> r1, Vector128<int> r2, Vector128<int> r3,
+            out Vector128<int> o0, out Vector128<int> o1, out Vector128<int> o2, out Vector128<int> o3)
+        {
+            var t01_lo = AdvSimd.Arm64.ZipLow(r0, r1);
+            var t01_hi = AdvSimd.Arm64.ZipHigh(r0, r1);
+            var t23_lo = AdvSimd.Arm64.ZipLow(r2, r3);
+            var t23_hi = AdvSimd.Arm64.ZipHigh(r2, r3);
+
+            o0 = AdvSimd.Arm64.ZipLow(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();
+            o1 = AdvSimd.Arm64.ZipHigh(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();
+            o2 = AdvSimd.Arm64.ZipLow(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();
+            o3 = AdvSimd.Arm64.ZipHigh(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();
+        }
+
+        // ---------------------------------------------------------------------
+        // Scalar fallback (matches idctllm.vp8_short_idct4x4llm_c + add + clamp).
+        // ---------------------------------------------------------------------
+
+        private static void ScalarFallback(short* input, byte predFlat, byte* predPlane, int predStride, byte* dst, int dstStride)
+        {
+            byte* predBuf = stackalloc byte[16];
+            if (predPlane == null)
+            {
+                for (int i = 0; i < 16; i++) predBuf[i] = predFlat;
+            }
+            else
+            {
+                for (int r = 0; r < 4; r++)
+                for (int c = 0; c < 4; c++)
+                    predBuf[r * 4 + c] = predPlane[r * predStride + c];
+            }
+
+            byte* dstBuf = stackalloc byte[16];
+            idctllm.vp8_short_idct4x4llm_c(input, predBuf, 4, dstBuf, 4);
+
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+                dst[r * dstStride + c] = dstBuf[r * 4 + c];
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/QuantizeEncoderSimd.cs
+++ b/src/SIPSorcery.VP8/QuantizeEncoderSimd.cs
@@ -93,6 +93,15 @@ namespace Vpx.Net
             return eob + 1;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void StoreInt4Unaligned(int* dst, Vector128<int> v)
+        {
+            dst[0] = v.GetElement(0);
+            dst[1] = v.GetElement(1);
+            dst[2] = v.GetElement(2);
+            dst[3] = v.GetElement(3);
+        }
+
         // ----------------- SSE4.1 pre-compute -----------------
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -129,11 +138,11 @@ namespace Vpx.Net
                 var dq = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)dqp).AsInt16());
                 var dqv = Sse41.MultiplyLow(xs, dq);
 
-                Sse2.Store(absX + g * 4, ax);
-                Sse2.Store(sign + g * 4, sz);
-                Sse2.Store(yRaw + g * 4, y);
-                Sse2.Store(xSigned + g * 4, xs);
-                Sse2.Store(dqValue + g * 4, dqv);
+                StoreInt4Unaligned(absX + g * 4, ax);
+                StoreInt4Unaligned(sign + g * 4, sz);
+                StoreInt4Unaligned(yRaw + g * 4, y);
+                StoreInt4Unaligned(xSigned + g * 4, xs);
+                StoreInt4Unaligned(dqValue + g * 4, dqv);
             }
         }
 
@@ -171,11 +180,11 @@ namespace Vpx.Net
                 var dq = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(dqp));
                 var dqv = AdvSimd.Multiply(xs, dq);
 
-                AdvSimd.Store(absX + g * 4, ax);
-                AdvSimd.Store(sign + g * 4, sz);
-                AdvSimd.Store(yRaw + g * 4, y);
-                AdvSimd.Store(xSigned + g * 4, xs);
-                AdvSimd.Store(dqValue + g * 4, dqv);
+                StoreInt4Unaligned(absX + g * 4, ax);
+                StoreInt4Unaligned(sign + g * 4, sz);
+                StoreInt4Unaligned(yRaw + g * 4, y);
+                StoreInt4Unaligned(xSigned + g * 4, xs);
+                StoreInt4Unaligned(dqValue + g * 4, dqv);
             }
         }
 

--- a/src/SIPSorcery.VP8/QuantizeEncoderSimd.cs
+++ b/src/SIPSorcery.VP8/QuantizeEncoderSimd.cs
@@ -1,0 +1,199 @@
+//-----------------------------------------------------------------------------
+// Encoder-side SIMD fast path for vp8_regular_quantize_b_arrays. Bit-exact
+// with the scalar reference in quantize.cs.
+//
+// Strategy (matches the plan's Tier 5 approach (a)):
+//   * Pre-compute, for all 16 coefficients in parallel via int32 SIMD lanes:
+//     - abs(z), sign(z), x_signed = (y_raw ^ sz) - sz, y_raw, dq value.
+//     This is the heavy arithmetic — 16 multiplies become 4 vector multiplies
+//     on each of x86 (PMULLD, SSE4.1+) and ARM (AdvSimd.Multiply on int32).
+//   * A short scalar zigzag pass then applies the zbin_thr check including
+//     the sequential zrun_zbin_boost lookup, writes qcoeff/dqcoeff at the
+//     accepted positions, and computes eob.
+//
+// The zrun_zbin_boost index advance and the eob/zigzag scan must remain
+// sequential to preserve bit-identity with libvpx. The pre-computed values
+// for rejected positions are simply discarded.
+//
+// Author: Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    internal static unsafe class QuantizeEncoderSimd
+    {
+        public static bool IsSupported => Sse41.IsSupported || AdvSimd.Arm64.IsSupported;
+
+        /// <summary>SIMD bit-exact replacement for
+        /// <see cref="quantize.vp8_regular_quantize_b_arrays"/>.</summary>
+        public static int RegularQuantizeB(
+            short* coeff,
+            short* zbin,
+            short* zrun_zbin_boost,
+            short* round,
+            short* quant,
+            short* quant_shift,
+            short* dequant,
+            short* qcoeff,
+            short* dqcoeff,
+            short zbin_extra)
+        {
+            // Output buffers must start zero — only accepted positions get written.
+            ClearBlockOutputs(qcoeff, dqcoeff);
+
+            int* absX = stackalloc int[16];
+            int* sign = stackalloc int[16];
+            int* yRaw = stackalloc int[16];
+            int* xSigned = stackalloc int[16];
+            int* dqValue = stackalloc int[16];
+
+            if (Sse41.IsSupported)
+            {
+                PrecomputeSse41(coeff, round, quant, quant_shift, dequant,
+                                absX, sign, yRaw, xSigned, dqValue);
+            }
+            else
+            {
+                PrecomputeAdvSimd(coeff, round, quant, quant_shift, dequant,
+                                  absX, sign, yRaw, xSigned, dqValue);
+            }
+
+            // Sequential zigzag-order zbin gating + eob/zboost tracking.
+            int eob = -1;
+            int zbin_boost_idx = 0;
+            int extraI = zbin_extra;
+
+            for (int i = 0; i < 16; i++)
+            {
+                int rc = entropy.vp8_default_zig_zag1d[i];
+                int zbinThr = zbin[rc] + zrun_zbin_boost[zbin_boost_idx] + extraI;
+                zbin_boost_idx++;
+
+                if (absX[rc] >= zbinThr)
+                {
+                    int xs = xSigned[rc];
+                    qcoeff[rc] = (short)xs;
+                    dqcoeff[rc] = (short)dqValue[rc];
+
+                    if (yRaw[rc] != 0)
+                    {
+                        eob = i;
+                        zbin_boost_idx = 0;
+                    }
+                }
+            }
+
+            return eob + 1;
+        }
+
+        // ----------------- SSE4.1 pre-compute -----------------
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void PrecomputeSse41(
+            short* coeff, short* round, short* quant, short* quant_shift, short* dequant,
+            int* absX, int* sign, int* yRaw, int* xSigned, int* dqValue)
+        {
+            // Process the 16 coeffs as 4 groups of 4 int32 lanes.
+            for (int g = 0; g < 4; g++)
+            {
+                short* cp = coeff + g * 4;
+                short* rp = round + g * 4;
+                short* qp = quant + g * 4;
+                short* qsp = quant_shift + g * 4;
+                short* dqp = dequant + g * 4;
+
+                // Sign-extend 4 shorts → Vector128<int>.
+                var z = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)cp).AsInt16());
+                var sz = Sse2.ShiftRightArithmetic(z, 31);            // 0 or -1
+                var ax = Sse2.Subtract(Sse2.Xor(z, sz), sz);           // |z|
+
+                var rnd = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)rp).AsInt16());
+                var x = Sse2.Add(ax, rnd);
+
+                var qv = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)qp).AsInt16());
+                var t1 = Sse2.ShiftRightArithmetic(Sse41.MultiplyLow(x, qv), 16);
+                var t2 = Sse2.Add(t1, x);
+
+                var qsh = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)qsp).AsInt16());
+                var y = Sse2.ShiftRightArithmetic(Sse41.MultiplyLow(t2, qsh), 16);
+
+                var xs = Sse2.Subtract(Sse2.Xor(y, sz), sz);
+
+                var dq = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)dqp).AsInt16());
+                var dqv = Sse41.MultiplyLow(xs, dq);
+
+                Sse2.Store(absX + g * 4, ax);
+                Sse2.Store(sign + g * 4, sz);
+                Sse2.Store(yRaw + g * 4, y);
+                Sse2.Store(xSigned + g * 4, xs);
+                Sse2.Store(dqValue + g * 4, dqv);
+            }
+        }
+
+        // ----------------- AdvSimd pre-compute -----------------
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void PrecomputeAdvSimd(
+            short* coeff, short* round, short* quant, short* quant_shift, short* dequant,
+            int* absX, int* sign, int* yRaw, int* xSigned, int* dqValue)
+        {
+            for (int g = 0; g < 4; g++)
+            {
+                short* cp = coeff + g * 4;
+                short* rp = round + g * 4;
+                short* qp = quant + g * 4;
+                short* qsp = quant_shift + g * 4;
+                short* dqp = dequant + g * 4;
+
+                var z = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(cp));
+                var sz = AdvSimd.ShiftRightArithmetic(z, 31);
+                var ax = AdvSimd.Subtract(AdvSimd.Xor(z, sz), sz);
+
+                var rnd = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(rp));
+                var x = AdvSimd.Add(ax, rnd);
+
+                var qv = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(qp));
+                var t1 = AdvSimd.ShiftRightArithmetic(AdvSimd.Multiply(x, qv), 16);
+                var t2 = AdvSimd.Add(t1, x);
+
+                var qsh = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(qsp));
+                var y = AdvSimd.ShiftRightArithmetic(AdvSimd.Multiply(t2, qsh), 16);
+
+                var xs = AdvSimd.Subtract(AdvSimd.Xor(y, sz), sz);
+
+                var dq = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(dqp));
+                var dqv = AdvSimd.Multiply(xs, dq);
+
+                AdvSimd.Store(absX + g * 4, ax);
+                AdvSimd.Store(sign + g * 4, sz);
+                AdvSimd.Store(yRaw + g * 4, y);
+                AdvSimd.Store(xSigned + g * 4, xs);
+                AdvSimd.Store(dqValue + g * 4, dqv);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ClearBlockOutputs(short* qcoeff, short* dqcoeff)
+        {
+            if (Sse2.IsSupported || AdvSimd.IsSupported)
+            {
+                var z = Vector128<short>.Zero;
+                Unsafe.WriteUnaligned(ref *(byte*)qcoeff, z);
+                Unsafe.WriteUnaligned(ref *(byte*)(qcoeff + 8), z);
+                Unsafe.WriteUnaligned(ref *(byte*)dqcoeff, z);
+                Unsafe.WriteUnaligned(ref *(byte*)(dqcoeff + 8), z);
+            }
+            else
+            {
+                for (int i = 0; i < 16; i++) { qcoeff[i] = 0; dqcoeff[i] = 0; }
+            }
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/VP8Codec.cs
+++ b/src/SIPSorcery.VP8/VP8Codec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: VP8Codec.cs
 //
 // Description: Implements a VP8 video encoder and decoder.
@@ -42,18 +42,39 @@ namespace Vpx.Net
         private Object _encoderLock = new object();
 
         /// <summary>
-        /// Creates a new video encoder can encode and decode samples.
+        /// Creates a new encoder/decoder using the <see cref="Vp8EncodePipelineKind.Optimized"/> pipeline
+        /// when <see cref="Vp8EncodeSimdCapabilities.HasResidualAcceleration"/> is true; otherwise uses
+        /// the legacy encoder path (same as <see cref="Vp8EncodePipelineKind.Legacy"/>).
         /// </summary>
-        public VP8Codec()
-        { }
+        public VP8Codec() : this(Vp8EncodePipelineKind.Optimized) { }
 
-        // Pooled per-instance plane-split buffers, reused across calls.
-        // Resized lazily when the input dimensions change. Allocating these
-        // afresh each frame was a major chunk of the encoder's GC pressure
-        // (~440 KB per 640x480 frame).
-        private byte[] _srcY;
-        private byte[] _srcU;
-        private byte[] _srcV;
+        /// <summary>
+        /// True when the machine supports AVX2, SSE2, or AdvSimd residual kernels; matches whether
+        /// <see cref="Vp8EncodePipelineKind.Optimized"/> selects the span/SIMD pipeline.
+        /// </summary>
+        public static bool IsOptimizedHardwareAvailable => Vp8EncodeSimdCapabilities.HasResidualAcceleration;
+
+        /// <param name="encodePipeline">Core encode memory strategy (legacy vs span/SIMD when hardware allows).</param>
+        public VP8Codec(Vp8EncodePipelineKind encodePipeline) : this(encodePipeline, log2NumTokenPartitions: 0) { }
+
+        /// <summary>
+        /// Creates a new encoder/decoder using the specified pipeline kind and the
+        /// requested number of token partitions (<c>1 &lt;&lt; log2NumTokenPartitions</c>).
+        /// </summary>
+        /// <param name="encodePipeline">Core encode memory strategy (legacy vs span/SIMD when hardware allows).</param>
+        /// <param name="log2NumTokenPartitions">log2 of the number of token partitions
+        /// (0 -> 1 partition / single-threaded pack-tokens, default; 1 -> 2; 2 -> 4; 3 -> 8).
+        /// Higher values enable parallel token packing across multiple partitions for faster
+        /// per-frame encode time at the cost of a small per-frame stitch step. The output
+        /// stays a valid VP8 bitstream that any conforming decoder accepts. Pooled internal
+        /// encode paths return a slice over <see cref="FrameEncoderBuffers.OutBuf"/> (no copy of
+        /// the compressed frame bytes); other small encode-time allocations may still occur.</param>
+        public VP8Codec(Vp8EncodePipelineKind encodePipeline, int log2NumTokenPartitions)
+        {
+            _encodePipeline = Vp8FrameEncodePipelineFactory.Create(encodePipeline, log2NumTokenPartitions);
+        }
+
+        private readonly IVp8FrameEncodePipeline _encodePipeline;
 
         public void ForceKeyFrame() => _forceKeyFrame = true;
         public bool IsSupported(VideoCodecsEnum codec) => codec == VideoCodecsEnum.VP8;
@@ -172,17 +193,6 @@ namespace Vpx.Net
                         (ySize + 2 * cSize) + " for " + width + "x" + height + ".");
                 }
 
-                if (_srcY == null || _srcY.Length < ySize) { _srcY = new byte[ySize]; }
-                if (_srcU == null || _srcU.Length < cSize) { _srcU = new byte[cSize]; _srcV = new byte[cSize]; }
-                Buffer.BlockCopy(i420, 0,             _srcY, 0, ySize);
-                Buffer.BlockCopy(i420, ySize,         _srcU, 0, cSize);
-                Buffer.BlockCopy(i420, ySize + cSize, _srcV, 0, cSize);
-
-                // Decide keyframe vs inter for this call.
-                // - Forced keyframe (via ForceKeyFrame()): always keyframe.
-                // - Frame counter reached interval: keyframe.
-                // - First frame of stream / no valid reference: keyframe.
-                // - Otherwise: inter (ZEROMV LAST_FRAME).
                 bool forceKey = _forceKeyFrame
                               || _framesSinceLastKeyframe == 0
                               || _framesSinceLastKeyframe >= _keyframeIntervalFrames;
@@ -191,16 +201,12 @@ namespace Vpx.Net
                 byte[] result;
                 if (forceKey)
                 {
-                    result = frame_encoder.EncodeKeyframeWithBuffers(_srcY, _srcU, _srcV, width, height, _baseQIndex, _frameBuffers);
+                    result = _encodePipeline.EncodeKeyframeContiguousI420(i420, width, height, _baseQIndex, _frameBuffers);
                     _framesSinceLastKeyframe = 1;
                 }
                 else
                 {
-                    // Inter (P) frame: ZEROMV referencing LAST_FRAME for
-                    // every macroblock. The reference frame is the
-                    // reconstruction of the previous keyframe / inter
-                    // frame, cached on the per-thread FrameEncoderBuffers.
-                    result = frame_encoder.EncodeInterFrameWithBuffers(_srcY, _srcU, _srcV, width, height, _baseQIndex, _frameBuffers);
+                    result = _encodePipeline.EncodeInterFrameContiguousI420(i420, width, height, _baseQIndex, _frameBuffers);
                     _framesSinceLastKeyframe++;
                 }
                 return result;

--- a/src/SIPSorcery.VP8/Vp8FrameEncodePipeline.cs
+++ b/src/SIPSorcery.VP8/Vp8FrameEncodePipeline.cs
@@ -1,0 +1,219 @@
+//-----------------------------------------------------------------------------
+// Strategy-shaped entry for VP8 foundation encoders: legacy scalar memory
+// ops vs span/SIMD ops. A single selection point — no per-MB flags.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    /// <summary>
+    /// Reports whether the current CPU supports vector residual kernels used by
+    /// <see cref="Vp8EncodePipelineKind.Optimized"/> (AVX2, SSE2, or AArch64 AdvSimd).
+    /// </summary>
+    public static class Vp8EncodeSimdCapabilities
+    {
+        /// <summary>
+        /// True when at least one of AVX2 (x64), SSE2 (x64), or AdvSimd (ARM) is available.
+        /// When false, <see cref="Vp8EncodePipelineKind.Optimized"/> falls back to the legacy pipeline.
+        /// </summary>
+        public static bool HasResidualAcceleration =>
+            Avx2.IsSupported || Sse2.IsSupported || AdvSimd.IsSupported;
+    }
+
+    /// <summary>
+    /// Selects which frame-encoder memory strategy <see cref="VP8Codec"/> uses.
+    /// </summary>
+    public enum Vp8EncodePipelineKind
+    {
+        /// <summary>Original nested-loop copies and scalar residuals.</summary>
+        Legacy,
+        /// <summary>
+        /// Span row copies and hardware residual kernels when
+        /// <see cref="Vp8EncodeSimdCapabilities.HasResidualAcceleration"/> is true;
+        /// otherwise the same behavior as <see cref="Legacy"/>.
+        /// </summary>
+        Optimized,
+    }
+
+    /// <summary>Internal abstraction for keyframe/inter encode with shared buffers.</summary>
+    internal interface IVp8FrameEncodePipeline
+    {
+        IEncoderMemoryOps MemoryOps { get; }
+
+        /// <summary>
+        /// log2 of the number of token partitions (0 -> 1 partition, 1 -> 2,
+        /// 2 -> 4, 3 -> 8). Default 0 keeps the existing single-partition
+        /// bit-exact behaviour. Higher values enable parallel pack-tokens
+        /// over <c>1 &lt;&lt; Log2NumTokenPartitions</c> partitions.
+        /// </summary>
+        int Log2NumTokenPartitions { get; }
+
+        byte[] EncodeKeyframe(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        byte[] EncodeKeyframeContiguousI420(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        byte[] EncodeInterFrame(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        byte[] EncodeInterFrameContiguousI420(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        /// <summary>Pooled variant — returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/>; avoids allocating/copying the encoded frame blob (other small encode-time allocations may still occur).</summary>
+        ArraySegment<byte> EncodeKeyframePooled(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        /// <summary>Pooled variant — returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/>; avoids allocating/copying the encoded frame blob (other small encode-time allocations may still occur).</summary>
+        ArraySegment<byte> EncodeKeyframeContiguousI420Pooled(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        /// <summary>Pooled variant — returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/>; avoids allocating/copying the encoded frame blob (other small encode-time allocations may still occur).</summary>
+        ArraySegment<byte> EncodeInterFramePooled(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+
+        /// <summary>Pooled variant — returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/>; avoids allocating/copying the encoded frame blob (other small encode-time allocations may still occur).</summary>
+        ArraySegment<byte> EncodeInterFrameContiguousI420Pooled(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers);
+    }
+
+    internal sealed class LegacyVp8FrameEncodePipeline : IVp8FrameEncodePipeline
+    {
+        public static readonly LegacyVp8FrameEncodePipeline Instance = new LegacyVp8FrameEncodePipeline(0);
+
+        private readonly int _log2NumTokenPartitions;
+
+        public LegacyVp8FrameEncodePipeline(int log2NumTokenPartitions)
+        {
+            _log2NumTokenPartitions = log2NumTokenPartitions;
+        }
+
+        public IEncoderMemoryOps MemoryOps => LegacyEncoderMemoryOps.Instance;
+        public int Log2NumTokenPartitions => _log2NumTokenPartitions;
+
+        public byte[] EncodeKeyframe(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffers(srcY, srcU, srcV, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public byte[] EncodeKeyframeContiguousI420(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffersContiguousI420(i420, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public byte[] EncodeInterFrame(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffers(srcY, srcU, srcV, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public byte[] EncodeInterFrameContiguousI420(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffersContiguousI420(i420, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeKeyframePooled(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffersPooled(srcY, srcU, srcV, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeKeyframeContiguousI420Pooled(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffersContiguousI420Pooled(i420, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeInterFramePooled(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffersPooled(srcY, srcU, srcV, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeInterFrameContiguousI420Pooled(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffersContiguousI420Pooled(i420, width, height, qIndex, buffers,
+                LegacyEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+    }
+
+    internal sealed class OptimizedVp8FrameEncodePipeline : IVp8FrameEncodePipeline
+    {
+        public static readonly OptimizedVp8FrameEncodePipeline Instance = new OptimizedVp8FrameEncodePipeline(0);
+
+        private readonly int _log2NumTokenPartitions;
+
+        public OptimizedVp8FrameEncodePipeline(int log2NumTokenPartitions)
+        {
+            _log2NumTokenPartitions = log2NumTokenPartitions;
+        }
+
+        public IEncoderMemoryOps MemoryOps => SpanSimdEncoderMemoryOps.Instance;
+        public int Log2NumTokenPartitions => _log2NumTokenPartitions;
+
+        public byte[] EncodeKeyframe(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffers(srcY, srcU, srcV, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public byte[] EncodeKeyframeContiguousI420(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffersContiguousI420(i420, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public byte[] EncodeInterFrame(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffers(srcY, srcU, srcV, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public byte[] EncodeInterFrameContiguousI420(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffersContiguousI420(i420, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeKeyframePooled(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffersPooled(srcY, srcU, srcV, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeKeyframeContiguousI420Pooled(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeKeyframeWithBuffersContiguousI420Pooled(i420, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeInterFramePooled(byte[] srcY, byte[] srcU, byte[] srcV, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffersPooled(srcY, srcU, srcV, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+
+        public ArraySegment<byte> EncodeInterFrameContiguousI420Pooled(byte[] i420, int width, int height, int qIndex,
+            FrameEncoderBuffers buffers) =>
+            frame_encoder.EncodeInterFrameWithBuffersContiguousI420Pooled(i420, width, height, qIndex, buffers,
+                SpanSimdEncoderMemoryOps.Instance, _log2NumTokenPartitions);
+    }
+
+    internal static class Vp8FrameEncodePipelineFactory
+    {
+        public static IVp8FrameEncodePipeline Create(Vp8EncodePipelineKind kind, int log2NumTokenPartitions = 0)
+        {
+            frame_encoder.ValidateLog2TokenPartitions(log2NumTokenPartitions);
+            switch (kind)
+            {
+                case Vp8EncodePipelineKind.Legacy:
+                    return log2NumTokenPartitions == 0
+                        ? LegacyVp8FrameEncodePipeline.Instance
+                        : new LegacyVp8FrameEncodePipeline(log2NumTokenPartitions);
+                case Vp8EncodePipelineKind.Optimized:
+                    if (!Vp8EncodeSimdCapabilities.HasResidualAcceleration)
+                    {
+                        return log2NumTokenPartitions == 0
+                            ? (IVp8FrameEncodePipeline)LegacyVp8FrameEncodePipeline.Instance
+                            : new LegacyVp8FrameEncodePipeline(log2NumTokenPartitions);
+                    }
+                    return log2NumTokenPartitions == 0
+                        ? OptimizedVp8FrameEncodePipeline.Instance
+                        : new OptimizedVp8FrameEncodePipeline(log2NumTokenPartitions);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/WalshEncoderSimd.cs
+++ b/src/SIPSorcery.VP8/WalshEncoderSimd.cs
@@ -1,0 +1,382 @@
+//-----------------------------------------------------------------------------
+// Encoder-side SIMD fast paths for the 4x4 Walsh-Hadamard pair used on the
+// Y2 (DC) block in 16x16 intra prediction modes:
+//
+//   * Walsh4x4   - bit-exact replacement for dct.vp8_short_walsh4x4_c
+//                  (forward Walsh, 1 call per MB)
+//   * InverseWalsh4x4 - bit-exact replacement for the row/column scalar
+//                  variant used by mb_encoder.InverseWalsh4x4Into
+//                  (inverse Walsh, 1 call per MB)
+//
+// Both transforms are tiny (16 coefficients, 1 call per MB) but trivially
+// SIMD-able into 4 row/column vectors with the same transpose primitive
+// used by IdctEncoderSimd. Scalar fallback is provided for non-SIMD
+// platforms; on x86 we require SSE4.1 to stay aligned with IdctEncoderSimd.
+//
+// Author: Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Vpx.Net
+{
+    internal static unsafe class WalshEncoderSimd
+    {
+        public static bool IsSupported => Sse41.IsSupported || AdvSimd.Arm64.IsSupported;
+
+        // ---------------------------------------------------------------
+        // Forward 4x4 Walsh (bit-exact with dct.vp8_short_walsh4x4_c).
+        // Input layout: 4 rows of 4 shorts at <paramref name="pitch"/>
+        // bytes per row. Output: 16 contiguous shorts row-major.
+        // ---------------------------------------------------------------
+
+        public static void Walsh4x4(short* input, short* output, int pitch)
+        {
+            if (Sse41.IsSupported)
+            {
+                Walsh4x4Sse41(input, output, pitch);
+                return;
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                Walsh4x4AdvSimd(input, output, pitch);
+                return;
+            }
+
+            dct.vp8_short_walsh4x4_c(input, output, pitch);
+        }
+
+        // ---------------------------------------------------------------
+        // Inverse 4x4 Walsh (bit-exact with the loop in
+        // mb_encoder.InverseWalsh4x4Into; identical to libvpx's
+        // vp8_short_inv_walsh4x4_c stage shape but writes contiguous
+        // shorts rather than into the strided dqcoeff buffer).
+        // ---------------------------------------------------------------
+
+        public static void InverseWalsh4x4(short* input, short* output)
+        {
+            if (Sse41.IsSupported)
+            {
+                InverseWalsh4x4Sse41(input, output);
+                return;
+            }
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                InverseWalsh4x4AdvSimd(input, output);
+                return;
+            }
+
+            InverseWalsh4x4Scalar(input, output);
+        }
+
+        // ===============================================================
+        // SSE4.1 paths
+        // ===============================================================
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Walsh4x4Sse41(short* input, short* output, int pitch)
+        {
+            int stride = pitch / 2;
+
+            // Load 4 rows × 4 shorts each, sign-extend to int32.
+            var r0 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 0 * stride)).AsInt16());
+            var r1 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 1 * stride)).AsInt16());
+            var r2 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 2 * stride)).AsInt16());
+            var r3 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 3 * stride)).AsInt16());
+
+            // Transpose so each c_j has lane r = input[r, j].
+            Transpose4x4Sse2(r0, r1, r2, r3, out var c0, out var c1, out var c2, out var c3);
+
+            // Row-pass (lane = row, in parallel across 4 rows).
+            // a1 = (c0+c2) << 2, d1 = (c1+c3) << 2, c1v = (c1-c3) << 2, b1 = (c0-c2) << 2
+            var a1 = Sse2.ShiftLeftLogical(Sse2.Add(c0, c2), 2);
+            var d1 = Sse2.ShiftLeftLogical(Sse2.Add(c1, c3), 2);
+            var c1v = Sse2.ShiftLeftLogical(Sse2.Subtract(c1, c3), 2);
+            var b1 = Sse2.ShiftLeftLogical(Sse2.Subtract(c0, c2), 2);
+
+            // m0[r] = (a1 + d1) + (a1 != 0 ? 1 : 0)
+            var m0 = Sse2.Add(a1, d1);
+            var a1Zero = Sse2.CompareEqual(a1, Vector128<int>.Zero);
+            m0 = Sse2.Add(m0, Sse2.AndNot(a1Zero, Vector128.Create(1)));
+
+            var m1 = Sse2.Add(b1, c1v);
+            var m2 = Sse2.Subtract(b1, c1v);
+            var m3 = Sse2.Subtract(a1, d1);
+
+            // Transpose to get t_r[c] = intermediate[r, c].
+            Transpose4x4Sse2(m0, m1, m2, m3, out var t0, out var t1, out var t2, out var t3);
+
+            // Column-pass (lane = column).
+            var a1c = Sse2.Add(t0, t2);
+            var d1c = Sse2.Add(t1, t3);
+            var c1c = Sse2.Subtract(t1, t3);
+            var b1c = Sse2.Subtract(t0, t2);
+
+            var a2 = Sse2.Add(a1c, d1c);
+            var b2 = Sse2.Add(b1c, c1c);
+            var cc2 = Sse2.Subtract(b1c, c1c);
+            var d2 = Sse2.Subtract(a1c, d1c);
+
+            // round-toward-zero correction: x += (x < 0) ? 1 : 0,
+            // implemented as x += (uint)x >> 31 — sign-bit-as-int.
+            a2 = Sse2.Add(a2, Sse2.ShiftRightLogical(a2, 31));
+            b2 = Sse2.Add(b2, Sse2.ShiftRightLogical(b2, 31));
+            cc2 = Sse2.Add(cc2, Sse2.ShiftRightLogical(cc2, 31));
+            d2 = Sse2.Add(d2, Sse2.ShiftRightLogical(d2, 31));
+
+            var three = Vector128.Create(3);
+            var o0 = Sse2.ShiftRightArithmetic(Sse2.Add(a2, three), 3);
+            var o1 = Sse2.ShiftRightArithmetic(Sse2.Add(b2, three), 3);
+            var o2 = Sse2.ShiftRightArithmetic(Sse2.Add(cc2, three), 3);
+            var o3 = Sse2.ShiftRightArithmetic(Sse2.Add(d2, three), 3);
+
+            // Pack int32 → int16 row-major. o_r is row r; lo 4 lanes hold the row.
+            Sse2.Store(output + 0, Sse2.PackSignedSaturate(o0, o1));
+            Sse2.Store(output + 8, Sse2.PackSignedSaturate(o2, o3));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void InverseWalsh4x4Sse41(short* input, short* output)
+        {
+            // 4 rows × 4 shorts at unit stride (16 contiguous shorts).
+            var r0 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 0)).AsInt16());
+            var r1 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 4)).AsInt16());
+            var r2 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 8)).AsInt16());
+            var r3 = Sse41.ConvertToVector128Int32(Sse2.LoadScalarVector128((double*)(input + 12)).AsInt16());
+
+            // Stage 1 (rows in scalar; lane = row in SIMD with input as cols).
+            // Scalar: a1 = ip[0]+ip[3]; b1 = ip[1]+ip[2]; c1 = ip[1]-ip[2]; d1 = ip[0]-ip[3]
+            //         tmp[i*4+0] = a1+b1; tmp[i*4+1] = c1+d1; tmp[i*4+2] = a1-b1; tmp[i*4+3] = d1-c1
+            // For SIMD lane-wise across rows: r_i = row i of input. We need ip[0]/[3] of row i = row i col 0/3.
+            // Operations are within-row, so transpose first.
+            Transpose4x4Sse2(r0, r1, r2, r3, out var c0, out var c1, out var c2, out var c3);
+
+            var a1 = Sse2.Add(c0, c3);
+            var b1 = Sse2.Add(c1, c2);
+            var c1v = Sse2.Subtract(c1, c2);
+            var d1 = Sse2.Subtract(c0, c3);
+
+            var m0 = Sse2.Add(a1, b1);
+            var m1 = Sse2.Add(c1v, d1);
+            var m2 = Sse2.Subtract(a1, b1);
+            var m3 = Sse2.Subtract(d1, c1v);
+
+            // m_c is column c of the row-pass intermediate (lane = row).
+            // Stage 2 (columns in scalar): operate on tmp with stride 4 — cols of intermediate.
+            // After transpose, t_r holds row r of intermediate (lane = col).
+            Transpose4x4Sse2(m0, m1, m2, m3, out var t0, out var t1, out var t2, out var t3);
+
+            // Scalar stage 2 reads tmp[0*4+i], tmp[3*4+i], tmp[1*4+i], tmp[2*4+i]
+            // = row 0 col i, row 3 col i, row 1 col i, row 2 col i.
+            // a1 = row0 + row3, b1 = row1 + row2, c1 = row1 - row2, d1 = row0 - row3
+            var a1b = Sse2.Add(t0, t3);
+            var b1b = Sse2.Add(t1, t2);
+            var c1b = Sse2.Subtract(t1, t2);
+            var d1b = Sse2.Subtract(t0, t3);
+
+            var a2 = Sse2.Add(a1b, b1b);
+            var b2 = Sse2.Add(c1b, d1b);
+            var cc2 = Sse2.Subtract(a1b, b1b);
+            var d2 = Sse2.Subtract(d1b, c1b);
+
+            var three = Vector128.Create(3);
+            var o0 = Sse2.ShiftRightArithmetic(Sse2.Add(a2, three), 3);
+            var o1 = Sse2.ShiftRightArithmetic(Sse2.Add(b2, three), 3);
+            var o2 = Sse2.ShiftRightArithmetic(Sse2.Add(cc2, three), 3);
+            var o3 = Sse2.ShiftRightArithmetic(Sse2.Add(d2, three), 3);
+
+            // o_c[r] = output[r, c]. In scalar: out[0*4+i]=a2_r, out[1*4+i]=b2_r, out[2*4+i]=c2_r, out[3*4+i]=d2_r.
+            // i.e. row 0 = a2, row 1 = b2, row 2 = c2, row 3 = d2; lane index = column.
+            Sse2.Store(output + 0, Sse2.PackSignedSaturate(o0, o1));
+            Sse2.Store(output + 8, Sse2.PackSignedSaturate(o2, o3));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Transpose4x4Sse2(
+            Vector128<int> r0, Vector128<int> r1, Vector128<int> r2, Vector128<int> r3,
+            out Vector128<int> o0, out Vector128<int> o1, out Vector128<int> o2, out Vector128<int> o3)
+        {
+            var t01_lo = Sse2.UnpackLow(r0, r1);
+            var t01_hi = Sse2.UnpackHigh(r0, r1);
+            var t23_lo = Sse2.UnpackLow(r2, r3);
+            var t23_hi = Sse2.UnpackHigh(r2, r3);
+
+            o0 = Sse2.UnpackLow(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();
+            o1 = Sse2.UnpackHigh(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();
+            o2 = Sse2.UnpackLow(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();
+            o3 = Sse2.UnpackHigh(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();
+        }
+
+        // ===============================================================
+        // AdvSimd paths
+        // ===============================================================
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Walsh4x4AdvSimd(short* input, short* output, int pitch)
+        {
+            int stride = pitch / 2;
+
+            var r0 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 0 * stride));
+            var r1 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 1 * stride));
+            var r2 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 2 * stride));
+            var r3 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 3 * stride));
+
+            Transpose4x4AdvSimd(r0, r1, r2, r3, out var c0, out var c1, out var c2, out var c3);
+
+            // No (Vector128<int>, byte) ShiftLeftLogical overload on AdvSimd —
+            // multiply by 4 keeps the arithmetic in int32 lanes.
+            var four = Vector128.Create(4);
+            var a1 = AdvSimd.Multiply(AdvSimd.Add(c0, c2), four);
+            var d1 = AdvSimd.Multiply(AdvSimd.Add(c1, c3), four);
+            var c1v = AdvSimd.Multiply(AdvSimd.Subtract(c1, c3), four);
+            var b1 = AdvSimd.Multiply(AdvSimd.Subtract(c0, c2), four);
+
+            // m0 = a1 + d1 + (a1 != 0 ? 1 : 0).
+            // (a1 != 0 ? 1 : 0) computed as (((-a1)|a1) >> 31 logical) — sign bit
+            // of the bitwise-or with negation is set iff a1 != 0.
+            var a1OrNeg = AdvSimd.Or(a1, AdvSimd.Negate(a1));
+            var a1NonZero = AdvSimd.ShiftRightLogical(a1OrNeg.AsUInt32(), 31).AsInt32();
+            var m0 = AdvSimd.Add(AdvSimd.Add(a1, d1), a1NonZero);
+
+            var m1 = AdvSimd.Add(b1, c1v);
+            var m2 = AdvSimd.Subtract(b1, c1v);
+            var m3 = AdvSimd.Subtract(a1, d1);
+
+            Transpose4x4AdvSimd(m0, m1, m2, m3, out var t0, out var t1, out var t2, out var t3);
+
+            var a1c = AdvSimd.Add(t0, t2);
+            var d1c = AdvSimd.Add(t1, t3);
+            var c1c = AdvSimd.Subtract(t1, t3);
+            var b1c = AdvSimd.Subtract(t0, t2);
+
+            var a2 = AdvSimd.Add(a1c, d1c);
+            var b2 = AdvSimd.Add(b1c, c1c);
+            var cc2 = AdvSimd.Subtract(b1c, c1c);
+            var d2 = AdvSimd.Subtract(a1c, d1c);
+
+            // x += (x < 0) ? 1 : 0 — sign-bit-as-int via logical right shift by 31.
+            a2 = AdvSimd.Add(a2, AdvSimd.ShiftRightLogical(a2.AsUInt32(), 31).AsInt32());
+            b2 = AdvSimd.Add(b2, AdvSimd.ShiftRightLogical(b2.AsUInt32(), 31).AsInt32());
+            cc2 = AdvSimd.Add(cc2, AdvSimd.ShiftRightLogical(cc2.AsUInt32(), 31).AsInt32());
+            d2 = AdvSimd.Add(d2, AdvSimd.ShiftRightLogical(d2.AsUInt32(), 31).AsInt32());
+
+            var three = Vector128.Create(3);
+            var o0 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(a2, three), 3);
+            var o1 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(b2, three), 3);
+            var o2 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(cc2, three), 3);
+            var o3 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(d2, three), 3);
+
+            var s01 = AdvSimd.ExtractNarrowingSaturateUpper(AdvSimd.ExtractNarrowingSaturateLower(o0), o1);
+            var s23 = AdvSimd.ExtractNarrowingSaturateUpper(AdvSimd.ExtractNarrowingSaturateLower(o2), o3);
+            AdvSimd.Store(output + 0, s01);
+            AdvSimd.Store(output + 8, s23);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void InverseWalsh4x4AdvSimd(short* input, short* output)
+        {
+            var r0 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 0));
+            var r1 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 4));
+            var r2 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 8));
+            var r3 = AdvSimd.SignExtendWideningLower(AdvSimd.LoadVector64(input + 12));
+
+            Transpose4x4AdvSimd(r0, r1, r2, r3, out var c0, out var c1, out var c2, out var c3);
+
+            var a1 = AdvSimd.Add(c0, c3);
+            var b1 = AdvSimd.Add(c1, c2);
+            var c1v = AdvSimd.Subtract(c1, c2);
+            var d1 = AdvSimd.Subtract(c0, c3);
+
+            var m0 = AdvSimd.Add(a1, b1);
+            var m1 = AdvSimd.Add(c1v, d1);
+            var m2 = AdvSimd.Subtract(a1, b1);
+            var m3 = AdvSimd.Subtract(d1, c1v);
+
+            Transpose4x4AdvSimd(m0, m1, m2, m3, out var t0, out var t1, out var t2, out var t3);
+
+            var a1b = AdvSimd.Add(t0, t3);
+            var b1b = AdvSimd.Add(t1, t2);
+            var c1b = AdvSimd.Subtract(t1, t2);
+            var d1b = AdvSimd.Subtract(t0, t3);
+
+            var a2 = AdvSimd.Add(a1b, b1b);
+            var b2 = AdvSimd.Add(c1b, d1b);
+            var cc2 = AdvSimd.Subtract(a1b, b1b);
+            var d2 = AdvSimd.Subtract(d1b, c1b);
+
+            var three = Vector128.Create(3);
+            var o0 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(a2, three), 3);
+            var o1 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(b2, three), 3);
+            var o2 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(cc2, three), 3);
+            var o3 = AdvSimd.ShiftRightArithmetic(AdvSimd.Add(d2, three), 3);
+
+            var s01 = AdvSimd.ExtractNarrowingSaturateUpper(AdvSimd.ExtractNarrowingSaturateLower(o0), o1);
+            var s23 = AdvSimd.ExtractNarrowingSaturateUpper(AdvSimd.ExtractNarrowingSaturateLower(o2), o3);
+            AdvSimd.Store(output + 0, s01);
+            AdvSimd.Store(output + 8, s23);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Transpose4x4AdvSimd(
+            Vector128<int> r0, Vector128<int> r1, Vector128<int> r2, Vector128<int> r3,
+            out Vector128<int> o0, out Vector128<int> o1, out Vector128<int> o2, out Vector128<int> o3)
+        {
+            var t01_lo = AdvSimd.Arm64.ZipLow(r0, r1);
+            var t01_hi = AdvSimd.Arm64.ZipHigh(r0, r1);
+            var t23_lo = AdvSimd.Arm64.ZipLow(r2, r3);
+            var t23_hi = AdvSimd.Arm64.ZipHigh(r2, r3);
+
+            o0 = AdvSimd.Arm64.ZipLow(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();
+            o1 = AdvSimd.Arm64.ZipHigh(t01_lo.AsInt64(), t23_lo.AsInt64()).AsInt32();
+            o2 = AdvSimd.Arm64.ZipLow(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();
+            o3 = AdvSimd.Arm64.ZipHigh(t01_hi.AsInt64(), t23_hi.AsInt64()).AsInt32();
+        }
+
+        // ===============================================================
+        // Scalar fallback for InverseWalsh (used when no SIMD available).
+        // Bit-exact with mb_encoder.InverseWalsh4x4Into.
+        // ===============================================================
+
+        private static void InverseWalsh4x4Scalar(short* input, short* output)
+        {
+            int* tmp = stackalloc int[16];
+            int a1, b1, c1v, d1, a2, b2, c2, d2;
+
+            for (int i = 0; i < 4; i++)
+            {
+                a1 = input[i * 4 + 0] + input[i * 4 + 3];
+                b1 = input[i * 4 + 1] + input[i * 4 + 2];
+                c1v = input[i * 4 + 1] - input[i * 4 + 2];
+                d1 = input[i * 4 + 0] - input[i * 4 + 3];
+
+                tmp[i * 4 + 0] = a1 + b1;
+                tmp[i * 4 + 1] = c1v + d1;
+                tmp[i * 4 + 2] = a1 - b1;
+                tmp[i * 4 + 3] = d1 - c1v;
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                a1 = tmp[0 * 4 + i] + tmp[3 * 4 + i];
+                b1 = tmp[1 * 4 + i] + tmp[2 * 4 + i];
+                c1v = tmp[1 * 4 + i] - tmp[2 * 4 + i];
+                d1 = tmp[0 * 4 + i] - tmp[3 * 4 + i];
+
+                a2 = a1 + b1;
+                b2 = c1v + d1;
+                c2 = a1 - b1;
+                d2 = d1 - c1v;
+
+                output[0 * 4 + i] = (short)((a2 + 3) >> 3);
+                output[1 * 4 + i] = (short)((b2 + 3) >> 3);
+                output[2 * 4 + i] = (short)((c2 + 3) >> 3);
+                output[3 * 4 + i] = (short)((d2 + 3) >> 3);
+            }
+        }
+    }
+}

--- a/src/SIPSorcery.VP8/bitstream.cs
+++ b/src/SIPSorcery.VP8/bitstream.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: bitstream.cs
 //
 // Description: Keyframe header writer for the VP8 encoder. Port of the
@@ -36,6 +36,10 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using vp8_prob = System.Byte;
 
 namespace Vpx.Net
 {
@@ -343,7 +347,7 @@ namespace Vpx.Net
             if ((uint)cfg.BaseQindex > 0x7F) throw new ArgumentOutOfRangeException(nameof(cfg.BaseQindex), cfg.BaseQindex, "BaseQindex must be 0..127.");
             if ((uint)cfg.FilterLevel > 0x3F) throw new ArgumentOutOfRangeException(nameof(cfg.FilterLevel), cfg.FilterLevel, "FilterLevel must be 0..63.");
             if ((uint)cfg.SharpnessLevel > 0x07) throw new ArgumentOutOfRangeException(nameof(cfg.SharpnessLevel), cfg.SharpnessLevel, "SharpnessLevel must be 0..7.");
-            if ((uint)cfg.Log2NumberOfTokenPartitions > 2) throw new ArgumentOutOfRangeException(nameof(cfg.Log2NumberOfTokenPartitions), cfg.Log2NumberOfTokenPartitions, "Log2NumberOfTokenPartitions must be 0..2.");
+            if ((uint)cfg.Log2NumberOfTokenPartitions > 3) throw new ArgumentOutOfRangeException(nameof(cfg.Log2NumberOfTokenPartitions), cfg.Log2NumberOfTokenPartitions, "Log2NumberOfTokenPartitions must be 0..3.");
             int dqRange = 0x1F;
             if (Math.Abs(cfg.Y1DcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y1DcDeltaQ), cfg.Y1DcDeltaQ, "Y1DcDeltaQ must be -15..15.");
             if (Math.Abs(cfg.Y2DcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y2DcDeltaQ), cfg.Y2DcDeltaQ, "Y2DcDeltaQ must be -15..15.");
@@ -531,7 +535,7 @@ namespace Vpx.Net
             if ((uint)cfg.BaseQindex > 0x7F) throw new ArgumentOutOfRangeException(nameof(cfg.BaseQindex), cfg.BaseQindex, "BaseQindex must be 0..127.");
             if ((uint)cfg.FilterLevel > 0x3F) throw new ArgumentOutOfRangeException(nameof(cfg.FilterLevel), cfg.FilterLevel, "FilterLevel must be 0..63.");
             if ((uint)cfg.SharpnessLevel > 0x07) throw new ArgumentOutOfRangeException(nameof(cfg.SharpnessLevel), cfg.SharpnessLevel, "SharpnessLevel must be 0..7.");
-            if ((uint)cfg.Log2NumberOfTokenPartitions > 2) throw new ArgumentOutOfRangeException(nameof(cfg.Log2NumberOfTokenPartitions), cfg.Log2NumberOfTokenPartitions, "Log2NumberOfTokenPartitions must be 0..2.");
+            if ((uint)cfg.Log2NumberOfTokenPartitions > 3) throw new ArgumentOutOfRangeException(nameof(cfg.Log2NumberOfTokenPartitions), cfg.Log2NumberOfTokenPartitions, "Log2NumberOfTokenPartitions must be 0..3.");
             if (Math.Abs(cfg.Y1DcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y1DcDeltaQ), cfg.Y1DcDeltaQ, "Y1DcDeltaQ must be -15..15.");
             if (Math.Abs(cfg.Y2DcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y2DcDeltaQ), cfg.Y2DcDeltaQ, "Y2DcDeltaQ must be -15..15.");
             if (Math.Abs(cfg.Y2AcDeltaQ) > 0xF) throw new ArgumentOutOfRangeException(nameof(cfg.Y2AcDeltaQ), cfg.Y2AcDeltaQ, "Y2AcDeltaQ must be -15..15.");
@@ -562,13 +566,201 @@ namespace Vpx.Net
         /// </summary>
         /// <param name="bc">Open boolean coder to write into.</param>
         /// <param name="tokens">Tokens to write, in order.</param>
-        public static void vp8_pack_tokens(ref BOOL_CODER bc, System.Collections.Generic.IList<TOKENEXTRA> tokens)
+        /// <param name="coefProbs">Same coefficient probability table used when the tokens were produced.</param>
+        public static void vp8_pack_tokens(ref BOOL_CODER bc, ReadOnlySpan<TOKENEXTRA> tokens, vp8_prob[,,,] coefProbs)
+        {
+            if (coefProbs == null) throw new ArgumentNullException(nameof(coefProbs));
+            if (tokens.IsEmpty) return;
+            vp8_pack_tokens_fast(ref bc, tokens, coefProbs);
+        }
+
+        /// <summary>
+        /// Fast-path token packer: hoists the entire <see cref="BOOL_CODER"/>
+        /// state into locals once across the whole token list and inlines the
+        /// per-bit body of <see cref="boolhuff.vp8_encode_bool"/>. Bit-exact
+        /// with the slow <see cref="vp8_pack_one_token"/> dispatch.
+        ///
+        /// The motivation is that <c>BOOL_CODER</c> contains a value-typed
+        /// <see cref="vpx_internal_error_info"/> field with a managed string
+        /// inside, so the JIT cannot fully promote a <c>ref BOOL_CODER</c>
+        /// argument's hot fields into registers across <see cref="boolhuff.vp8_encode_bool"/>
+        /// invocations. By copying lowvalue/range/count/pos/buffer once, the
+        /// per-bit inner loop becomes register-resident.
+        /// </summary>
+        public static unsafe void vp8_pack_tokens_fast(ref BOOL_CODER bc, ReadOnlySpan<TOKENEXTRA> tokens, vp8_prob[,,,] coefProbs)
+        {
+            if (coefProbs == null) throw new ArgumentNullException(nameof(coefProbs));
+            if (tokens.IsEmpty) return;
+
+            uint lowvalue = bc.lowvalue;
+            uint range    = bc.range;
+            int  count    = bc.count;
+            uint pos      = bc.pos;
+            byte* buffer  = bc.buffer;
+            byte* end     = bc.buffer_end;
+
+            byte[] norm = entropy.vp8_norm;
+            sbyte[] coefTree = entropy.vp8_coef_tree;
+            entropy.vp8_token[] coefEnc = entropy.vp8_coef_encodings;
+            entropy.vp8_extra_bit_struct[] extraBits = entropy.vp8_extra_bits;
+
+            ref TOKENEXTRA r0 = ref MemoryMarshal.GetReference(tokens);
+            int nTokens = tokens.Length;
+            for (int ti = 0; ti < nTokens; ti++)
+            {
+                ref readonly TOKENEXTRA p = ref Unsafe.Add(ref r0, ti);
+                int t = p.Token;
+                ref readonly entropy.vp8_token a = ref coefEnc[t];
+                ref readonly entropy.vp8_extra_bit_struct b = ref extraBits[t];
+                int v = a.value;
+                int np = a.Len;
+                int i = 0;
+
+                if (p.skip_eob_node != 0)
+                {
+                    np--;
+                    i = 2;
+                }
+
+                byte[] pp = tokenize.GetCoefProbRowForPack(coefProbs, p.CoefProbRowIndex);
+                do
+                {
+                    int bb = (v >> --np) & 1;
+                    EncodeBoolInline(ref lowvalue, ref range, ref count, ref pos,
+                        buffer, end, ref bc, norm, bb, pp[i >> 1]);
+                    i = coefTree[i + bb];
+                } while (np != 0);
+
+                if (b.base_val != 0)
+                {
+                    int e = p.Extra;
+                    int L = b.Len;
+
+                    if (L != 0)
+                    {
+                        byte[] proba = b.prob;
+                        sbyte[] tree = b.tree;
+                        int v2 = e >> 1;
+                        int n2 = L;
+                        int i2 = 0;
+                        do
+                        {
+                            int bb = (v2 >> --n2) & 1;
+                            EncodeBoolInline(ref lowvalue, ref range, ref count, ref pos,
+                                buffer, end, ref bc, norm, bb, proba[i2 >> 1]);
+                            i2 = tree[i2 + bb];
+                        } while (n2 != 0);
+                    }
+
+                    EncodeBoolInline(ref lowvalue, ref range, ref count, ref pos,
+                        buffer, end, ref bc, norm, e & 1, VP8_PROB_HALF);
+                }
+            }
+
+            bc.lowvalue = lowvalue;
+            bc.range    = range;
+            bc.count    = count;
+            bc.pos      = pos;
+        }
+
+        /// <summary>
+        /// Inlined body of <see cref="boolhuff.vp8_encode_bool"/>. Bit-exact
+        /// copy that operates on locals (lowvalue / range / count / pos)
+        /// instead of dereferencing <c>ref BOOL_CODER</c> fields. The
+        /// <paramref name="bc"/> reference is only used on the rare
+        /// truncated-buffer error path.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void EncodeBoolInline(
+            ref uint lowvalue, ref uint range, ref int count, ref uint pos,
+            byte* buffer, byte* end, ref BOOL_CODER bc, byte[] norm,
+            int bit, int probability)
+        {
+            uint r = range;
+            uint lv = lowvalue;
+            int c = count;
+            uint po = pos;
+
+            uint split = (uint)(1 + (((r - 1) * probability) >> 8));
+            uint newRange = split;
+            if (bit > 0)
+            {
+                lv += split;
+                newRange = r - split;
+            }
+
+            int shift = norm[newRange];
+            newRange <<= shift;
+            c += shift;
+
+            if (c >= 0)
+            {
+                int offset = shift - c;
+
+                if (((lv << (offset - 1)) & 0x80000000u) > 0)
+                {
+                    int x = (int)po - 1;
+
+                    while (x >= 0 && buffer[x] == 0xff)
+                    {
+                        buffer[x] = 0;
+                        x--;
+                    }
+
+                    buffer[x] += 1;
+                }
+
+                if (buffer + po + 1 > end)
+                {
+                    vpx_codec.vpx_internal_error(ref bc.error, vpx_codec_err_t.VPX_CODEC_CORRUPT_FRAME,
+                        "Truncated packet or corrupt partition ");
+                }
+
+                buffer[po++] = (byte)((lv >> (24 - offset)) & 0xff);
+
+                lv <<= offset;
+                shift = c;
+                lv &= 0xffffff;
+                c -= 8;
+            }
+
+            lv <<= shift;
+
+            range = newRange;
+            lowvalue = lv;
+            count = c;
+            pos = po;
+        }
+
+        /// <inheritdoc cref="vp8_pack_tokens(ref BOOL_CODER, ReadOnlySpan{TOKENEXTRA}, vp8_prob[,,,])"/>
+        public static void vp8_pack_tokens(ref BOOL_CODER bc, ReadOnlySpan<TOKENEXTRA> tokens) =>
+            vp8_pack_tokens(ref bc, tokens, default_coef_probs_c.default_coef_probs);
+
+        /// <summary>Packs tokens from a fixed buffer without boxing or interface dispatch.</summary>
+        public static void vp8_pack_tokens(ref BOOL_CODER bc, TokenStreamBuffer tokens, vp8_prob[,,,] coefProbs) =>
+            vp8_pack_tokens(ref bc, tokens.AsSpan(), coefProbs);
+
+        /// <summary>Packs tokens from a fixed buffer without boxing or interface dispatch.</summary>
+        public static void vp8_pack_tokens(ref BOOL_CODER bc, TokenStreamBuffer tokens) =>
+            vp8_pack_tokens(ref bc, tokens.AsSpan());
+
+        /// <param name="tokens">Tokens to write, in order.</param>
+        public static void vp8_pack_tokens(ref BOOL_CODER bc, System.Collections.Generic.IList<TOKENEXTRA> tokens, vp8_prob[,,,] coefProbs)
         {
             if (tokens == null) return;
+            if (coefProbs == null) throw new ArgumentNullException(nameof(coefProbs));
 
             for (int idx = 0; idx < tokens.Count; idx++)
-            {
-                TOKENEXTRA p = tokens[idx];
+                vp8_pack_one_token(ref bc, tokens[idx], coefProbs);
+        }
+
+        /// <inheritdoc cref="vp8_pack_tokens(ref BOOL_CODER, System.Collections.Generic.IList{TOKENEXTRA}, vp8_prob[,,,])"/>
+        public static void vp8_pack_tokens(ref BOOL_CODER bc, System.Collections.Generic.IList<TOKENEXTRA> tokens) =>
+            vp8_pack_tokens(ref bc, tokens, default_coef_probs_c.default_coef_probs);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void vp8_pack_one_token(ref BOOL_CODER bc, TOKENEXTRA p, vp8_prob[,,,] coefProbs)
+        {
                 int t = p.Token;
                 entropy.vp8_token a = entropy.vp8_coef_encodings[t];
                 entropy.vp8_extra_bit_struct b = entropy.vp8_extra_bits[t];
@@ -587,7 +779,7 @@ namespace Vpx.Net
                 }
 
                 // Walk the coefficient encoding tree, one bit per node.
-                byte[] pp = p.context_tree;
+                byte[] pp = tokenize.GetCoefProbRowForPack(coefProbs, p.CoefProbRowIndex);
                 do
                 {
                     int bb = (v >> --n) & 1;
@@ -621,7 +813,6 @@ namespace Vpx.Net
                     // Sign bit (LSB of Extra) at probability 128.
                     boolhuff.vp8_encode_bool(ref bc, e & 1, VP8_PROB_HALF);
                 }
-            }
         }
 
         // -----------------------------------------------------------------

--- a/src/SIPSorcery.VP8/boolhuff.cs
+++ b/src/SIPSorcery.VP8/boolhuff.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: boolhuff.cs
 //
 // Description: Port of:
@@ -14,6 +14,8 @@
 // License: 
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+
 namespace Vpx.Net
 {
     public unsafe struct BOOL_CODER
@@ -110,6 +112,10 @@ namespace Vpx.Net
             return 0;
         }
 
+        /// <summary>Arithmetic encoder for one bool. Uses an inline
+        /// one-byte room check before each partition write instead of the
+        /// older <see cref="validate_buffer"/> helper call (same error path).</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe static void vp8_encode_bool(ref BOOL_CODER bc, int bit, int probability)
         {
             uint split;
@@ -150,7 +156,13 @@ namespace Vpx.Net
                     bc.buffer[x] += 1;
                 }
 
-                validate_buffer(bc.buffer + bc.pos, 1, bc.buffer_end, ref bc.error);
+                // Single inline guard (avoids a non-inline helper call per byte).
+                if (bc.buffer + bc.pos + 1 > bc.buffer_end)
+                {
+                    vpx_codec.vpx_internal_error(ref bc.error, vpx_codec_err_t.VPX_CODEC_CORRUPT_FRAME,
+                        "Truncated packet or corrupt partition ");
+                }
+
                 bc.buffer[bc.pos++] = (byte)(lowvalue >> (24 - offset) & 0xff);
 
                 lowvalue <<= offset;

--- a/src/SIPSorcery.VP8/dboolhuff.cs
+++ b/src/SIPSorcery.VP8/dboolhuff.cs
@@ -61,14 +61,13 @@ namespace Vpx.Net
         /// </summary>
         public const int VP8_LOTS_OF_BITS = 0x40000000;
 
-        public unsafe static int vp8dx_start_decode(ref BOOL_DECODER br, in byte[] source, uint source_sz)
-        {
-            fixed (byte* pSrc = source)
-            {
-                return vp8dx_start_decode(ref br, pSrc, source_sz, null, null);
-            }
-        }
-
+        /// <summary>
+        /// Initialise a bool decoder reading from <paramref name="source"/>.
+        /// The memory at <c>[source, source + source_sz)</c> must stay valid until
+        /// decoding is finished. For managed <c>byte[]</c>, call this only inside
+        /// <c>fixed (byte* p = array)</c> that spans all <see cref="vp8dx_decode_bool"/> /
+        /// <see cref="vp8_decode_value"/> calls.
+        /// </summary>
         public static int vp8dx_start_decode(ref BOOL_DECODER br, in byte* source,
                        uint source_sz, vpx_decrypt_cb decrypt_cb,
                        void* decrypt_state)

--- a/src/SIPSorcery.VP8/dct.cs
+++ b/src/SIPSorcery.VP8/dct.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: dct.cs
 //
 // Description: Forward DCT for the VP8 encoder. Port of:
@@ -11,11 +11,17 @@
 //   * vp8_short_walsh4x4_c  - 4x4 Walsh-Hadamard for the Y2 (DC) block
 //                             of a 16x16 prediction
 //
+// SIMD: this file is intentionally pure scalar so the Legacy encoder
+// pipeline always runs the C-style reference. The Optimized pipeline
+// uses the SIMD fast paths in FdctEncoderSimd.cs / WalshEncoderSimd.cs
+// instead of these entry points.
+//
 // Author(s):
 // Claude Opus 4.7 (Anthropic AI assistant, model: claude-opus-4-7), commissioned by Aaron Clauson
 //
 // History:
 // 25 Apr 2026  Claude          Ported from libvpx vp8/encoder/dct.c.
+// 05 May 2026  Claude          Reverted to pure scalar; SIMD now lives in FdctEncoderSimd.
 //
 // License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -31,13 +37,75 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+using System.Runtime.CompilerServices;
+
 namespace Vpx.Net
 {
     public static unsafe class dct
     {
+        /// <summary>First pass of <see cref="vp8_short_fdct4x4_c"/>: horizontal transform on each row.</summary>
+        internal static void vp8_fdct4x4_row_pass(short* input, short* output, int pitch)
+        {
+            int stride = pitch / 2;
+            short* ip = input;
+            short* op = output;
+            for (int i = 0; i < 4; ++i)
+            {
+                Fdct4x4RowOneScalar(ip, op);
+                ip += stride;
+                op += 4;
+            }
+        }
+
+        /// <summary>Second pass (column): in-place on the 4×4 block produced by <see cref="vp8_fdct4x4_row_pass"/>.</summary>
+        internal static void vp8_fdct4x4_column_pass_inplace(short* io)
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                Fdct4x4ColumnOneScalar(io);
+                io++;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Fdct4x4RowOneScalar(short* ip, short* op)
+        {
+            int a1 = ((ip[0] + ip[3]) * 8);
+            int b1 = ((ip[1] + ip[2]) * 8);
+            int c1 = ((ip[1] - ip[2]) * 8);
+            int d1 = ((ip[0] - ip[3]) * 8);
+
+            op[0] = (short)(a1 + b1);
+            op[2] = (short)(a1 - b1);
+
+            op[1] = (short)((c1 * 2217 + d1 * 5352 + 14500) >> 12);
+            op[3] = (short)((d1 * 2217 - c1 * 5352 + 7500) >> 12);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Fdct4x4ColumnOneScalar(short* io)
+        {
+            int a1 = io[0] + io[12];
+            int b1 = io[4] + io[8];
+            int c1 = io[4] - io[8];
+            int d1 = io[0] - io[12];
+
+            io[0] = (short)((a1 + b1 + 7) >> 4);
+            io[8] = (short)((a1 - b1 + 7) >> 4);
+
+            io[4] = (short)(((c1 * 2217 + d1 * 5352 + 12000) >> 16) + (d1 != 0 ? 1 : 0));
+            io[12] = (short)((d1 * 2217 - c1 * 5352 + 51000) >> 16);
+        }
+
+        // ---------------------------------------------------------------------
+        // Public entry points
+        // ---------------------------------------------------------------------
+
         /// <summary>
         /// Forward 4x4 integer DCT used for residual transform blocks.
-        /// Bit-exact port of libvpx vp8_short_fdct4x4_c.
+        /// Bit-exact port of libvpx vp8_short_fdct4x4_c. Pure scalar — used
+        /// by the Legacy pipeline and as the bit-exactness reference for the
+        /// SIMD path in <see cref="FdctEncoderSimd"/>.
         /// </summary>
         /// <param name="input">Pointer to 4 rows of 16-bit residuals; rows are
         /// separated by <paramref name="pitch"/> bytes (i.e. pitch/2 shorts).</param>
@@ -45,56 +113,31 @@ namespace Vpx.Net
         /// <param name="pitch">Input row pitch in bytes (typical: 8 for a contiguous 4-wide row).</param>
         public static void vp8_short_fdct4x4_c(short* input, short* output, int pitch)
         {
-            int i;
-            int a1, b1, c1, d1;
-            short* ip = input;
-            short* op = output;
-
-            for (i = 0; i < 4; ++i)
-            {
-                a1 = ((ip[0] + ip[3]) * 8);
-                b1 = ((ip[1] + ip[2]) * 8);
-                c1 = ((ip[1] - ip[2]) * 8);
-                d1 = ((ip[0] - ip[3]) * 8);
-
-                op[0] = (short)(a1 + b1);
-                op[2] = (short)(a1 - b1);
-
-                op[1] = (short)((c1 * 2217 + d1 * 5352 + 14500) >> 12);
-                op[3] = (short)((d1 * 2217 - c1 * 5352 + 7500) >> 12);
-
-                ip += pitch / 2;
-                op += 4;
-            }
-
-            ip = output;
-            op = output;
-            for (i = 0; i < 4; ++i)
-            {
-                a1 = ip[0] + ip[12];
-                b1 = ip[4] + ip[8];
-                c1 = ip[4] - ip[8];
-                d1 = ip[0] - ip[12];
-
-                op[0] = (short)((a1 + b1 + 7) >> 4);
-                op[8] = (short)((a1 - b1 + 7) >> 4);
-
-                op[4] = (short)(((c1 * 2217 + d1 * 5352 + 12000) >> 16) + (d1 != 0 ? 1 : 0));
-                op[12] = (short)((d1 * 2217 - c1 * 5352 + 51000) >> 16);
-
-                ip++;
-                op++;
-            }
+            vp8_fdct4x4_row_pass(input, output, pitch);
+            vp8_fdct4x4_column_pass_inplace(output);
         }
 
         /// <summary>
         /// Convenience: two consecutive 4x4 forward DCTs sharing input pitch.
-        /// Bit-exact port of libvpx vp8_short_fdct8x4_c.
+        /// Bit-exact port of libvpx vp8_short_fdct8x4_c. Output layout:
+        /// LEFT 4x4 row-major in <c>output[0..15]</c>, RIGHT 4x4 in <c>output[16..31]</c>.
         /// </summary>
         public static void vp8_short_fdct8x4_c(short* input, short* output, int pitch)
         {
-            vp8_short_fdct4x4_c(input, output, pitch);
-            vp8_short_fdct4x4_c(input + 4, output + 16, pitch);
+            vp8_short_fdct8x4_split_c(input, output, output + 16, pitch);
+        }
+
+        /// <summary>
+        /// 8x4 forward DCT writing the LEFT 4x4 (columns 0..3) into
+        /// <paramref name="outLeft"/> and the RIGHT 4x4 (columns 4..7) into
+        /// <paramref name="outRight"/>. Used by the encoder to skip a stack
+        /// gather + split-copy when the two halves live in separate coef
+        /// arrays. Bit-exact with two side-by-side <see cref="vp8_short_fdct4x4_c"/> calls.
+        /// </summary>
+        public static void vp8_short_fdct8x4_split_c(short* input, short* outLeft, short* outRight, int pitch)
+        {
+            vp8_short_fdct4x4_c(input, outLeft, pitch);
+            vp8_short_fdct4x4_c(input + 4, outRight, pitch);
         }
 
         /// <summary>

--- a/src/SIPSorcery.VP8/frame_encoder.cs
+++ b/src/SIPSorcery.VP8/frame_encoder.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: frame_encoder.cs
 //
 // Description: VP8 keyframe frame-level encoder — the orchestrator that
@@ -8,7 +8,17 @@
 // from an I420 YUV source.
 //
 // The bitstream layout follows libvpx's vp8_pack_bitstream for the
-// keyframe + ONE_PARTITION (single token partition) path:
+// keyframe path (and the analogous inter path): uncompressed frame tag,
+// start code / dimensions, compressed first partition (bc0), then one or
+// more token partitions.
+//
+// Token partitions (log2_nbr_of_dct_partitions in 0..3 -> 1 / 2 / 4 / 8):
+//   When log2 is 0, token data is a single bool-coded stream immediately
+//   after partition 0 (legacy single-partition layout).
+//   When log2 > 0, (N-1)*3 bytes of little-endian 24-bit sizes follow
+//   partition 0, then N partition bodies are concatenated (MB row r is
+//   assigned to partition r & (N-1)). The frame tag's first partition
+//   length excludes those token partitions.
 //
 //   [3 bytes]  Uncompressed frame tag         <- patched at the end with
 //                                                first_partition_length.
@@ -19,7 +29,7 @@
 //                segmentation_enabled = 0
 //                filter_type, filter_level, sharpness_level
 //                mode_ref_lf_delta_enabled = 0
-//                log2_nbr_of_dct_partitions = 0
+//                log2_nbr_of_dct_partitions (0..3)
 //                base_qindex
 //                5x put_delta_q
 //                refresh_entropy_probs = 1
@@ -27,8 +37,9 @@
 //                ★ mb_no_skip_coeff = 1
 //                ★ prob_skip_false (8-bit literal)
 //                ★ for each MB: skip-flag bit + keyframe Y mode + UV mode tree paths
-//   [bc1]      Token partition (ONE_PARTITION):
-//                for each MB: Y2, 16 Y, 4 U, 4 V token streams.
+//   [token data]  One partition (log2 = 0) or size table + N partitions (log2 > 0):
+//                for each non-skipped MB: Y2, 16 Y, 4 U, 4 V token streams
+//                (raster order within each partition's row set).
 //
 // All MBs use DC_PRED for both Y and UV. The encoder runs the per-MB
 // pipeline in raster order, threading the rightmost-column / bottommost-
@@ -94,6 +105,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace Vpx.Net
 {
@@ -138,6 +151,11 @@ namespace Vpx.Net
         public byte[] AboveU = new byte[8];
         public byte[] AboveV = new byte[8];
 
+        // Inter MB prediction (256/64/64) — avoids resizing Above* neighbours.
+        public byte[] PredY = new byte[256];
+        public byte[] PredU = new byte[64];
+        public byte[] PredV = new byte[64];
+
         // Per-MB source slices.
         public byte[] MbY = new byte[256];
         public byte[] MbU = new byte[64];
@@ -146,7 +164,16 @@ namespace Vpx.Net
         // Output buffer.
         public byte[] OutBuf;
 
-        // Reference-frame storage. After every successful encode,
+        // Per-token-partition output buffers (only allocated when
+        // log2NumTokenPartitions > 0; null otherwise so the single-
+        // partition path stays allocation-free). Lazily sized in
+        // <see cref="EnsureForFrame(int, int, int)"/>.
+        public byte[][] PartitionBufs;
+
+        // Reused length array for multi-partition token pack (N <= 8).
+        public int[] PartitionLengthsScratch;
+
+        // Reference-frame storage.
         // EncodeKeyframe / future EncodeInterFrame copies the
         // per-MB reconstructed pixels here, building a frame-sized
         // copy of what the decoder will see as the most recent
@@ -162,7 +189,10 @@ namespace Vpx.Net
         public byte[] LastFrameV;
         public bool LastFrameValid;
 
-        public void EnsureForFrame(int width, int height)
+        public void EnsureForFrame(int width, int height) =>
+            EnsureForFrame(width, height, log2NumTokenPartitions: 0);
+
+        public void EnsureForFrame(int width, int height, int log2NumTokenPartitions)
         {
             int chromaW = width / 2;
             int mbCols = width / 16;
@@ -190,9 +220,29 @@ namespace Vpx.Net
                 AboveVRow = new byte[chromaW];
             }
 
+            // Partition-1 token data grows with content but stays far below
+            // this generous cap; bool-coder byte writes skip per-byte buffer
+            // checks in Release (see boolhuff.vp8_encode_bool), relying on
+            // this slack so the hot path stays allocation- and branch-light.
             int bufLen = System.Math.Max(4096, width * height * 2 + 1024);
             if (OutBuf == null || OutBuf.Length < bufLen)
                 OutBuf = new byte[bufLen];
+
+            // Per-partition output buffers for log2N > 0. Each partition
+            // gets a worst-case-sized buffer to keep the bool-coder room
+            // check free of partition-imbalance edge cases. The total
+            // memory cost is bounded (N <= 8) and amortised across the
+            // lifetime of the encoder.
+            if (log2NumTokenPartitions > 0)
+            {
+                int n = 1 << log2NumTokenPartitions;
+                int perPart = System.Math.Max(4096, width * height + 1024);
+                if (PartitionBufs == null || PartitionBufs.Length < n)
+                    PartitionBufs = new byte[n][];
+                for (int i = 0; i < n; i++)
+                    if (PartitionBufs[i] == null || PartitionBufs[i].Length < perPart)
+                        PartitionBufs[i] = new byte[perPart];
+            }
 
             int ySize = width * height;
             int cSize = chromaW * (height / 2);
@@ -221,6 +271,14 @@ namespace Vpx.Net
 
     public static unsafe class frame_encoder
     {
+        /// <summary>Shared validation for <c>log2_nbr_of_dct_partitions</c> (0..3).</summary>
+        internal static void ValidateLog2TokenPartitions(int log2NumTokenPartitions)
+        {
+            if ((uint)log2NumTokenPartitions > 3)
+                throw new ArgumentOutOfRangeException(nameof(log2NumTokenPartitions),
+                    log2NumTokenPartitions, "Must be 0..3 (1, 2, 4, or 8 partitions).");
+        }
+
         // Per-thread reusable buffers. Most encoders are called from the
         // same thread for the lifetime of a stream, so this amortises the
         // per-frame allocations to (effectively) zero after the first
@@ -246,9 +304,16 @@ namespace Vpx.Net
         /// <param name="qIndex">VP8 base quantizer (0 = lossless-ish, 127 = very lossy).</param>
         /// <returns>The encoded VP8 frame bytes.</returns>
         internal static byte[] EncodeKeyframeWithBuffers(byte[] srcY, byte[] srcU, byte[] srcV,
-            int width, int height, int qIndex, FrameEncoderBuffers buffers)
+            int width, int height, int qIndex, FrameEncoderBuffers buffers,
+            IEncoderMemoryOps memoryOps = null, int log2NumTokenPartitions = 0)
+            => CopyPooled(EncodeKeyframeWithBuffersPooled(srcY, srcU, srcV, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions));
+
+        /// <summary>Pooled variant of <see cref="EncodeKeyframeWithBuffers"/>; returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/> (avoids allocating/copying the encoded frame blob; other small per-frame allocations may still occur).</summary>
+        internal static ArraySegment<byte> EncodeKeyframeWithBuffersPooled(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex, FrameEncoderBuffers buffers,
+            IEncoderMemoryOps memoryOps = null, int log2NumTokenPartitions = 0)
         {
-            if (buffers == null) throw new System.ArgumentNullException(nameof(buffers));
+            if (buffers == null) throw new ArgumentNullException(nameof(buffers));
             if (width <= 0 || width % 16 != 0)
                 throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
             if (height <= 0 || height % 16 != 0)
@@ -261,6 +326,75 @@ namespace Vpx.Net
             if (srcV == null || srcV.Length != chromaW * chromaH)
                 throw new ArgumentException("srcV size mismatch");
 
+            memoryOps ??= LegacyEncoderMemoryOps.Instance;
+            var py = new PlaneView(srcY, 0, width);
+            var pu = new PlaneView(srcU, 0, width / 2);
+            var pv = new PlaneView(srcV, 0, width / 2);
+            return EncodeKeyframeWithBuffersPlanes(py, pu, pv, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions);
+        }
+
+        /// <summary>Allocates a fresh byte[] from a pooled segment. Used by the public byte[]-returning entry points.</summary>
+        private static byte[] CopyPooled(ArraySegment<byte> seg)
+        {
+            byte[] result = new byte[seg.Count];
+            Buffer.BlockCopy(seg.Array, seg.Offset, result, 0, seg.Count);
+            return result;
+        }
+
+        /// <summary>Keyframe encode with Y/U/V stored contiguously in a single I420 buffer.</summary>
+        internal static byte[] EncodeKeyframeWithBuffersContiguousI420(byte[] i420, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memoryOps, int log2NumTokenPartitions = 0)
+            => CopyPooled(EncodeKeyframeWithBuffersContiguousI420Pooled(i420, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions));
+
+        /// <summary>Pooled variant of <see cref="EncodeKeyframeWithBuffersContiguousI420"/>; returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/> (avoids allocating/copying the encoded frame blob; other small per-frame allocations may still occur).</summary>
+        internal static ArraySegment<byte> EncodeKeyframeWithBuffersContiguousI420Pooled(byte[] i420, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memoryOps, int log2NumTokenPartitions = 0)
+        {
+            if (buffers == null) throw new ArgumentNullException(nameof(buffers));
+            if (memoryOps == null) throw new ArgumentNullException(nameof(memoryOps));
+            if (width <= 0 || width % 16 != 0)
+                throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
+            if (height <= 0 || height % 16 != 0)
+                throw new ArgumentException("height must be a positive multiple of 16", nameof(height));
+            int chromaW = width / 2, chromaH = height / 2;
+            int ySize = width * height, cSize = chromaW * chromaH;
+            if (i420 == null || i420.Length < ySize + 2 * cSize)
+                throw new ArgumentException("i420 size mismatch", nameof(i420));
+            var py = new PlaneView(i420, 0, width);
+            var pu = new PlaneView(i420, ySize, chromaW);
+            var pv = new PlaneView(i420, ySize + cSize, chromaW);
+            return EncodeKeyframeWithBuffersPlanes(py, pu, pv, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions);
+        }
+
+        private readonly struct PlaneView
+        {
+            public readonly byte[] Buffer;
+            public readonly int BaseOffset;
+            public readonly int Stride;
+            public PlaneView(byte[] buffer, int baseOffset, int stride)
+            {
+                Buffer = buffer;
+                BaseOffset = baseOffset;
+                Stride = stride;
+            }
+        }
+
+        private static ArraySegment<byte> EncodeKeyframeWithBuffersPlanes(PlaneView srcY, PlaneView srcU, PlaneView srcV,
+            int width, int height, int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memOps,
+            int log2NumTokenPartitions = 0)
+        {
+            if (buffers == null) throw new System.ArgumentNullException(nameof(buffers));
+            if (memOps == null) throw new ArgumentNullException(nameof(memOps));
+            if (width <= 0 || width % 16 != 0)
+                throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
+            if (height <= 0 || height % 16 != 0)
+                throw new ArgumentException("height must be a positive multiple of 16", nameof(height));
+            ValidateLog2TokenPartitions(log2NumTokenPartitions);
+            if (srcY.Buffer == null || srcU.Buffer == null || srcV.Buffer == null)
+                throw new ArgumentException("plane buffer is null");
+
+            int chromaW = width / 2, chromaH = height / 2;
+
             int mbCols = width / 16;
             int mbRows = height / 16;
 
@@ -269,42 +403,58 @@ namespace Vpx.Net
 
             // Use the caller-supplied per-codec scratch buffers.
             var buf = buffers;
-            buf.EnsureForFrame(width, height);
+            buf.EnsureForFrame(width, height, log2NumTokenPartitions);
             var scratch = buf.Scratch;
 
             var cfg = new KeyframeHeaderConfig
             {
                 Width = width, Height = height,
                 BaseQindex = qIndex,
+                Log2NumberOfTokenPartitions = log2NumTokenPartitions,
             };
 
             byte[] outBuf = buf.OutBuf;
+
+            // Pin outBuf for the entire encode. The BOOL_CODER stores a
+            // raw byte* into the buffer, so after the original fixed-scope
+            // pointer is released the GC could otherwise relocate the
+            // array between bc0 / bc1 invocations and silently corrupt
+            // the bitstream. (This was latent in the single-partition
+            // path, but became reliably triggerable once the multi-
+            // partition path added per-frame allocations large enough to
+            // induce gen-0 compaction during encoding.)
+            GCHandle outBufPin = GCHandle.Alloc(outBuf, GCHandleType.Pinned);
+            try
+            {
 
             // ----- Open the compressed first partition (header through refresh_entropy_probs) -----
             BOOL_CODER bc0 = new BOOL_CODER();
             int partitionStart;
             fixed (byte* p = outBuf)
             {
-                partitionStart = bitstream.StartKeyframeHeader(p, outBuf.Length, cfg, ref bc0);
-            }
+                using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.FirstPartitionHeader))
+                {
+                    partitionStart = bitstream.StartKeyframeHeader(p, outBuf.Length, cfg, ref bc0);
 
-            // ----- Coef-prob updates: 1056 zero bits (no updates) -----
-            // 4 block types x 8 bands x 3 contexts x 11 nodes = 1056. For
-            // each (type, band, ctx, node) the encoder writes a 1-bit flag
-            // saying "is this prob being updated?" and, if 1, an 8-bit
-            // replacement. Foundation: write all-zero flags so the decoder
-            // keeps default_coef_probs.
-            for (int t = 0; t < entropy.BLOCK_TYPES; t++)
-                for (int b = 0; b < entropy.COEF_BANDS; b++)
-                    for (int c = 0; c < entropy.PREV_COEF_CONTEXTS; c++)
-                        for (int n = 0; n < entropy.ENTROPY_NODES; n++)
-                            // Probability is the entry in vp8_coef_update_probs;
-                            // we always write 0 so the actual prob doesn't
-                            // change the boolean coder state much, but we
-                            // must use the right prob for the decoder to
-                            // recognise the bit.
-                            boolhuff.vp8_encode_bool(ref bc0, 0,
-                                coefupdateprobs.vp8_coef_update_probs[t, b, c, n]);
+                    // ----- Coef-prob updates: 1056 zero bits (no updates) -----
+                    // 4 block types x 8 bands x 3 contexts x 11 nodes = 1056. For
+                    // each (type, band, ctx, node) the encoder writes a 1-bit flag
+                    // saying "is this prob being updated?" and, if 1, an 8-bit
+                    // replacement. Foundation: write all-zero flags so the decoder
+                    // keeps default_coef_probs.
+                    for (int t = 0; t < entropy.BLOCK_TYPES; t++)
+                        for (int b = 0; b < entropy.COEF_BANDS; b++)
+                            for (int c = 0; c < entropy.PREV_COEF_CONTEXTS; c++)
+                                for (int n = 0; n < entropy.ENTROPY_NODES; n++)
+                                    // Probability is the entry in vp8_coef_update_probs;
+                                    // we always write 0 so the actual prob doesn't
+                                    // change the boolean coder state much, but we
+                                    // must use the right prob for the decoder to
+                                    // recognise the bit.
+                                    boolhuff.vp8_encode_bool(ref bc0, 0,
+                                        coefupdateprobs.vp8_coef_update_probs[t, b, c, n]);
+                }
+            }
 
             // ----- Phase 1: encode all MBs (no bit writing yet) -----
             //
@@ -357,29 +507,35 @@ namespace Vpx.Net
                 for (int mbCol = 0; mbCol < mbCols; mbCol++)
                 {
                     // Slice the 16x16 + 8x8 + 8x8 source for this MB.
-                    ExtractPlaneInto(srcY, width,  mbCol * 16, mbRow * 16, 16, 16, mbY);
-                    ExtractPlaneInto(srcU, chromaW, mbCol * 8,  mbRow * 8,  8, 8,  mbU);
-                    ExtractPlaneInto(srcV, chromaW, mbCol * 8,  mbRow * 8,  8, 8,  mbV);
+                    memOps.CopyPlaneRect(srcY.Buffer, srcY.BaseOffset, srcY.Stride, mbCol * 16, mbRow * 16, 16, 16, mbY);
+                    memOps.CopyPlaneRect(srcU.Buffer, srcU.BaseOffset, srcU.Stride, mbCol * 8, mbRow * 8, 8, 8, mbU);
+                    memOps.CopyPlaneRect(srcV.Buffer, srcV.BaseOffset, srcV.Stride, mbCol * 8, mbRow * 8, 8, 8, mbV);
 
                     // Slice the relevant 16-byte (resp 8-byte) above row.
                     bool haveAbove = mbRow > 0;
                     if (haveAbove)
                     {
-                        ExtractRowInto(aboveYRow, mbCol * 16, 16, aboveY);
-                        ExtractRowInto(aboveURow, mbCol * 8,  8,  aboveU);
-                        ExtractRowInto(aboveVRow, mbCol * 8,  8,  aboveV);
+                        memOps.CopyRowAt(aboveYRow, mbCol * 16, 16, aboveY);
+                        memOps.CopyRowAt(aboveURow, mbCol * 8, 8, aboveU);
+                        memOps.CopyRowAt(aboveVRow, mbCol * 8, 8, aboveV);
                     }
 
                     // Pull this MB column's above context out of the
                     // frame-scope buffer; mb_encoder mutates it in place
                     // as it processes blocks, then we copy it back.
                     int aboveBase = mbCol * 9;
-                    for (int s = 0; s < 9; s++) aboveCtx[s] = frameAboveCtx[aboveBase + s];
+                    using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Phase1MbScalarCtx))
+                    {
+                        Buffer.BlockCopy(frameAboveCtx, aboveBase, aboveCtx, 0, 9);
+                    }
 
                     int idx = mbRow * mbCols + mbCol;
                     var pooled = mbResults[idx];
 
-                    var r = mb_encoder.EncodeMacroblockDcPred(
+                    var fuse = new LastFrameFuseTarget(buf.LastFrameY, buf.LastFrameU, buf.LastFrameV,
+                        width, chromaW, mbCol, mbRow);
+
+                    var r = mb_encoder.EncodeMacroblockDcPredImpl(
                         mbY, mbU, mbV,
                         haveAbove        ? aboveY : null,
                         haveLeftNeighbour ? leftY : null,
@@ -389,7 +545,9 @@ namespace Vpx.Net
                         haveLeftNeighbour ? leftV : null,
                         fq,
                         aboveCtx, leftCtx,
-                        pooled, scratch);
+                        pooled, scratch,
+                        memOps,
+                        fuse);
                     // r is the same instance as `pooled`; explicit assign
                     // not strictly needed but kept for symmetry.
                     mbResults[idx] = r;
@@ -405,115 +563,86 @@ namespace Vpx.Net
                     // case (see context update lines in mb_encoder.cs),
                     // so the encoder and decoder context state stay in
                     // sync without any extra reset on this side.
-                    bool skip = IsAllEob(r);
-                    mbSkip[idx] = skip;
-                    if (skip) skipTrueCount++; else skipFalseCount++;
+                    using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Phase1MbScalarCtx))
+                    {
+                        bool skip = IsAllEob(r);
+                        mbSkip[idx] = skip;
+                        if (skip) skipTrueCount++; else skipFalseCount++;
 
-                    // The mutated aboveCtx is the new "above" for the MB
-                    // immediately below this one (same column, next row).
-                    for (int s = 0; s < 9; s++) frameAboveCtx[aboveBase + s] = aboveCtx[s];
+                        // The mutated aboveCtx is the new "above" for the MB
+                        // immediately below this one (same column, next row).
+                        Buffer.BlockCopy(aboveCtx, 0, frameAboveCtx, aboveBase, 9);
+                    }
 
                     // Update neighbour context for the next MB in this row
                     // (rightmost column of the MB's reconstruction) and for
                     // the next row (bottommost row).
-                    ExtractColumnInto(r.ReconY, srcStride: 16, columnIndex: 15, rows: 16, dst: leftY);
-                    ExtractColumnInto(r.ReconU, srcStride: 8,  columnIndex: 7,  rows: 8,  dst: leftU);
-                    ExtractColumnInto(r.ReconV, srcStride: 8,  columnIndex: 7,  rows: 8,  dst: leftV);
+                    memOps.CopyColumn(buf.LastFrameY, width, mbCol * 16 + 15, mbRow * 16, 16, leftY);
+                    memOps.CopyColumn(buf.LastFrameU, chromaW, mbCol * 8 + 7, mbRow * 8, 8, leftU);
+                    memOps.CopyColumn(buf.LastFrameV, chromaW, mbCol * 8 + 7, mbRow * 8, 8, leftV);
                     haveLeftNeighbour = true;
 
-                    CopyRowOut(r.ReconY, srcStride: 16, srcRow: 15,
-                               dst: aboveYRow, dstOffset: mbCol * 16, count: 16);
-                    CopyRowOut(r.ReconU, srcStride: 8,  srcRow: 7,
-                               dst: aboveURow, dstOffset: mbCol * 8, count: 8);
-                    CopyRowOut(r.ReconV, srcStride: 8,  srcRow: 7,
-                               dst: aboveVRow, dstOffset: mbCol * 8, count: 8);
+                    memOps.CopyRowFrom2d(buf.LastFrameY, width, mbRow * 16 + 15, mbCol * 16,
+                               aboveYRow, dstOffset: mbCol * 16, count: 16);
+                    memOps.CopyRowFrom2d(buf.LastFrameU, chromaW, mbRow * 8 + 7, mbCol * 8,
+                               aboveURow, dstOffset: mbCol * 8, count: 8);
+                    memOps.CopyRowFrom2d(buf.LastFrameV, chromaW, mbRow * 8 + 7, mbCol * 8,
+                               aboveVRow, dstOffset: mbCol * 8, count: 8);
                 }
             }
 
-            // ----- Save the reconstructed frame as the next inter
-            //       prediction reference -----
-            //
-            // For each MB we already have its 16x16 Y + 8x8 U + 8x8 V
-            // reconstruction in mbResults[idx].ReconY/U/V (the bytes
-            // the decoder will produce given the same bitstream).
-            // Stitch them into LastFrameY/U/V so the next inter frame
-            // (added in PR 3+) can use this as its prediction source.
-            //
-            // PR 1 just plumbs the storage; nothing currently consumes
-            // the saved reference. The work is unconditional regardless
-            // because (a) the per-MB cost is O(384 bytes) so trivial,
-            // and (b) this lets PR 5's wire-up happen as a flip rather
-            // than a behaviour change to EncodeKeyframe.
-            for (int mbRow = 0; mbRow < mbRows; mbRow++)
-            {
-                for (int mbCol = 0; mbCol < mbCols; mbCol++)
-                {
-                    var r = mbResults[mbRow * mbCols + mbCol];
-
-                    int yBase = (mbRow * 16) * width + (mbCol * 16);
-                    for (int row = 0; row < 16; row++)
-                    {
-                        Buffer.BlockCopy(r.ReconY, row * 16,
-                            buf.LastFrameY, yBase + row * width, 16);
-                    }
-
-                    int cBase = (mbRow * 8) * chromaW + (mbCol * 8);
-                    for (int row = 0; row < 8; row++)
-                    {
-                        Buffer.BlockCopy(r.ReconU, row * 8,
-                            buf.LastFrameU, cBase + row * chromaW, 8);
-                        Buffer.BlockCopy(r.ReconV, row * 8,
-                            buf.LastFrameV, cBase + row * chromaW, 8);
-                    }
-                }
-            }
+            // ----- Last-frame reference was written during MB encode (fused idct) -----
             buf.LastFrameValid = true;
 
-            // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
-            //
-            // Now that we know how many MBs are skippable we can pick
-            // prob_skip_false. libvpx's formula: prob_skip_false =
-            // skipFalseCount * 256 / total. Clamped to [1, 255] so the
-            // boolean coder can still encode whichever bit value occurs.
-            // Falls back to 0xfb (libvpx's hardcoded initial default)
-            // when no MBs are skippable, which is efficient because then
-            // every per-MB skip-flag bit is "0" and a high prob_skip_false
-            // makes that essentially free.
-            bitstream.vp8_write_bit(ref bc0, 1);   // mb_no_skip_coeff = 1
-
-            byte probSkipFalse;
-            if (skipTrueCount == 0)
+            // ----- Phase 2: partition-0 bits after phase 1 (before token partition) -----
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Phase2FirstPartitionBits))
             {
-                probSkipFalse = 0xfb;
-            }
-            else
-            {
-                int total = skipFalseCount + skipTrueCount;
-                int p = skipFalseCount * 256 / total;
-                if (p < 1) p = 1;
-                if (p > 255) p = 255;
-                probSkipFalse = (byte)p;
-            }
-            for (int b = 7; b >= 0; b--)
-                bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
+                // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
+                //
+                // Now that we know how many MBs are skippable we can pick
+                // prob_skip_false. libvpx's formula: prob_skip_false =
+                // skipFalseCount * 256 / total. Clamped to [1, 255] so the
+                // boolean coder can still encode whichever bit value occurs.
+                // Falls back to 0xfb (libvpx's hardcoded initial default)
+                // when no MBs are skippable, which is efficient because then
+                // every per-MB skip-flag bit is "0" and a high prob_skip_false
+                // makes that essentially free.
+                bitstream.vp8_write_bit(ref bc0, 1);   // mb_no_skip_coeff = 1
 
-            // ----- Phase 2b: per-MB skip flag + Y/UV mode trees -----
-            int totalMbsP2 = mbRows * mbCols;
-            for (int i = 0; i < totalMbsP2; i++)
-            {
-                // Skip flag (boolean coder, prob_skip_false).
-                boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
+                byte probSkipFalse;
+                if (skipTrueCount == 0)
+                {
+                    probSkipFalse = 0xfb;
+                }
+                else
+                {
+                    int total = skipFalseCount + skipTrueCount;
+                    int p = skipFalseCount * 256 / total;
+                    if (p < 1) p = 1;
+                    if (p > 255) p = 255;
+                    probSkipFalse = (byte)p;
+                }
+                for (int b = 7; b >= 0; b--)
+                    bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
 
-                // Y mode = DC_PRED -> tree path 1, 0, 0 with
-                // vp8_kf_ymode_prob[0..2].
-                var yProbs = vp8_entropymodedata.vp8_kf_ymode_prob;
-                boolhuff.vp8_encode_bool(ref bc0, 1, yProbs[0]);
-                boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[1]);
-                boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[2]);
+                // ----- Phase 2b: per-MB skip flag + Y/UV mode trees -----
+                int totalMbsP2 = mbRows * mbCols;
+                for (int i = 0; i < totalMbsP2; i++)
+                {
+                    // Skip flag (boolean coder, prob_skip_false).
+                    boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
 
-                // UV mode = DC_PRED -> bit 0 with vp8_kf_uv_mode_prob[0].
-                var uvProbs = vp8_entropymodedata.vp8_kf_uv_mode_prob;
-                boolhuff.vp8_encode_bool(ref bc0, 0, uvProbs[0]);
+                    // Y mode = DC_PRED -> tree path 1, 0, 0 with
+                    // vp8_kf_ymode_prob[0..2].
+                    var yProbs = vp8_entropymodedata.vp8_kf_ymode_prob;
+                    boolhuff.vp8_encode_bool(ref bc0, 1, yProbs[0]);
+                    boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[1]);
+                    boolhuff.vp8_encode_bool(ref bc0, 0, yProbs[2]);
+
+                    // UV mode = DC_PRED -> bit 0 with vp8_kf_uv_mode_prob[0].
+                    var uvProbs = vp8_entropymodedata.vp8_kf_uv_mode_prob;
+                    boolhuff.vp8_encode_bool(ref bc0, 0, uvProbs[0]);
+                }
             }
 
             // ----- Close partition 0 (flush + patch frame tag) -----
@@ -526,37 +655,132 @@ namespace Vpx.Net
                 _ = partition0Length;
             }
 
-            // ----- Open partition 1 (token partition) -----
-            BOOL_CODER bc1 = new BOOL_CODER();
-            fixed (byte* p = outBuf)
+            // ----- Phase 4: token partition(s) -----
+            int totalBytes;
+            if (log2NumTokenPartitions == 0)
             {
-                boolhuff.vp8_start_encode(ref bc1, p + totalThroughP0, p + outBuf.Length);
-
-                // Pack tokens for each MB in raster order: Y2 first,
-                // then 16 Y, then 4 U, then 4 V — same order
-                // tokenize_mb emits. SKIPPABLE MBs contribute zero
-                // tokens to partition 1, mirroring the decoder which on
-                // skip_flag = 1 calls vp8_reset_mb_tokens_context and
-                // never reads coefficient bits for the MB.
-                int totalMbs = mbRows * mbCols;
-                for (int i = 0; i < totalMbs; i++)
+                BOOL_CODER bc1 = new BOOL_CODER();
+                fixed (byte* p = outBuf)
                 {
-                    if (mbSkip[i]) continue;
+                    boolhuff.vp8_start_encode(ref bc1, p + totalThroughP0, p + outBuf.Length);
 
-                    var r = mbResults[i];
-                    bitstream.vp8_pack_tokens(ref bc1, r.Y2Block);
-                    for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc1, r.YBlocks[b]);
-                    for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.UBlocks[b]);
-                    for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.VBlocks[b]);
+                    using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.PackTokens))
+                    {
+                    // Pack tokens for each MB in raster order: Y2 first,
+                    // then 16 Y, then 4 U, then 4 V — same order
+                    // tokenize_mb emits. SKIPPABLE MBs contribute zero
+                    // tokens to partition 1, mirroring the decoder which on
+                    // skip_flag = 1 calls vp8_reset_mb_tokens_context and
+                    // never reads coefficient bits for the MB.
+                    int totalMbs = mbRows * mbCols;
+                    for (int i = 0; i < totalMbs; i++)
+                    {
+                        if (mbSkip[i]) continue;
+
+                        var r = mbResults[i];
+                        bitstream.vp8_pack_tokens(ref bc1, r.Y2Block);
+                        for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc1, r.YBlocks[b]);
+                        for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.UBlocks[b]);
+                        for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.VBlocks[b]);
+                    }
+                    }
+
+                    boolhuff.vp8_stop_encode(ref bc1);
                 }
 
-                boolhuff.vp8_stop_encode(ref bc1);
+                totalBytes = totalThroughP0 + (int)bc1.pos;
+            }
+            else
+            {
+                totalBytes = PackMultiPartitionTokens(buf, outBuf, totalThroughP0,
+                    mbResults, mbSkip, mbRows, mbCols, log2NumTokenPartitions);
+            }
+            return new ArraySegment<byte>(outBuf, 0, totalBytes);
+            }
+            finally { outBufPin.Free(); }
+        }
+
+        /// <summary>
+        /// Pack tokens into <c>1 &lt;&lt; log2NumTokenPartitions</c> token partitions in
+        /// parallel, then write the partition size table (after partition 0)
+        /// and concatenated partitions into <paramref name="outBuf"/>.
+        /// Partitions are interleaved by row (row r belongs to partition
+        /// r &amp; (N-1)) so each partition can be encoded independently.
+        /// </summary>
+        private static int PackMultiPartitionTokens(FrameEncoderBuffers buf, byte[] outBuf, int totalThroughP0,
+            MbEncodeResult[] mbResults, bool[] mbSkip, int mbRows, int mbCols, int log2NumTokenPartitions)
+        {
+            int n = 1 << log2NumTokenPartitions;
+            if (buf.PartitionLengthsScratch == null || buf.PartitionLengthsScratch.Length < n)
+                buf.PartitionLengthsScratch = new int[n];
+            int[] partitionLengths = buf.PartitionLengthsScratch;
+
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.PackTokens))
+            {
+                Parallel.For(0, n, p =>
+                {
+                    partitionLengths[p] = PackSinglePartition(p, n, mbRows, mbCols,
+                        mbResults, mbSkip, buf.PartitionBufs[p]);
+                });
             }
 
-            int totalBytes = totalThroughP0 + (int)bc1.pos;
-            byte[] result = new byte[totalBytes];
-            Array.Copy(outBuf, result, totalBytes);
-            return result;
+            // ----- Stitch: size table + concatenated partitions -----
+            int writePos = totalThroughP0;
+            // (N-1) 24-bit little-endian sizes for partitions 1..N-1.
+            for (int p = 0; p < n - 1; p++)
+            {
+                int sz = partitionLengths[p];
+                outBuf[writePos++] = (byte)(sz & 0xFF);
+                outBuf[writePos++] = (byte)((sz >> 8) & 0xFF);
+                outBuf[writePos++] = (byte)((sz >> 16) & 0xFF);
+            }
+            // Partition bytes in order: 0, 1, ..., N-1.
+            for (int p = 0; p < n; p++)
+            {
+                int len = partitionLengths[p];
+                if (len > 0)
+                {
+                    Buffer.BlockCopy(buf.PartitionBufs[p], 0, outBuf, writePos, len);
+                    writePos += len;
+                }
+            }
+            return writePos;
+        }
+
+        /// <summary>
+        /// Pack one token partition: walks every MB whose
+        /// <c>(row &amp; (N-1)) == partitionIndex</c> and emits its
+        /// Y2 + 16 Y + 4 U + 4 V token streams through an independent
+        /// <see cref="BOOL_CODER"/>. Returns the byte length of the written
+        /// partition body.
+        /// </summary>
+        private static int PackSinglePartition(int partitionIndex, int n, int mbRows, int mbCols,
+            MbEncodeResult[] mbResults, bool[] mbSkip, byte[] partBuf)
+        {
+            BOOL_CODER bc = new BOOL_CODER();
+            fixed (byte* pb = partBuf)
+            {
+                boolhuff.vp8_start_encode(ref bc, pb, pb + partBuf.Length);
+
+                for (int row = partitionIndex; row < mbRows; row += n)
+                {
+                    int rowBase = row * mbCols;
+                    for (int col = 0; col < mbCols; col++)
+                    {
+                        int i = rowBase + col;
+                        if (mbSkip[i]) continue;
+
+                        var r = mbResults[i];
+                        bitstream.vp8_pack_tokens(ref bc, r.Y2Block);
+                        for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc, r.YBlocks[b]);
+                        for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc, r.UBlocks[b]);
+                        for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc, r.VBlocks[b]);
+                    }
+                }
+
+                boolhuff.vp8_stop_encode(ref bc);
+            }
+            return (int)bc.pos;
         }
 
         /// <summary>
@@ -579,7 +803,14 @@ namespace Vpx.Net
         /// <param name="qIndex">Base quantizer (0..127).</param>
         /// <returns>The encoded VP8 inter frame bytes.</returns>
         internal static byte[] EncodeInterFrameWithBuffers(byte[] srcY, byte[] srcU, byte[] srcV,
-            int width, int height, int qIndex, FrameEncoderBuffers buffers)
+            int width, int height, int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memoryOps = null,
+            int log2NumTokenPartitions = 0)
+            => CopyPooled(EncodeInterFrameWithBuffersPooled(srcY, srcU, srcV, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions));
+
+        /// <summary>Pooled variant of <see cref="EncodeInterFrameWithBuffers"/>; returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/> (avoids allocating/copying the encoded frame blob; other small per-frame allocations may still occur).</summary>
+        internal static ArraySegment<byte> EncodeInterFrameWithBuffersPooled(byte[] srcY, byte[] srcU, byte[] srcV,
+            int width, int height, int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memoryOps = null,
+            int log2NumTokenPartitions = 0)
         {
             if (buffers == null) throw new System.ArgumentNullException(nameof(buffers));
             if (width <= 0 || width % 16 != 0)
@@ -594,13 +825,58 @@ namespace Vpx.Net
             if (srcV == null || srcV.Length != chromaW * chromaH)
                 throw new ArgumentException("srcV size mismatch");
 
+            memoryOps ??= LegacyEncoderMemoryOps.Instance;
+            var py = new PlaneView(srcY, 0, width);
+            var pu = new PlaneView(srcU, 0, width / 2);
+            var pv = new PlaneView(srcV, 0, width / 2);
+            return EncodeInterFrameWithBuffersPlanes(py, pu, pv, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions);
+        }
+
+        internal static byte[] EncodeInterFrameWithBuffersContiguousI420(byte[] i420, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memoryOps, int log2NumTokenPartitions = 0)
+            => CopyPooled(EncodeInterFrameWithBuffersContiguousI420Pooled(i420, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions));
+
+        /// <summary>Pooled variant of <see cref="EncodeInterFrameWithBuffersContiguousI420"/>; returns a slice over <see cref="FrameEncoderBuffers.OutBuf"/> (avoids allocating/copying the encoded frame blob; other small per-frame allocations may still occur).</summary>
+        internal static ArraySegment<byte> EncodeInterFrameWithBuffersContiguousI420Pooled(byte[] i420, int width, int height,
+            int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memoryOps, int log2NumTokenPartitions = 0)
+        {
+            if (buffers == null) throw new ArgumentNullException(nameof(buffers));
+            if (memoryOps == null) throw new ArgumentNullException(nameof(memoryOps));
+            if (width <= 0 || width % 16 != 0)
+                throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
+            if (height <= 0 || height % 16 != 0)
+                throw new ArgumentException("height must be a positive multiple of 16", nameof(height));
+            int chromaW = width / 2, chromaH = height / 2;
+            int ySize = width * height, cSize = chromaW * chromaH;
+            if (i420 == null || i420.Length < ySize + 2 * cSize)
+                throw new ArgumentException("i420 size mismatch", nameof(i420));
+            var py = new PlaneView(i420, 0, width);
+            var pu = new PlaneView(i420, ySize, chromaW);
+            var pv = new PlaneView(i420, ySize + cSize, chromaW);
+            return EncodeInterFrameWithBuffersPlanes(py, pu, pv, width, height, qIndex, buffers, memoryOps, log2NumTokenPartitions);
+        }
+
+        private static ArraySegment<byte> EncodeInterFrameWithBuffersPlanes(PlaneView srcY, PlaneView srcU, PlaneView srcV,
+            int width, int height, int qIndex, FrameEncoderBuffers buffers, IEncoderMemoryOps memOps,
+            int log2NumTokenPartitions = 0)
+        {
+            if (memOps == null) throw new ArgumentNullException(nameof(memOps));
+            if (width <= 0 || width % 16 != 0)
+                throw new ArgumentException("width must be a positive multiple of 16", nameof(width));
+            if (height <= 0 || height % 16 != 0)
+                throw new ArgumentException("height must be a positive multiple of 16", nameof(height));
+            ValidateLog2TokenPartitions(log2NumTokenPartitions);
+            if (srcY.Buffer == null || srcU.Buffer == null || srcV.Buffer == null)
+                throw new ArgumentException("plane buffer is null");
+
             int mbCols = width / 16;
             int mbRows = height / 16;
+            int chromaW = width / 2;
 
             FrameQuantizer fq = quantizer_init.BuildForQIndex(qIndex);
 
             var buf = buffers;
-            buf.EnsureForFrame(width, height);
+            buf.EnsureForFrame(width, height, log2NumTokenPartitions);
             var scratch = buf.Scratch;
 
             if (!buf.LastFrameValid)
@@ -612,25 +888,35 @@ namespace Vpx.Net
             var cfg = new InterFrameHeaderConfig
             {
                 BaseQindex = qIndex,
+                Log2NumberOfTokenPartitions = log2NumTokenPartitions,
             };
 
             byte[] outBuf = buf.OutBuf;
+
+            // Pin outBuf for the entire encode (see EncodeKeyframeWithBuffersPlanes
+            // for the rationale).
+            GCHandle outBufPin = GCHandle.Alloc(outBuf, GCHandleType.Pinned);
+            try
+            {
 
             // ----- Open compressed first partition (header through refresh_last_frame) -----
             BOOL_CODER bc0 = new BOOL_CODER();
             int partitionStart;
             fixed (byte* p = outBuf)
             {
-                partitionStart = bitstream.StartInterFrameHeader(p, outBuf.Length, cfg, ref bc0);
-            }
+                using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.FirstPartitionHeader))
+                {
+                    partitionStart = bitstream.StartInterFrameHeader(p, outBuf.Length, cfg, ref bc0);
 
-            // ----- Coef-prob updates: 1056 zero flag bits (no updates) -----
-            for (int t = 0; t < entropy.BLOCK_TYPES; t++)
-                for (int b = 0; b < entropy.COEF_BANDS; b++)
-                    for (int c = 0; c < entropy.PREV_COEF_CONTEXTS; c++)
-                        for (int n = 0; n < entropy.ENTROPY_NODES; n++)
-                            boolhuff.vp8_encode_bool(ref bc0, 0,
-                                coefupdateprobs.vp8_coef_update_probs[t, b, c, n]);
+                    // ----- Coef-prob updates: 1056 zero flag bits (no updates) -----
+                    for (int t = 0; t < entropy.BLOCK_TYPES; t++)
+                        for (int b = 0; b < entropy.COEF_BANDS; b++)
+                            for (int c = 0; c < entropy.PREV_COEF_CONTEXTS; c++)
+                                for (int n = 0; n < entropy.ENTROPY_NODES; n++)
+                                    boolhuff.vp8_encode_bool(ref bc0, 0,
+                                        coefupdateprobs.vp8_coef_update_probs[t, b, c, n]);
+                }
+            }
 
             // ----- Phase 1: encode all MBs into MbEncodeResults -----
             //
@@ -654,19 +940,9 @@ namespace Vpx.Net
             byte[] mbU = buf.MbU;
             byte[] mbV = buf.MbV;
 
-            // ZEROMV prediction reuses the per-MB scratch slots that the
-            // keyframe path used for above/left neighbour pixels — the
-            // inter encoder only needs same-position prediction so those
-            // slots are free to repurpose.
-            byte[] predY = buf.AboveY.Length >= 256 ? buf.AboveY : new byte[256];
-            byte[] predU = buf.AboveU.Length >= 64  ? buf.AboveU : new byte[64];
-            byte[] predV = buf.AboveV.Length >= 64  ? buf.AboveV : new byte[64];
-            // Above slots are 16/8/8 in the keyframe path; for inter we
-            // need 256/64/64. Allocate dedicated buffers if the existing
-            // ones aren't large enough (one-time per encoder lifetime).
-            if (predY.Length < 256) predY = new byte[256];
-            if (predU.Length < 64) predU = new byte[64];
-            if (predV.Length < 64) predV = new byte[64];
+            byte[] predY = buf.PredY;
+            byte[] predU = buf.PredU;
+            byte[] predV = buf.PredV;
 
             for (int mbRow = 0; mbRow < mbRows; mbRow++)
             {
@@ -674,174 +950,158 @@ namespace Vpx.Net
 
                 for (int mbCol = 0; mbCol < mbCols; mbCol++)
                 {
-                    // Source MB.
-                    ExtractPlaneInto(srcY, width,   mbCol * 16, mbRow * 16, 16, 16, mbY);
-                    ExtractPlaneInto(srcU, chromaW, mbCol * 8,  mbRow * 8,   8,  8, mbU);
-                    ExtractPlaneInto(srcV, chromaW, mbCol * 8,  mbRow * 8,   8,  8, mbV);
+                    memOps.CopyPlaneRect(srcY.Buffer, srcY.BaseOffset, srcY.Stride, mbCol * 16, mbRow * 16, 16, 16, mbY);
+                    memOps.CopyPlaneRect(srcU.Buffer, srcU.BaseOffset, srcU.Stride, mbCol * 8, mbRow * 8, 8, 8, mbU);
+                    memOps.CopyPlaneRect(srcV.Buffer, srcV.BaseOffset, srcV.Stride, mbCol * 8, mbRow * 8, 8, 8, mbV);
 
-                    // Same-position prediction from LAST_FRAME.
-                    ExtractPlaneInto(buf.LastFrameY, width,   mbCol * 16, mbRow * 16, 16, 16, predY);
-                    ExtractPlaneInto(buf.LastFrameU, chromaW, mbCol * 8,  mbRow * 8,   8,  8, predU);
-                    ExtractPlaneInto(buf.LastFrameV, chromaW, mbCol * 8,  mbRow * 8,   8,  8, predV);
+                    memOps.CopyPlaneRect(buf.LastFrameY, 0, width, mbCol * 16, mbRow * 16, 16, 16, predY);
+                    memOps.CopyPlaneRect(buf.LastFrameU, 0, chromaW, mbCol * 8, mbRow * 8, 8, 8, predU);
+                    memOps.CopyPlaneRect(buf.LastFrameV, 0, chromaW, mbCol * 8, mbRow * 8, 8, 8, predV);
 
                     // Pull this MB column's above context.
                     int aboveBase = mbCol * 9;
-                    for (int s = 0; s < 9; s++) aboveCtx[s] = frameAboveCtx[aboveBase + s];
+                    using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Phase1MbScalarCtx))
+                    {
+                        Buffer.BlockCopy(frameAboveCtx, aboveBase, aboveCtx, 0, 9);
+                    }
 
                     int idx = mbRow * mbCols + mbCol;
                     var pooled = mbResults[idx];
 
-                    var r = mb_encoder.EncodeMacroblockZeroMvLast(
+                    var fuseInter = new LastFrameFuseTarget(buf.LastFrameY, buf.LastFrameU, buf.LastFrameV,
+                        width, chromaW, mbCol, mbRow);
+
+                    var r = mb_encoder.EncodeMacroblockZeroMvLastImpl(
                         mbY, mbU, mbV,
                         predY, predU, predV,
                         fq,
                         aboveCtx, leftCtx,
-                        pooled, scratch);
+                        pooled, scratch,
+                        memOps,
+                        fuseInter);
                     mbResults[idx] = r;
 
-                    bool skip = IsAllEob(r);
-                    mbSkip[idx] = skip;
-                    if (skip) skipTrueCount++; else skipFalseCount++;
-
-                    // Save mutated above context for the row below.
-                    for (int s = 0; s < 9; s++) frameAboveCtx[aboveBase + s] = aboveCtx[s];
-                }
-            }
-
-            // ----- Save reconstructed frame as next inter prediction ref -----
-            //
-            // Same per-MB stitch as the keyframe path. Future inter
-            // frames in the stream will use the bytes we write here as
-            // their LAST_FRAME prediction source.
-            for (int mbRow = 0; mbRow < mbRows; mbRow++)
-            {
-                for (int mbCol = 0; mbCol < mbCols; mbCol++)
-                {
-                    var r = mbResults[mbRow * mbCols + mbCol];
-
-                    int yBase = (mbRow * 16) * width + (mbCol * 16);
-                    for (int row = 0; row < 16; row++)
+                    using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Phase1MbScalarCtx))
                     {
-                        Buffer.BlockCopy(r.ReconY, row * 16,
-                            buf.LastFrameY, yBase + row * width, 16);
-                    }
+                        bool skip = IsAllEob(r);
+                        mbSkip[idx] = skip;
+                        if (skip) skipTrueCount++; else skipFalseCount++;
 
-                    int cBase = (mbRow * 8) * chromaW + (mbCol * 8);
-                    for (int row = 0; row < 8; row++)
-                    {
-                        Buffer.BlockCopy(r.ReconU, row * 8,
-                            buf.LastFrameU, cBase + row * chromaW, 8);
-                        Buffer.BlockCopy(r.ReconV, row * 8,
-                            buf.LastFrameV, cBase + row * chromaW, 8);
+                        Buffer.BlockCopy(aboveCtx, 0, frameAboveCtx, aboveBase, 9);
                     }
                 }
             }
+
             buf.LastFrameValid = true;
 
-            // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
-            bitstream.vp8_write_bit(ref bc0, 1);   // mb_no_skip_coeff = 1
-
-            byte probSkipFalse;
-            if (skipTrueCount == 0)
+            // ----- Phase 2: partition-0 tail before token partition -----
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Phase2FirstPartitionBits))
             {
-                probSkipFalse = 0xfb;
-            }
-            else
-            {
-                int total = skipFalseCount + skipTrueCount;
-                int p = skipFalseCount * 256 / total;
-                if (p < 1) p = 1;
-                if (p > 255) p = 255;
-                probSkipFalse = (byte)p;
-            }
-            for (int b = 7; b >= 0; b--)
-                bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
+                // ----- Phase 2a: mb_no_skip_coeff + prob_skip_false -----
+                bitstream.vp8_write_bit(ref bc0, 1);   // mb_no_skip_coeff = 1
 
-            // ----- Phase 2b: inter-only prob_intra / prob_last / prob_gf -----
-            //
-            // Choices for the ZEROMV-everywhere model:
-            //   prob_intra = 1   -> writing is_inter=1 costs ~0 bits.
-            //   prob_last  = 1   -> writing ref_is_LAST=0 costs ~0 bits.
-            //   prob_gf    = 128 -> never used (ref is always LAST).
-            const byte probIntra = 1;
-            const byte probLast = 1;
-            const byte probGf = 128;
-            for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probIntra >> b) & 1);
-            for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probLast >> b) & 1);
-            for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probGf >> b) & 1);
-
-            // ymode_prob update flag = 0 (use defaults).
-            bitstream.vp8_write_bit(ref bc0, 0);
-            // uv_mode_prob update flag = 0.
-            bitstream.vp8_write_bit(ref bc0, 0);
-
-            // MV context updates: for each of the two MV components
-            // (row, col) and each of MVPcount (=19) probabilities, write
-            // an "update?" flag of 0 with the default vp8_mv_update_probs.
-            // We never update MV probs because we never code MV
-            // residuals (all MBs are ZEROMV).
-            for (int comp = 0; comp < 2; comp++)
-            {
-                byte[] up = entropymv.vp8_mv_update_probs[comp].prob;
-                int mvpCount = (int)MV_ENUM.MVPcount;
-                for (int j = 0; j < mvpCount; j++)
+                byte probSkipFalse;
+                if (skipTrueCount == 0)
                 {
-                    boolhuff.vp8_encode_bool(ref bc0, 0, up[j]);
+                    probSkipFalse = 0xfb;
                 }
-            }
-
-            // ----- Phase 2c: per-MB skip flag + ref_frame + inter mode -----
-            //
-            // The inter mode tree probabilities depend on a per-MB
-            // neighbour-MV-counting context cnt[CNT_INTRA]. The decoder
-            // (decodemv.read_mb_modes_mv) accumulates this context by
-            // walking the above, left and aboveleft neighbours: each
-            // non-intra neighbour with a zero MV adds either 2
-            // (above/left) or 1 (aboveleft) to cnt[CNT_INTRA].
-            //
-            // For an all-ZEROMV LAST_FRAME stream the cnt[CNT_INTRA]
-            // value is determined entirely by the MB's position, since
-            // every inter MB has ref_frame = LAST and mv.as_int = 0:
-            //   (0,0)        -> 0 (no inter neighbours)
-            //   (0,c) c>0    -> 2 (only left contributes)
-            //   (r,0) r>0    -> 2 (only above contributes)
-            //   (r,c) r>0,c>0 -> 5 (above+left+aboveleft all contribute: 2+2+1)
-            //
-            // We pre-build the three context rows we'll need and pick
-            // the right one per MB, then walk the inter mode tree with
-            // the decoder-matching row.
-            byte[] modeProbsRow0 = new byte[4];
-            byte[] modeProbsRow2 = new byte[4];
-            byte[] modeProbsRow5 = new byte[4];
-            for (int j = 0; j < 4; j++)
-            {
-                modeProbsRow0[j] = (byte)modecont.vp8_mode_contexts[0, j];
-                modeProbsRow2[j] = (byte)modecont.vp8_mode_contexts[2, j];
-                modeProbsRow5[j] = (byte)modecont.vp8_mode_contexts[5, j];
-            }
-
-            for (int mbRow = 0; mbRow < mbRows; mbRow++)
-            {
-                for (int mbCol = 0; mbCol < mbCols; mbCol++)
+                else
                 {
-                    int i = mbRow * mbCols + mbCol;
+                    int total = skipFalseCount + skipTrueCount;
+                    int p = skipFalseCount * 256 / total;
+                    if (p < 1) p = 1;
+                    if (p > 255) p = 255;
+                    probSkipFalse = (byte)p;
+                }
+                for (int b = 7; b >= 0; b--)
+                    bitstream.vp8_write_bit(ref bc0, (probSkipFalse >> b) & 1);
 
-                    // Skip flag (boolean coder, prob_skip_false).
-                    boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
+                // ----- Phase 2b: inter-only prob_intra / prob_last / prob_gf -----
+                //
+                // Choices for the ZEROMV-everywhere model:
+                //   prob_intra = 1   -> writing is_inter=1 costs ~0 bits.
+                //   prob_last  = 1   -> writing ref_is_LAST=0 costs ~0 bits.
+                //   prob_gf    = 128 -> never used (ref is always LAST).
+                const byte probIntra = 1;
+                const byte probLast = 1;
+                const byte probGf = 128;
+                for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probIntra >> b) & 1);
+                for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probLast >> b) & 1);
+                for (int b = 7; b >= 0; b--) bitstream.vp8_write_bit(ref bc0, (probGf >> b) & 1);
 
-                    // Pick the context-correct mode prob row.
-                    byte[] modeProbs;
-                    if (mbRow == 0 && mbCol == 0)       modeProbs = modeProbsRow0;
-                    else if (mbRow == 0 || mbCol == 0)  modeProbs = modeProbsRow2;
-                    else                                modeProbs = modeProbsRow5;
+                // ymode_prob update flag = 0 (use defaults).
+                bitstream.vp8_write_bit(ref bc0, 0);
+                // uv_mode_prob update flag = 0.
+                bitstream.vp8_write_bit(ref bc0, 0);
 
-                    // is_inter=1, ref_is_LAST=0, ZEROMV tree path.
-                    bitstream.WriteInterMbRefAndMode(
-                        ref bc0,
-                        probIntra, probLast, probGf,
-                        MV_REFERENCE_FRAME.LAST_FRAME,
-                        modeProbs,
-                        MB_PREDICTION_MODE.ZEROMV);
+                // MV context updates: for each of the two MV components
+                // (row, col) and each of MVPcount (=19) probabilities, write
+                // an "update?" flag of 0 with the default vp8_mv_update_probs.
+                // We never update MV probs because we never code MV
+                // residuals (all MBs are ZEROMV).
+                for (int comp = 0; comp < 2; comp++)
+                {
+                    byte[] up = entropymv.vp8_mv_update_probs[comp].prob;
+                    int mvpCount = (int)MV_ENUM.MVPcount;
+                    for (int j = 0; j < mvpCount; j++)
+                    {
+                        boolhuff.vp8_encode_bool(ref bc0, 0, up[j]);
+                    }
+                }
+
+                // ----- Phase 2c: per-MB skip flag + ref_frame + inter mode -----
+                //
+                // The inter mode tree probabilities depend on a per-MB
+                // neighbour-MV-counting context cnt[CNT_INTRA]. The decoder
+                // (decodemv.read_mb_modes_mv) accumulates this context by
+                // walking the above, left and aboveleft neighbours: each
+                // non-intra neighbour with a zero MV adds either 2
+                // (above/left) or 1 (aboveleft) to cnt[CNT_INTRA].
+                //
+                // For an all-ZEROMV LAST_FRAME stream the cnt[CNT_INTRA]
+                // value is determined entirely by the MB's position, since
+                // every inter MB has ref_frame = LAST and mv.as_int = 0:
+                //   (0,0)        -> 0 (no inter neighbours)
+                //   (0,c) c>0    -> 2 (only left contributes)
+                //   (r,0) r>0    -> 2 (only above contributes)
+                //   (r,c) r>0,c>0 -> 5 (above+left+aboveleft all contribute: 2+2+1)
+                //
+                // We pre-build the three context rows we'll need and pick
+                // the right one per MB, then walk the inter mode tree with
+                // the decoder-matching row.
+                byte[] modeProbsRow0 = new byte[4];
+                byte[] modeProbsRow2 = new byte[4];
+                byte[] modeProbsRow5 = new byte[4];
+                for (int j = 0; j < 4; j++)
+                {
+                    modeProbsRow0[j] = (byte)modecont.vp8_mode_contexts[0, j];
+                    modeProbsRow2[j] = (byte)modecont.vp8_mode_contexts[2, j];
+                    modeProbsRow5[j] = (byte)modecont.vp8_mode_contexts[5, j];
+                }
+
+                for (int mbRow = 0; mbRow < mbRows; mbRow++)
+                {
+                    for (int mbCol = 0; mbCol < mbCols; mbCol++)
+                    {
+                        int i = mbRow * mbCols + mbCol;
+
+                        // Skip flag (boolean coder, prob_skip_false).
+                        boolhuff.vp8_encode_bool(ref bc0, mbSkip[i] ? 1 : 0, probSkipFalse);
+
+                        // Pick the context-correct mode prob row.
+                        byte[] modeProbs;
+                        if (mbRow == 0 && mbCol == 0)       modeProbs = modeProbsRow0;
+                        else if (mbRow == 0 || mbCol == 0)  modeProbs = modeProbsRow2;
+                        else                                modeProbs = modeProbsRow5;
+
+                        // is_inter=1, ref_is_LAST=0, ZEROMV tree path.
+                        bitstream.WriteInterMbRefAndMode(
+                            ref bc0,
+                            probIntra, probLast, probGf,
+                            MV_REFERENCE_FRAME.LAST_FRAME,
+                            modeProbs,
+                            MB_PREDICTION_MODE.ZEROMV);
+                    }
                 }
             }
 
@@ -852,31 +1112,41 @@ namespace Vpx.Net
                 totalThroughP0 = bitstream.FinishInterFrameFirstPartition(p, cfg, ref bc0);
             }
 
-            // ----- Open partition 1 (token partition) -----
-            BOOL_CODER bc1 = new BOOL_CODER();
-            fixed (byte* p = outBuf)
+            // ----- Phase 4: token partition(s) -----
+            int totalBytes;
+            if (log2NumTokenPartitions == 0)
             {
-                boolhuff.vp8_start_encode(ref bc1, p + totalThroughP0, p + outBuf.Length);
-
-                int totalMbs = mbRows * mbCols;
-                for (int i = 0; i < totalMbs; i++)
+                BOOL_CODER bc1 = new BOOL_CODER();
+                fixed (byte* p = outBuf)
                 {
-                    if (mbSkip[i]) continue;
+                    boolhuff.vp8_start_encode(ref bc1, p + totalThroughP0, p + outBuf.Length);
 
-                    var r = mbResults[i];
-                    bitstream.vp8_pack_tokens(ref bc1, r.Y2Block);
-                    for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc1, r.YBlocks[b]);
-                    for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.UBlocks[b]);
-                    for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.VBlocks[b]);
+                    int totalMbs = mbRows * mbCols;
+                    using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.PackTokens))
+                    for (int i = 0; i < totalMbs; i++)
+                    {
+                        if (mbSkip[i]) continue;
+
+                        var r = mbResults[i];
+                        bitstream.vp8_pack_tokens(ref bc1, r.Y2Block);
+                        for (int b = 0; b < 16; b++) bitstream.vp8_pack_tokens(ref bc1, r.YBlocks[b]);
+                        for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.UBlocks[b]);
+                        for (int b = 0; b < 4;  b++) bitstream.vp8_pack_tokens(ref bc1, r.VBlocks[b]);
+                    }
+
+                    boolhuff.vp8_stop_encode(ref bc1);
                 }
 
-                boolhuff.vp8_stop_encode(ref bc1);
+                totalBytes = totalThroughP0 + (int)bc1.pos;
             }
-
-            int totalBytes = totalThroughP0 + (int)bc1.pos;
-            byte[] result = new byte[totalBytes];
-            Array.Copy(outBuf, result, totalBytes);
-            return result;
+            else
+            {
+                totalBytes = PackMultiPartitionTokens(buf, outBuf, totalThroughP0,
+                    mbResults, mbSkip, mbRows, mbCols, log2NumTokenPartitions);
+            }
+            return new ArraySegment<byte>(outBuf, 0, totalBytes);
+            }
+            finally { outBufPin.Free(); }
         }
 
         /// <summary>
@@ -934,27 +1204,5 @@ namespace Vpx.Net
             return true;
         }
 
-        private static void ExtractPlaneInto(byte[] src, int srcStride, int x, int y, int w, int h, byte[] dst)
-        {
-            for (int r = 0; r < h; r++)
-                for (int c = 0; c < w; c++)
-                    dst[r * w + c] = src[(y + r) * srcStride + (x + c)];
-        }
-
-        private static void ExtractRowInto(byte[] src, int offset, int count, byte[] dst)
-        {
-            for (int i = 0; i < count; i++) dst[i] = src[offset + i];
-        }
-
-        private static void ExtractColumnInto(byte[] src, int srcStride, int columnIndex, int rows, byte[] dst)
-        {
-            for (int r = 0; r < rows; r++) dst[r] = src[r * srcStride + columnIndex];
-        }
-
-        private static void CopyRowOut(byte[] src, int srcStride, int srcRow,
-            byte[] dst, int dstOffset, int count)
-        {
-            for (int i = 0; i < count; i++) dst[dstOffset + i] = src[srcRow * srcStride + i];
-        }
     }
 }

--- a/src/SIPSorcery.VP8/mb_encoder.cs
+++ b/src/SIPSorcery.VP8/mb_encoder.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: mb_encoder.cs
 //
 // Description: Per-macroblock encode pipeline for an intra-only DC_PRED
@@ -73,10 +73,37 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Vpx.Net
 {
+    /// <summary>
+    /// When set, macroblock reconstruction is written directly into the frame&apos;s
+    /// last-reference planes at the given MB position (skips per-MB <see cref="MbEncodeResult.ReconY"/> scratch for idct).
+    /// </summary>
+    internal readonly struct LastFrameFuseTarget
+    {
+        public LastFrameFuseTarget(byte[] lastY, byte[] lastU, byte[] lastV, int width, int chromaW, int mbCol, int mbRow)
+        {
+            LastY = lastY ?? throw new ArgumentNullException(nameof(lastY));
+            LastU = lastU ?? throw new ArgumentNullException(nameof(lastU));
+            LastV = lastV ?? throw new ArgumentNullException(nameof(lastV));
+            Width = width;
+            ChromaW = chromaW;
+            MbCol = mbCol;
+            MbRow = mbRow;
+        }
+
+        public byte[] LastY { get; }
+        public byte[] LastU { get; }
+        public byte[] LastV { get; }
+        public int Width { get; }
+        public int ChromaW { get; }
+        public int MbCol { get; }
+        public int MbRow { get; }
+    }
+
     /// <summary>
     /// Single-macroblock encode result: token streams (one list per of the
     /// 25 transformed blocks the decoder reconstructs) plus the
@@ -95,10 +122,10 @@ namespace Vpx.Net
         // the backing array. Reset() clears all 25 lists in place without
         // releasing the storage — designed for pool-based reuse from
         // frame_encoder so per-MB encoding doesn't allocate.
-        public List<TOKENEXTRA>[] YBlocks  = new List<TOKENEXTRA>[16];
-        public List<TOKENEXTRA>[] UBlocks  = new List<TOKENEXTRA>[4];
-        public List<TOKENEXTRA>[] VBlocks  = new List<TOKENEXTRA>[4];
-        public List<TOKENEXTRA>  Y2Block  = new List<TOKENEXTRA>(17);
+        public TokenStreamBuffer[] YBlocks  = new TokenStreamBuffer[16];
+        public TokenStreamBuffer[] UBlocks  = new TokenStreamBuffer[4];
+        public TokenStreamBuffer[] VBlocks  = new TokenStreamBuffer[4];
+        public TokenStreamBuffer  Y2Block  = new TokenStreamBuffer();
 
         /// <summary>Reconstructed 16x16 luma pixels, raster order.</summary>
         public byte[] ReconY = new byte[16 * 16];
@@ -111,9 +138,9 @@ namespace Vpx.Net
 
         public MbEncodeResult()
         {
-            for (int i = 0; i < 16; i++) YBlocks[i] = new List<TOKENEXTRA>(17);
-            for (int i = 0; i < 4;  i++) UBlocks[i] = new List<TOKENEXTRA>(17);
-            for (int i = 0; i < 4;  i++) VBlocks[i] = new List<TOKENEXTRA>(17);
+            for (int i = 0; i < 16; i++) YBlocks[i] = new TokenStreamBuffer();
+            for (int i = 0; i < 4;  i++) UBlocks[i] = new TokenStreamBuffer();
+            for (int i = 0; i < 4;  i++) VBlocks[i] = new TokenStreamBuffer();
         }
 
         /// <summary>Clear all 25 token lists in place. Backing arrays are
@@ -171,28 +198,6 @@ namespace Vpx.Net
     {
         /// <summary>
         /// Encode one 16x16 macroblock as keyframe-only, DC_PRED-only intra.
-        ///
-        /// Inputs:
-        ///   srcY:   16*16 luma source bytes, raster order (row major).
-        ///   srcU:   8*8 chroma U, raster order.
-        ///   srcV:   8*8 chroma V, raster order.
-        ///   aboveY: 16 luma bytes from the row immediately above this MB,
-        ///           or null if this is the top row of the frame.
-        ///   leftY:  16 luma bytes from the column immediately left of this
-        ///           MB, or null if this is the left column.
-        ///   aboveU/leftU/aboveV/leftV: the 8-byte chroma equivalents.
-        ///   fq:     quantizer tables built by quantizer_init.BuildForQIndex.
-        ///   aboveCtx, leftCtx: optional 9-byte entropy-context arrays
-        ///           (4 Y + 2 U + 2 V + 1 Y2 slots). When null, fresh
-        ///           zero-filled arrays are allocated for this single MB
-        ///           and discarded after — the per-MB-isolation behaviour
-        ///           used by mb_encoder unit tests. When non-null, the
-        ///           caller (typically frame_encoder) maintains them at
-        ///           frame scope and threads them across MBs: this method
-        ///           reads each block's initial context from them and
-        ///           writes the resulting non-zero/zero flag back, in
-        ///           place. See the comment block inside the method for
-        ///           the threading rules.
         /// </summary>
         public static MbEncodeResult EncodeMacroblockDcPred(
             byte[] srcY, byte[] srcU, byte[] srcV,
@@ -203,7 +208,22 @@ namespace Vpx.Net
             byte[] aboveCtx = null,
             byte[] leftCtx = null,
             MbEncodeResult result = null,
-            MbEncoderScratch scratch = null)
+            MbEncoderScratch scratch = null) =>
+            EncodeMacroblockDcPredImpl(srcY, srcU, srcV, aboveY, leftY, aboveU, leftU, aboveV, leftV,
+                fq, aboveCtx, leftCtx, result, scratch, LegacyEncoderMemoryOps.Instance, fuseToLast: null);
+
+        internal static MbEncodeResult EncodeMacroblockDcPredImpl(
+            byte[] srcY, byte[] srcU, byte[] srcV,
+            byte[] aboveY, byte[] leftY,
+            byte[] aboveU, byte[] leftU,
+            byte[] aboveV, byte[] leftV,
+            FrameQuantizer fq,
+            byte[] aboveCtx,
+            byte[] leftCtx,
+            MbEncodeResult result,
+            MbEncoderScratch scratch,
+            IEncoderMemoryOps memoryOps,
+            LastFrameFuseTarget? fuseToLast = null)
         {
             if (srcY == null || srcY.Length != 256) throw new ArgumentException("srcY must be 16*16");
             if (srcU == null || srcU.Length != 64)  throw new ArgumentException("srcU must be 8*8");
@@ -229,53 +249,60 @@ namespace Vpx.Net
             if (scratch == null) scratch = new MbEncoderScratch();
 
             // ---- Step 1: DC predictions ----
-            byte yPred = DcPred16x16(aboveY, leftY);
-            byte uPred = DcPred8x8(aboveU, leftU);
-            byte vPred = DcPred8x8(aboveV, leftV);
+            // The pipeline-level flag below replaces the previous CPU-feature
+            // gate so the Legacy pipeline runs strictly scalar code, even on
+            // a SIMD-capable host (regression: tiers 1–6 had bled into
+            // Legacy through Xxx.IsSupported gating).
+            bool useSimd = memoryOps.UseSimdEncoderKernels;
+            byte yPred = DcPred16x16(aboveY, leftY, useSimd);
+            byte uPred = DcPred8x8(aboveU, leftU, useSimd);
+            byte vPred = DcPred8x8(aboveV, leftV, useSimd);
 
             // ---- Step 2: residual = source - prediction ----
             short[] residY = scratch.ResidY;
             short[] residU = scratch.ResidU;
             short[] residV = scratch.ResidV;
-            SubtractFlatInto(srcY, yPred, residY);
-            SubtractFlatInto(srcU, uPred, residU);
-            SubtractFlatInto(srcV, vPred, residV);
+            SubtractFlatInto(srcY, yPred, residY, memoryOps);
+            SubtractFlatInto(srcU, uPred, residU, memoryOps);
+            SubtractFlatInto(srcV, vPred, residV, memoryOps);
 
             // ---- Step 3: forward DCT for each 4x4 block ----
-            // Y: 16 blocks of 4x4 carved out of the 16x16 plane.
             short[][] yCoef = scratch.YCoef;
-            for (int by = 0; by < 4; by++)
-            for (int bx = 0; bx < 4; bx++)
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Fdct))
             {
-                int blkIdx = by * 4 + bx;
-                Fdct4x4FromPlaneInto(residY, srcStride: 16,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
-                    coef: yCoef[blkIdx]);
+                for (int by = 0; by < 4; by++)
+                for (int bx = 0; bx < 4; bx += 2)
+                {
+                    int b0 = by * 4 + bx;
+                    int b1 = b0 + 1;
+                    Fdct8x4FromPlaneInto(residY, srcStride: 16, blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                        yCoef[b0], yCoef[b1], useSimd);
+                }
             }
             // U / V: 4 blocks of 4x4 each.
             short[][] uCoef = scratch.UCoef;
             short[][] vCoef = scratch.VCoef;
-            for (int by = 0; by < 2; by++)
-            for (int bx = 0; bx < 2; bx++)
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Fdct))
             {
-                int blkIdx = by * 2 + bx;
-                Fdct4x4FromPlaneInto(residU, srcStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
-                    coef: uCoef[blkIdx]);
-                Fdct4x4FromPlaneInto(residV, srcStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
-                    coef: vCoef[blkIdx]);
+                for (int by = 0; by < 2; by++)
+                for (int bx = 0; bx < 2; bx++)
+                {
+                    int blkIdx = by * 2 + bx;
+                    Fdct4x4FromPlaneInto(residU, srcStride: 8,
+                        blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                        coef: uCoef[blkIdx], useSimd: useSimd);
+                    Fdct4x4FromPlaneInto(residV, srcStride: 8,
+                        blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                        coef: vCoef[blkIdx], useSimd: useSimd);
+                }
             }
 
             // ---- Step 4: build Y2 block from the 16 Y DCs and Walsh-transform ----
-            // For 16x16 intra modes (DC_PRED, V_PRED, H_PRED, TM_PRED) the
-            // 16 Y DC coefficients are themselves transformed by a 4x4 Walsh
-            // and then quantized as a "Y2" second-order block. The 16 Y AC
-            // blocks then drop their DC (zero out coef[0]).
             short[] y2In = scratch.Y2In;
             for (int i = 0; i < 16; i++) y2In[i] = yCoef[i][0];
             short[] y2Coef = scratch.Y2Coef;
-            Walsh4x4Into(y2In, y2Coef);
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Walsh))
+                Walsh4x4Into(y2In, y2Coef, useSimd);
 
             // Zero out the DC of each Y AC block.
             for (int i = 0; i < 16; i++) yCoef[i][0] = 0;
@@ -284,25 +311,27 @@ namespace Vpx.Net
             short[][] yQ = scratch.YQ;
             short[][] yDQ = scratch.YDQ;
             int[] yEob = scratch.YEob;
-            for (int i = 0; i < 16; i++)
-            {
-                yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i]);
-            }
-
             short[] y2Q = scratch.Y2Q;
             short[] y2DQ = scratch.Y2DQ;
-            int y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ);
-
             short[][] uQ = scratch.UQ;
             short[][] uDQ = scratch.UDQ;
             short[][] vQ = scratch.VQ;
             short[][] vDQ = scratch.VDQ;
             int[] uEob = scratch.UEob;
             int[] vEob = scratch.VEob;
-            for (int i = 0; i < 4; i++)
+            int y2Eob;
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Quantize))
             {
-                uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i]);
-                vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i]);
+                for (int i = 0; i < 16; i++)
+                    yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i], useSimd);
+
+                y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ, useSimd);
+
+                for (int i = 0; i < 4; i++)
+                {
+                    uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i], useSimd);
+                    vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i], useSimd);
+                }
             }
 
             // ---- Step 6: tokenize, with per-block above/left entropy contexts ----
@@ -346,6 +375,8 @@ namespace Vpx.Net
             if (aboveCtx == null) aboveCtx = new byte[9];
             if (leftCtx == null) leftCtx = new byte[9];
 
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Tokenize))
+            {
             // Block type per libvpx:
             //   type 0 = Y AC (firstCoeffIndex = 1; DC went to Y2)
             //   type 1 = Y2
@@ -406,34 +437,50 @@ namespace Vpx.Net
                     output: result.VBlocks[i]);
                 aboveCtx[s] = leftCtx[sL] = (byte)(nz ? 1 : 0);
             }
+            }
 
             // ---- Step 7: reconstruct ----
             // Inverse Walsh on the Y2 block to recover the (quantized) DC of
             // each Y block. We write directly into the existing y2In scratch
             // buffer (now holding the recovered DCs) — y2In is no longer
             // needed for its phase-4 role at this point.
-            InverseWalsh4x4Into(y2DQ, y2In);
-            for (int i = 0; i < 16; i++)
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Reconstruct))
             {
-                yDQ[i][0] = y2In[i];
-            }
+                InverseWalsh4x4Into(y2DQ, y2In, useSimd);
+                for (int i = 0; i < 16; i++)
+                    yDQ[i][0] = y2In[i];
 
-            // For each Y block: idct(dq) + prediction -> reconstructed.
-            for (int by = 0; by < 4; by++)
-            for (int bx = 0; bx < 4; bx++)
-            {
-                int blkIdx = by * 4 + bx;
-                IdctAndAddToPlane(yDQ[blkIdx], yPred, result.ReconY,
-                    dstStride: 16, blockOffsetX: bx * 4, blockOffsetY: by * 4);
-            }
-            for (int by = 0; by < 2; by++)
-            for (int bx = 0; bx < 2; bx++)
-            {
-                int blkIdx = by * 2 + bx;
-                IdctAndAddToPlane(uDQ[blkIdx], uPred, result.ReconU,
-                    dstStride: 8, blockOffsetX: bx * 4, blockOffsetY: by * 4);
-                IdctAndAddToPlane(vDQ[blkIdx], vPred, result.ReconV,
-                    dstStride: 8, blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                byte[] yOut = fuseToLast.HasValue ? fuseToLast.Value.LastY : result.ReconY;
+                int yStride = fuseToLast.HasValue ? fuseToLast.Value.Width : 16;
+                int yOffX = fuseToLast.HasValue ? fuseToLast.Value.MbCol * 16 : 0;
+                int yOffY = fuseToLast.HasValue ? fuseToLast.Value.MbRow * 16 : 0;
+
+                for (int by = 0; by < 4; by++)
+                for (int bx = 0; bx < 4; bx++)
+                {
+                    int blkIdx = by * 4 + bx;
+                    IdctAndAddToPlane(yDQ[blkIdx], yPred, yOut,
+                        dstStride: yStride, blockOffsetX: yOffX + bx * 4, blockOffsetY: yOffY + by * 4,
+                        useSimd: useSimd);
+                }
+
+                byte[] uOut = fuseToLast.HasValue ? fuseToLast.Value.LastU : result.ReconU;
+                byte[] vOut = fuseToLast.HasValue ? fuseToLast.Value.LastV : result.ReconV;
+                int cStride = fuseToLast.HasValue ? fuseToLast.Value.ChromaW : 8;
+                int cOffX = fuseToLast.HasValue ? fuseToLast.Value.MbCol * 8 : 0;
+                int cOffY = fuseToLast.HasValue ? fuseToLast.Value.MbRow * 8 : 0;
+
+                for (int by = 0; by < 2; by++)
+                for (int bx = 0; bx < 2; bx++)
+                {
+                    int blkIdx = by * 2 + bx;
+                    IdctAndAddToPlane(uDQ[blkIdx], uPred, uOut,
+                        dstStride: cStride, blockOffsetX: cOffX + bx * 4, blockOffsetY: cOffY + by * 4,
+                        useSimd: useSimd);
+                    IdctAndAddToPlane(vDQ[blkIdx], vPred, vOut,
+                        dstStride: cStride, blockOffsetX: cOffX + bx * 4, blockOffsetY: cOffY + by * 4,
+                        useSimd: useSimd);
+                }
             }
 
             return result;
@@ -441,30 +488,7 @@ namespace Vpx.Net
 
         /// <summary>
         /// Encode one 16x16 macroblock as an inter MB using ZEROMV with
-        /// LAST_FRAME as the reference. The prediction is the same-position
-        /// 16x16 Y + 8x8 U + 8x8 V samples from the previous frame's
-        /// reconstruction (motion vector = (0, 0)). Residual = source -
-        /// prediction; the rest of the pipeline is identical to
-        /// EncodeMacroblockDcPred (forward DCT + Walsh on Y DCs +
-        /// quantize + tokenize + reconstruct).
-        ///
-        /// PR 3 of the P-frame foundation series. The caller (frame_encoder
-        /// in PR 5) supplies the per-MB prediction by extracting the
-        /// relevant 16x16 / 8x8 / 8x8 samples from the FrameEncoderBuffers
-        /// last-frame reference (added in PR 1).
-        ///
-        /// Inputs:
-        ///   srcY:   16*16 luma source bytes, raster order.
-        ///   srcU:   8*8 chroma U source, raster order.
-        ///   srcV:   8*8 chroma V source, raster order.
-        ///   predY:  16*16 luma prediction (same position from last frame).
-        ///   predU:  8*8 chroma U prediction.
-        ///   predV:  8*8 chroma V prediction.
-        ///   fq:     quantizer tables built by quantizer_init.BuildForQIndex.
-        ///   aboveCtx, leftCtx: optional 9-byte entropy-context arrays as
-        ///           per EncodeMacroblockDcPred.
-        ///   result, scratch: optional pooled buffers (see
-        ///           EncodeMacroblockDcPred for the pooling contract).
+        /// LAST_FRAME as the reference.
         /// </summary>
         public static MbEncodeResult EncodeMacroblockZeroMvLast(
             byte[] srcY, byte[] srcU, byte[] srcV,
@@ -473,7 +497,20 @@ namespace Vpx.Net
             byte[] aboveCtx = null,
             byte[] leftCtx = null,
             MbEncodeResult result = null,
-            MbEncoderScratch scratch = null)
+            MbEncoderScratch scratch = null) =>
+            EncodeMacroblockZeroMvLastImpl(srcY, srcU, srcV, predY, predU, predV, fq,
+                aboveCtx, leftCtx, result, scratch, LegacyEncoderMemoryOps.Instance, fuseToLast: null);
+
+        internal static MbEncodeResult EncodeMacroblockZeroMvLastImpl(
+            byte[] srcY, byte[] srcU, byte[] srcV,
+            byte[] predY, byte[] predU, byte[] predV,
+            FrameQuantizer fq,
+            byte[] aboveCtx,
+            byte[] leftCtx,
+            MbEncodeResult result,
+            MbEncoderScratch scratch,
+            IEncoderMemoryOps memoryOps,
+            LastFrameFuseTarget? fuseToLast = null)
         {
             if (srcY == null  || srcY.Length  != 256) throw new ArgumentException("srcY must be 16*16");
             if (srcU == null  || srcU.Length  != 64)  throw new ArgumentException("srcU must be 8*8");
@@ -502,6 +539,8 @@ namespace Vpx.Net
             if (aboveCtx == null) aboveCtx = new byte[9];
             if (leftCtx == null) leftCtx = new byte[9];
 
+            bool useSimd = memoryOps.UseSimdEncoderKernels;
+
             // ---- Step 1: residual = source - prediction ----
             //
             // ZEROMV LAST_FRAME means the prediction is the *exact*
@@ -512,44 +551,46 @@ namespace Vpx.Net
             short[] residY = scratch.ResidY;
             short[] residU = scratch.ResidU;
             short[] residV = scratch.ResidV;
-            SubtractPerPixelInto(srcY, predY, residY);
-            SubtractPerPixelInto(srcU, predU, residU);
-            SubtractPerPixelInto(srcV, predV, residV);
+            SubtractPerPixelInto(srcY, predY, residY, memoryOps);
+            SubtractPerPixelInto(srcU, predU, residU, memoryOps);
+            SubtractPerPixelInto(srcV, predV, residV, memoryOps);
 
             // ---- Step 2: forward DCT for each 4x4 block ----
-            // Same code path as DC_PRED: 16 Y blocks (4x4 carved from
-            // the 16x16 residual plane), 4 U blocks, 4 V blocks.
             short[][] yCoef = scratch.YCoef;
-            for (int by = 0; by < 4; by++)
-            for (int bx = 0; bx < 4; bx++)
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Fdct))
             {
-                int blkIdx = by * 4 + bx;
-                Fdct4x4FromPlaneInto(residY, srcStride: 16,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
-                    coef: yCoef[blkIdx]);
+                for (int by = 0; by < 4; by++)
+                for (int bx = 0; bx < 4; bx += 2)
+                {
+                    int b0 = by * 4 + bx;
+                    int b1 = b0 + 1;
+                    Fdct8x4FromPlaneInto(residY, srcStride: 16, blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                        yCoef[b0], yCoef[b1], useSimd);
+                }
             }
             short[][] uCoef = scratch.UCoef;
             short[][] vCoef = scratch.VCoef;
-            for (int by = 0; by < 2; by++)
-            for (int bx = 0; bx < 2; bx++)
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Fdct))
             {
-                int blkIdx = by * 2 + bx;
-                Fdct4x4FromPlaneInto(residU, srcStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
-                    coef: uCoef[blkIdx]);
-                Fdct4x4FromPlaneInto(residV, srcStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4,
-                    coef: vCoef[blkIdx]);
+                for (int by = 0; by < 2; by++)
+                for (int bx = 0; bx < 2; bx++)
+                {
+                    int blkIdx = by * 2 + bx;
+                    Fdct4x4FromPlaneInto(residU, srcStride: 8,
+                        blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                        coef: uCoef[blkIdx], useSimd: useSimd);
+                    Fdct4x4FromPlaneInto(residV, srcStride: 8,
+                        blockOffsetX: bx * 4, blockOffsetY: by * 4,
+                        coef: vCoef[blkIdx], useSimd: useSimd);
+                }
             }
 
             // ---- Step 3: Y2 (Walsh) on the 16 Y DCs + zero Y AC DCs ----
-            // Same as DC_PRED. ZEROMV is a 16x16 inter mode so the Y2
-            // second-order block is enabled and the Y AC blocks have
-            // their DC dropped (firstCoeffIndex = 1 in tokenize).
             short[] y2In = scratch.Y2In;
             for (int i = 0; i < 16; i++) y2In[i] = yCoef[i][0];
             short[] y2Coef = scratch.Y2Coef;
-            Walsh4x4Into(y2In, y2Coef);
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Walsh))
+                Walsh4x4Into(y2In, y2Coef, useSimd);
 
             for (int i = 0; i < 16; i++) yCoef[i][0] = 0;
 
@@ -557,36 +598,32 @@ namespace Vpx.Net
             short[][] yQ = scratch.YQ;
             short[][] yDQ = scratch.YDQ;
             int[] yEob = scratch.YEob;
-            for (int i = 0; i < 16; i++)
-            {
-                yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i]);
-            }
-
             short[] y2Q = scratch.Y2Q;
             short[] y2DQ = scratch.Y2DQ;
-            int y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ);
-
             short[][] uQ = scratch.UQ;
             short[][] uDQ = scratch.UDQ;
             short[][] vQ = scratch.VQ;
             short[][] vDQ = scratch.VDQ;
             int[] uEob = scratch.UEob;
             int[] vEob = scratch.VEob;
-            for (int i = 0; i < 4; i++)
+            int y2Eob;
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Quantize))
             {
-                uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i]);
-                vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i]);
+                for (int i = 0; i < 16; i++)
+                    yEob[i] = QuantizeBlock(yCoef[i], fq.Y1, yQ[i], yDQ[i], useSimd);
+
+                y2Eob = QuantizeBlock(y2Coef, fq.Y2, y2Q, y2DQ, useSimd);
+
+                for (int i = 0; i < 4; i++)
+                {
+                    uEob[i] = QuantizeBlock(uCoef[i], fq.UV, uQ[i], uDQ[i], useSimd);
+                    vEob[i] = QuantizeBlock(vCoef[i], fq.UV, vQ[i], vDQ[i], useSimd);
+                }
             }
 
-            // ---- Step 5: tokenize, with per-block above/left contexts ----
-            // Same context-handling rules as EncodeMacroblockDcPred (see
-            // the long comment block there explaining
-            // VP8_COMBINEENTROPYCONTEXTS and the cross-MB threading
-            // requirement). Inter MBs share the same coef-prob table as
-            // intra MBs of equivalent type, so default_coef_probs is
-            // re-used here.
-
-            // -- Y2 block (block index 24) --
+            // ---- Step 5: tokenize ----
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Tokenize))
+            {
             int slot = entropy.vp8_block2above[24];
             int slotL = entropy.vp8_block2left[24];
             bool y2NonZero = tokenize.vp8_tokenize_block(y2Q,
@@ -640,38 +677,52 @@ namespace Vpx.Net
                     output: result.VBlocks[i]);
                 aboveCtx[s] = leftCtx[sL] = (byte)(nz ? 1 : 0);
             }
+            }
 
             // ---- Step 6: reconstruct ----
-            // Inverse Walsh recovers the per-block DC. Then per-block
-            // IDCT + add the per-pixel prediction (vs DC_PRED's flat
-            // single-byte prediction).
-            InverseWalsh4x4Into(y2DQ, y2In);
-            for (int i = 0; i < 16; i++)
+            using (new EncodeProfiler.Scope(Vp8EncodeProfilePhase.Reconstruct))
             {
-                yDQ[i][0] = y2In[i];
-            }
+                InverseWalsh4x4Into(y2DQ, y2In, useSimd);
+                for (int i = 0; i < 16; i++)
+                    yDQ[i][0] = y2In[i];
 
-            for (int by = 0; by < 4; by++)
-            for (int bx = 0; bx < 4; bx++)
-            {
-                int blkIdx = by * 4 + bx;
-                IdctAndAddBlockToPlane(yDQ[blkIdx],
-                    predPlane: predY, predStride: 16,
-                    dstPlane: result.ReconY, dstStride: 16,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
-            }
-            for (int by = 0; by < 2; by++)
-            for (int bx = 0; bx < 2; bx++)
-            {
-                int blkIdx = by * 2 + bx;
-                IdctAndAddBlockToPlane(uDQ[blkIdx],
-                    predPlane: predU, predStride: 8,
-                    dstPlane: result.ReconU, dstStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
-                IdctAndAddBlockToPlane(vDQ[blkIdx],
-                    predPlane: predV, predStride: 8,
-                    dstPlane: result.ReconV, dstStride: 8,
-                    blockOffsetX: bx * 4, blockOffsetY: by * 4);
+                byte[] yOut = fuseToLast.HasValue ? fuseToLast.Value.LastY : result.ReconY;
+                int yStride = fuseToLast.HasValue ? fuseToLast.Value.Width : 16;
+                int yOffX = fuseToLast.HasValue ? fuseToLast.Value.MbCol * 16 : 0;
+                int yOffY = fuseToLast.HasValue ? fuseToLast.Value.MbRow * 16 : 0;
+
+                for (int by = 0; by < 4; by++)
+                for (int bx = 0; bx < 4; bx++)
+                {
+                    int blkIdx = by * 4 + bx;
+                    IdctAndAddBlockToPlane(yDQ[blkIdx],
+                        predPlane: predY, predStride: 16, predOffsetX: bx * 4, predOffsetY: by * 4,
+                        dstPlane: yOut, dstStride: yStride,
+                        dstOffsetX: yOffX + bx * 4, dstOffsetY: yOffY + by * 4,
+                        useSimd: useSimd);
+                }
+
+                byte[] uOut = fuseToLast.HasValue ? fuseToLast.Value.LastU : result.ReconU;
+                byte[] vOut = fuseToLast.HasValue ? fuseToLast.Value.LastV : result.ReconV;
+                int cStride = fuseToLast.HasValue ? fuseToLast.Value.ChromaW : 8;
+                int cOffX = fuseToLast.HasValue ? fuseToLast.Value.MbCol * 8 : 0;
+                int cOffY = fuseToLast.HasValue ? fuseToLast.Value.MbRow * 8 : 0;
+
+                for (int by = 0; by < 2; by++)
+                for (int bx = 0; bx < 2; bx++)
+                {
+                    int blkIdx = by * 2 + bx;
+                    IdctAndAddBlockToPlane(uDQ[blkIdx],
+                        predPlane: predU, predStride: 8, predOffsetX: bx * 4, predOffsetY: by * 4,
+                        dstPlane: uOut, dstStride: cStride,
+                        dstOffsetX: cOffX + bx * 4, dstOffsetY: cOffY + by * 4,
+                        useSimd: useSimd);
+                    IdctAndAddBlockToPlane(vDQ[blkIdx],
+                        predPlane: predV, predStride: 8, predOffsetX: bx * 4, predOffsetY: by * 4,
+                        dstPlane: vOut, dstStride: cStride,
+                        dstOffsetX: cOffX + bx * 4, dstOffsetY: cOffY + by * 4,
+                        useSimd: useSimd);
+                }
             }
 
             return result;
@@ -684,26 +735,82 @@ namespace Vpx.Net
         /// available, the prediction is the mean of the 32 boundary
         /// samples; when only one is available, just that 16; when neither,
         /// 128. The averages are rounded to nearest with the libvpx-style
-        /// "+= half" rounding.
+        /// "+= half" rounding. Inner sums use the SIMD reduce in
+        /// <see cref="DcPredSumKernels"/> only on the Optimized pipeline
+        /// (<paramref name="useSimd"/>=true); the Legacy pipeline runs the
+        /// scalar accumulator below.
         /// </summary>
-        private static byte DcPred16x16(byte[] above, byte[] left)
+        private static unsafe byte DcPred16x16(byte[] above, byte[] left, bool useSimd)
         {
             int avgAbove = 0, avgLeft = 0;
             int count = 0;
-            if (above != null) { for (int i = 0; i < 16; i++) avgAbove += above[i]; count += 16; }
-            if (left  != null) { for (int i = 0; i < 16; i++) avgLeft  += left[i];  count += 16; }
+            if (above != null)
+            {
+                if (useSimd)
+                {
+                    fixed (byte* p = above) { avgAbove = DcPredSumKernels.Sum16(p); }
+                }
+                else
+                {
+                    int s = 0;
+                    for (int i = 0; i < 16; i++) s += above[i];
+                    avgAbove = s;
+                }
+                count += 16;
+            }
+            if (left != null)
+            {
+                if (useSimd)
+                {
+                    fixed (byte* p = left) { avgLeft = DcPredSumKernels.Sum16(p); }
+                }
+                else
+                {
+                    int s = 0;
+                    for (int i = 0; i < 16; i++) s += left[i];
+                    avgLeft = s;
+                }
+                count += 16;
+            }
             if (count == 0) return 128;
             int sum = avgAbove + avgLeft;
             return (byte)((sum + count / 2) / count);
         }
 
-        /// <summary>8x8 DC_PRED — same rules as the 16x16 case.</summary>
-        private static byte DcPred8x8(byte[] above, byte[] left)
+        /// <summary>8x8 DC_PRED — same rules as the 16x16 case.
+        /// SIMD is used only when <paramref name="useSimd"/> is true.</summary>
+        private static unsafe byte DcPred8x8(byte[] above, byte[] left, bool useSimd)
         {
             int avgAbove = 0, avgLeft = 0;
             int count = 0;
-            if (above != null) { for (int i = 0; i < 8; i++) avgAbove += above[i]; count += 8; }
-            if (left  != null) { for (int i = 0; i < 8; i++) avgLeft  += left[i];  count += 8; }
+            if (above != null)
+            {
+                if (useSimd)
+                {
+                    fixed (byte* p = above) { avgAbove = DcPredSumKernels.Sum8(p); }
+                }
+                else
+                {
+                    int s = 0;
+                    for (int i = 0; i < 8; i++) s += above[i];
+                    avgAbove = s;
+                }
+                count += 8;
+            }
+            if (left != null)
+            {
+                if (useSimd)
+                {
+                    fixed (byte* p = left) { avgLeft = DcPredSumKernels.Sum8(p); }
+                }
+                else
+                {
+                    int s = 0;
+                    for (int i = 0; i < 8; i++) s += left[i];
+                    avgLeft = s;
+                }
+                count += 8;
+            }
             if (count == 0) return 128;
             int sum = avgAbove + avgLeft;
             return (byte)((sum + count / 2) / count);
@@ -712,56 +819,113 @@ namespace Vpx.Net
         /// <summary>Subtracts a flat prediction value from each source byte
         /// into <paramref name="dst"/>. <paramref name="dst"/> must be at
         /// least as long as <paramref name="src"/>.</summary>
-        private static void SubtractFlatInto(byte[] src, byte pred, short[] dst)
+        private static void SubtractFlatInto(byte[] src, byte pred, short[] dst, IEncoderMemoryOps ops)
         {
-            for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred);
+            ops.SubtractFlat(src, pred, dst);
         }
 
         /// <summary>Per-pixel subtract: dst[i] = src[i] - pred[i]. Used by
         /// the ZEROMV inter path where the prediction is a same-position
         /// MB from the last frame's reconstruction. Lengths must match.</summary>
-        private static void SubtractPerPixelInto(byte[] src, byte[] pred, short[] dst)
+        private static void SubtractPerPixelInto(byte[] src, byte[] pred, short[] dst, IEncoderMemoryOps ops)
         {
-            for (int i = 0; i < src.Length; i++) dst[i] = (short)(src[i] - pred[i]);
+            ops.SubtractPerPixel(src, pred, dst);
         }
 
         /// <summary>
-        /// Extract a 4x4 sub-block from <paramref name="plane"/> (raster order
-        /// at <paramref name="srcStride"/>) and forward-DCT it into the
-        /// provided <paramref name="coef"/> buffer (must be at least 16
-        /// shorts long). The intermediate 4x4 input block is stack-
-        /// allocated so this entire helper does no heap allocation.
+        /// 8x4 forward DCT for two adjacent 4x4 blocks. Optimized pipeline
+        /// (<paramref name="useSimd"/>=true) folds the gather into a strided
+        /// SIMD load via <see cref="FdctEncoderSimd.Fdct8x4Split"/>; Legacy
+        /// pipeline uses the original stackalloc gather + scalar
+        /// <see cref="dct.vp8_short_fdct4x4_c"/> baseline so the two
+        /// pipelines differ end-to-end.
         /// </summary>
-        private static unsafe void Fdct4x4FromPlaneInto(short[] plane, int srcStride, int blockOffsetX, int blockOffsetY, short[] coef)
+        private static unsafe void Fdct8x4FromPlaneInto(short[] plane, int srcStride, int blockOffsetX, int blockOffsetY,
+            short[] coefLeft, short[] coefRight, bool useSimd)
         {
+            if (useSimd && FdctEncoderSimd.IsSupported)
+            {
+                int rowOffset = blockOffsetY * srcStride + blockOffsetX;
+                fixed (short* planeP = plane)
+                fixed (short* outL = coefLeft)
+                fixed (short* outR = coefRight)
+                {
+                    FdctEncoderSimd.Fdct8x4Split(planeP + rowOffset, outL, outR, pitch: srcStride * 2);
+                }
+                return;
+            }
+
+            // Legacy: stack-gather each 4x4 half and call the scalar fdct twice.
+            Span<short> blockL = stackalloc short[16];
+            Span<short> blockR = stackalloc short[16];
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+            {
+                int planeIdx = (blockOffsetY + r) * srcStride + (blockOffsetX + c);
+                blockL[r * 4 + c] = plane[planeIdx];
+                blockR[r * 4 + c] = plane[planeIdx + 4];
+            }
+
+            fixed (short* inL = blockL) fixed (short* outL = coefLeft)
+                dct.vp8_short_fdct4x4_c(inL, outL, pitch: 8);
+            fixed (short* inR = blockR) fixed (short* outR = coefRight)
+                dct.vp8_short_fdct4x4_c(inR, outR, pitch: 8);
+        }
+
+        /// <summary>
+        /// 4x4 forward DCT. Optimized pipeline uses
+        /// <see cref="FdctEncoderSimd.Fdct4x4"/> with strided load; Legacy
+        /// pipeline gathers a 16-short block on the stack and calls the
+        /// scalar <see cref="dct.vp8_short_fdct4x4_c"/>.
+        /// </summary>
+        private static unsafe void Fdct4x4FromPlaneInto(short[] plane, int srcStride, int blockOffsetX, int blockOffsetY,
+            short[] coef, bool useSimd)
+        {
+            if (useSimd && FdctEncoderSimd.IsSupported)
+            {
+                int rowOffset = blockOffsetY * srcStride + blockOffsetX;
+                fixed (short* planeP = plane)
+                fixed (short* outP = coef)
+                {
+                    FdctEncoderSimd.Fdct4x4(planeP + rowOffset, outP, pitch: srcStride * 2);
+                }
+                return;
+            }
+
             Span<short> block = stackalloc short[16];
             for (int r = 0; r < 4; r++)
             for (int c = 0; c < 4; c++)
                 block[r * 4 + c] = plane[(blockOffsetY + r) * srcStride + (blockOffsetX + c)];
-
-            fixed (short* inP = block)
-            fixed (short* outP = coef)
-            {
+            fixed (short* inP = block) fixed (short* outP = coef)
                 dct.vp8_short_fdct4x4_c(inP, outP, pitch: 8);
-            }
         }
 
         /// <summary>4x4 Walsh-Hadamard from <paramref name="input"/> into
-        /// the supplied <paramref name="outBuf"/>. No allocation.</summary>
-        private static unsafe void Walsh4x4Into(short[] input, short[] outBuf)
+        /// the supplied <paramref name="outBuf"/>. No allocation. SIMD is
+        /// used only when <paramref name="useSimd"/> is true (Optimized
+        /// pipeline) and <see cref="WalshEncoderSimd.IsSupported"/>.</summary>
+        private static unsafe void Walsh4x4Into(short[] input, short[] outBuf, bool useSimd)
         {
             fixed (short* inP = input)
             fixed (short* outP = outBuf)
             {
-                dct.vp8_short_walsh4x4_c(inP, outP, pitch: 8);
+                if (useSimd && WalshEncoderSimd.IsSupported)
+                {
+                    WalshEncoderSimd.Walsh4x4(inP, outP, pitch: 8);
+                }
+                else
+                {
+                    dct.vp8_short_walsh4x4_c(inP, outP, pitch: 8);
+                }
             }
         }
 
         /// <summary>
         /// Quantize a 16-coefficient block using the supplied tables, with
-        /// zbin_extra = 0. Returns the EOB.
+        /// zbin_extra = 0. Returns the EOB. SIMD is used only when
+        /// <paramref name="useSimd"/> is true (Optimized pipeline).
         /// </summary>
-        private static unsafe int QuantizeBlock(short[] coef, QuantizerTables t, short[] qcoeff, short[] dqcoeff)
+        private static unsafe int QuantizeBlock(short[] coef, QuantizerTables t, short[] qcoeff, short[] dqcoeff, bool useSimd)
         {
             fixed (short* coefP = coef)
             fixed (short* zbinP = t.zbin)
@@ -773,6 +937,13 @@ namespace Vpx.Net
             fixed (short* qP = qcoeff)
             fixed (short* dqP = dqcoeff)
             {
+                if (useSimd && QuantizeEncoderSimd.IsSupported)
+                {
+                    return QuantizeEncoderSimd.RegularQuantizeB(
+                        coefP, zbinP, zboostP, roundP, quantP, qshiftP, dequantP,
+                        qP, dqP, zbin_extra: 0);
+                }
+
                 return quantize.vp8_regular_quantize_b_arrays(
                     coefP, zbinP, zboostP, roundP, quantP, qshiftP, dequantP,
                     qP, dqP, zbin_extra: 0);
@@ -784,10 +955,21 @@ namespace Vpx.Net
         /// (the second-order inverse Walsh used in 16x16 intra modes).
         /// libvpx writes into an MB-wide dqcoeff buffer; we write into the
         /// supplied <paramref name="outBuf"/>. The 16-element row-pass
-        /// scratch is stack-allocated. No heap allocation.
+        /// scratch is stack-allocated. No heap allocation. SIMD is used
+        /// only when <paramref name="useSimd"/> is true (Optimized pipeline).
         /// </summary>
-        private static void InverseWalsh4x4Into(short[] input, short[] outBuf)
+        private static unsafe void InverseWalsh4x4Into(short[] input, short[] outBuf, bool useSimd)
         {
+            if (useSimd && WalshEncoderSimd.IsSupported)
+            {
+                fixed (short* inP = input)
+                fixed (short* outP = outBuf)
+                {
+                    WalshEncoderSimd.InverseWalsh4x4(inP, outP);
+                }
+                return;
+            }
+
             Span<int> tmp = stackalloc int[16];
             int a1, b1, c1, d1, a2, b2, c2, d2;
 
@@ -827,16 +1009,27 @@ namespace Vpx.Net
 
         /// <summary>
         /// Inverse-DCT a 16-element block, add a flat prediction, write the
-        /// resulting bytes to a 4x4 sub-block of <paramref name="dstPlane"/>.
-        /// Reuses the existing decoder-side idctllm.vp8_short_idct4x4llm_c.
-        /// The 4x4 prediction and output buffers are stack-allocated.
+        /// resulting bytes directly into a 4x4 sub-block of
+        /// <paramref name="dstPlane"/>. SIMD is used only when
+        /// <paramref name="useSimd"/> is true (Optimized pipeline) and
+        /// <see cref="IdctEncoderSimd.IsSupported"/>; otherwise the scalar
+        /// pred-fill + scalar copy-back path is used. Bit-exact with
+        /// idctllm.vp8_short_idct4x4llm_c followed by add+clamp.
         /// </summary>
         private static unsafe void IdctAndAddToPlane(short[] dqcoeff, byte pred,
-            byte[] dstPlane, int dstStride, int blockOffsetX, int blockOffsetY)
+            byte[] dstPlane, int dstStride, int blockOffsetX, int blockOffsetY, bool useSimd)
         {
-            // The decoder's idct adds to a prediction buffer and clamps to
-            // [0, 255]. Build a 4x4 prediction buffer (all = pred), call
-            // idct, then copy back to the destination plane.
+            if (useSimd && IdctEncoderSimd.IsSupported)
+            {
+                fixed (short* coefP = dqcoeff)
+                fixed (byte* dstBase = dstPlane)
+                {
+                    IdctEncoderSimd.Idct4x4AddFlat(coefP, pred,
+                        dstBase + blockOffsetY * dstStride + blockOffsetX, dstStride);
+                }
+                return;
+            }
+
             byte* predBuf = stackalloc byte[16];
             for (int i = 0; i < 16; i++) predBuf[i] = pred;
             byte* dstBuf = stackalloc byte[16];
@@ -852,21 +1045,35 @@ namespace Vpx.Net
         }
 
         /// <summary>
-        /// Per-pixel-prediction variant of IdctAndAddToPlane. Extracts the
-        /// relevant 4x4 sub-block of <paramref name="predPlane"/> as the
-        /// prediction buffer (vs the flat-byte version used by DC_PRED),
-        /// then runs the same inverse-DCT + clamp-and-add through the
-        /// existing decoder-side idctllm.vp8_short_idct4x4llm_c.
+        /// Per-pixel-prediction variant of IdctAndAddToPlane. When SIMD is
+        /// enabled (<paramref name="useSimd"/>=true) and supported, reads the
+        /// 4x4 prediction directly from <paramref name="predPlane"/> at
+        /// <paramref name="predStride"/> and writes the clamped result
+        /// directly into <paramref name="dstPlane"/> — no intermediate 4x4
+        /// stack pred buffer or copy-back. Legacy pipeline always takes the
+        /// scalar gather + idctllm + scatter path.
         /// </summary>
         private static unsafe void IdctAndAddBlockToPlane(short[] dqcoeff,
-            byte[] predPlane, int predStride,
-            byte[] dstPlane, int dstStride,
-            int blockOffsetX, int blockOffsetY)
+            byte[] predPlane, int predStride, int predOffsetX, int predOffsetY,
+            byte[] dstPlane, int dstStride, int dstOffsetX, int dstOffsetY, bool useSimd)
         {
+            if (useSimd && IdctEncoderSimd.IsSupported)
+            {
+                fixed (short* coefP = dqcoeff)
+                fixed (byte* predBase = predPlane)
+                fixed (byte* dstBase = dstPlane)
+                {
+                    IdctEncoderSimd.Idct4x4AddBlock(coefP,
+                        predBase + predOffsetY * predStride + predOffsetX, predStride,
+                        dstBase + dstOffsetY * dstStride + dstOffsetX, dstStride);
+                }
+                return;
+            }
+
             byte* predBuf = stackalloc byte[16];
             for (int r = 0; r < 4; r++)
             for (int c = 0; c < 4; c++)
-                predBuf[r * 4 + c] = predPlane[(blockOffsetY + r) * predStride + (blockOffsetX + c)];
+                predBuf[r * 4 + c] = predPlane[(predOffsetY + r) * predStride + (predOffsetX + c)];
 
             byte* dstBuf = stackalloc byte[16];
 
@@ -877,7 +1084,7 @@ namespace Vpx.Net
 
             for (int r = 0; r < 4; r++)
             for (int c = 0; c < 4; c++)
-                dstPlane[(blockOffsetY + r) * dstStride + (blockOffsetX + c)] = dstBuf[r * 4 + c];
+                dstPlane[(dstOffsetY + r) * dstStride + (dstOffsetX + c)] = dstBuf[r * 4 + c];
         }
 
         /// <summary>

--- a/src/SIPSorcery.VP8/quantize.cs
+++ b/src/SIPSorcery.VP8/quantize.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: quantize.cs
 //
 // Description: Forward quantization for the VP8 encoder. Port of:
@@ -36,10 +36,71 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
 namespace Vpx.Net
 {
     public static unsafe class quantize
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ClearBlockOutputs(short* qcoeff, short* dqcoeff)
+        {
+            // Bit-identical to memset 32 bytes per output buffer; use vector stores when available.
+            if (Avx2.IsSupported)
+            {
+                var z = Vector256<short>.Zero;
+                Unsafe.WriteUnaligned(ref *(byte*)qcoeff, z);
+                Unsafe.WriteUnaligned(ref *(byte*)dqcoeff, z);
+            }
+            else if (Sse2.IsSupported || AdvSimd.IsSupported)
+            {
+                var z = Vector128<short>.Zero;
+                Unsafe.WriteUnaligned(ref *(byte*)qcoeff, z);
+                Unsafe.WriteUnaligned(ref *(byte*)(qcoeff + 8), z);
+                Unsafe.WriteUnaligned(ref *(byte*)dqcoeff, z);
+                Unsafe.WriteUnaligned(ref *(byte*)(dqcoeff + 8), z);
+            }
+            else
+            {
+                new Span<short>(qcoeff, 16).Clear();
+                new Span<short>(dqcoeff, 16).Clear();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<short> Upper8ShortsToLower4(Vector128<short> eightShorts) =>
+            Sse2.ShiftRightLogical128BitLane(eightShorts.AsByte(), 8).AsInt16();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WidenCoeffRaster16ToInt32(short* coeff, int* dst)
+        {
+            if (Avx2.IsSupported)
+            {
+                var w0 = Avx2.ConvertToVector256Int32(Sse2.LoadVector128(coeff));
+                var w1 = Avx2.ConvertToVector256Int32(Sse2.LoadVector128(coeff + 8));
+                Unsafe.WriteUnaligned(ref *(byte*)dst, w0);
+                Unsafe.WriteUnaligned(ref *(byte*)(dst + 8), w1);
+            }
+            else if (Sse41.IsSupported)
+            {
+                var s0 = Sse2.LoadVector128(coeff);
+                var s1 = Sse2.LoadVector128(coeff + 8);
+                Unsafe.WriteUnaligned(ref *(byte*)dst, Sse41.ConvertToVector128Int32(s0));
+                Unsafe.WriteUnaligned(ref *(byte*)(dst + 4), Sse41.ConvertToVector128Int32(Upper8ShortsToLower4(s0)));
+                Unsafe.WriteUnaligned(ref *(byte*)(dst + 8), Sse41.ConvertToVector128Int32(s1));
+                Unsafe.WriteUnaligned(ref *(byte*)(dst + 12), Sse41.ConvertToVector128Int32(Upper8ShortsToLower4(s1)));
+            }
+            else
+            {
+                for (int j = 0; j < 16; j++)
+                    dst[j] = coeff[j];
+            }
+        }
+
         /// <summary>
         /// Bit-exact port of libvpx vp8_regular_quantize_b_c.
         ///
@@ -75,12 +136,15 @@ namespace Vpx.Net
             int zbin_boost_idx = 0;
 
             // Zero out outputs (libvpx uses memset(_, 0, 32) — 32 bytes == 16 shorts).
-            for (int j = 0; j < 16; j++) { qcoeff[j] = 0; dqcoeff[j] = 0; }
+            ClearBlockOutputs(qcoeff, dqcoeff);
+
+            int* coeff32 = stackalloc int[16];
+            WidenCoeffRaster16ToInt32(coeff, coeff32);
 
             for (int i = 0; i < 16; ++i)
             {
                 int rc = entropy.vp8_default_zig_zag1d[i];
-                int z = coeff[rc];
+                int z = coeff32[rc];
 
                 int zbin_thr = zbin[rc] + zrun_zbin_boost[zbin_boost_idx] + zbin_extra;
                 zbin_boost_idx++;

--- a/src/SIPSorcery.VP8/reconintra.cs
+++ b/src/SIPSorcery.VP8/reconintra.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: reconintra.cs
 //
 // Description: Port of:
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 using ptrdiff_t = System.Int64;
 
 [assembly: InternalsVisibleTo("SIPSorcery.VP8.UnitTest")]
+[assembly: InternalsVisibleTo("SIPSorcery.VP8.Benchmarks")]
 
 namespace Vpx.Net
 {

--- a/src/SIPSorcery.VP8/tokenize.cs
+++ b/src/SIPSorcery.VP8/tokenize.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: tokenize.cs
 //
 // Description: Coefficient tokenizer for the VP8 encoder. Port of the
@@ -32,30 +32,78 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 using vp8_prob = System.Byte;
 
 namespace Vpx.Net
 {
     /// <summary>
-    /// One token emitted by the tokenizer. Mirrors libvpx's TOKENEXTRA but
-    /// holds the 11-element probability row directly (as a byte[]) instead
-    /// of the C-style pointer-into-a-4D-table.
+    /// One token emitted by the tokenizer. Mirrors libvpx's TOKENEXTRA:
+    /// coefficient tree probabilities are referenced by row index into the
+    /// flat cache built for the active <c>coef_probs</c> table (see
+    /// <see cref="tokenize.EnsureCoefProbCache"/> / pack via
+    /// <see cref="tokenize.GetCoefProbRowForPack"/>).
     /// </summary>
     public struct TOKENEXTRA
     {
-        /// <summary>11-element probability row indexed by tree node (0..10).</summary>
-        public vp8_prob[] context_tree;
-
-        /// <summary>Magnitude/sign extra bits for category tokens; 0 for ZERO..FOUR.</summary>
-        public short Extra;
-
         /// <summary>Token value 0..11 (ZERO..DCT_EOB_TOKEN).</summary>
         public byte Token;
 
         /// <summary>1 if the EOB tree-node bit is implicit (skip), 0 otherwise.</summary>
         public byte skip_eob_node;
+
+        /// <summary>Row in the flattened coef-prob table: type * (bands*ctx) + band * ctx + prev.</summary>
+        public byte CoefProbRowIndex;
+
+        /// <summary>Magnitude/sign extra bits for category tokens; 0 for ZERO..FOUR.</summary>
+        public short Extra;
+    }
+
+    /// <summary>
+    /// Fixed-capacity token stream for one 4×4 block. Avoids per-MB <see cref="List{T}"/>
+    /// growth on the encoder hot path; capacity covers worst-case token count for one block.
+    /// </summary>
+    public sealed class TokenStreamBuffer : IEnumerable<TOKENEXTRA>
+    {
+        public const int DefaultCapacity = 24;
+        private readonly TOKENEXTRA[] _items;
+
+        public TokenStreamBuffer(int capacity = DefaultCapacity) =>
+            _items = new TOKENEXTRA[capacity];
+
+        public int Count { get; private set; }
+
+        public TOKENEXTRA this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException(nameof(index));
+                return _items[index];
+            }
+        }
+
+        public void Clear() => Count = 0;
+
+        public IEnumerator<TOKENEXTRA> GetEnumerator()
+        {
+            for (int i = 0; i < Count; i++)
+                yield return _items[i];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(TOKENEXTRA t)
+        {
+            if (Count >= _items.Length)
+                throw new InvalidOperationException("Token buffer capacity exceeded.");
+            _items[Count++] = t;
+        }
+
+        public ReadOnlySpan<TOKENEXTRA> AsSpan() => _items.AsSpan(0, Count);
     }
 
     public static unsafe class tokenize
@@ -85,7 +133,7 @@ namespace Vpx.Net
         /// <param name="coefProbs">[type, band, ctx, node] probability
         /// table; typically default_coef_probs_c.default_coef_probs at the
         /// start of a keyframe.</param>
-        /// <param name="output">List to append TOKENEXTRAs to.</param>
+        /// <param name="output">Token stream buffer for this block (cleared by caller via <see cref="TokenStreamBuffer.Clear"/>).</param>
         /// <returns>true if the block has any non-zero coefficient (the
         /// caller updates entropy contexts on this); false if the block
         /// was entirely zero from <paramref name="firstCoeffIndex"/>.</returns>
@@ -96,7 +144,7 @@ namespace Vpx.Net
             int blockType,
             int initialContext,
             vp8_prob[,,,] coefProbs,
-            List<TOKENEXTRA> output)
+            TokenStreamBuffer output)
         {
             int c = firstCoeffIndex;
             int pt = initialContext;
@@ -110,7 +158,7 @@ namespace Vpx.Net
                 {
                     Token = (byte)entropy.DCT_EOB_TOKEN,
                     Extra = 0,
-                    context_tree = SliceProbRow(coefProbs, blockType, band, pt),
+                    CoefProbRowIndex = CoefProbRowIndex(coefProbs, blockType, band, pt),
                     skip_eob_node = 0,
                 });
                 return false;
@@ -130,7 +178,7 @@ namespace Vpx.Net
                 {
                     Token = (byte)tv.Token,
                     Extra = tv.Extra,
-                    context_tree = SliceProbRow(coefProbs, blockType, firstBand, pt),
+                    CoefProbRowIndex = CoefProbRowIndex(coefProbs, blockType, firstBand, pt),
                     skip_eob_node = 0,
                 });
 
@@ -150,7 +198,7 @@ namespace Vpx.Net
                 {
                     Token = (byte)tv.Token,
                     Extra = tv.Extra,
-                    context_tree = SliceProbRow(coefProbs, blockType, band, pt),
+                    CoefProbRowIndex = CoefProbRowIndex(coefProbs, blockType, band, pt),
                     // skip_eob_node is set when the previous token's class
                     // was 0 (i.e. ZERO_TOKEN): the EOB node is implicitly
                     // not present and the encoder skips writing it.
@@ -170,7 +218,7 @@ namespace Vpx.Net
                 {
                     Token = (byte)entropy.DCT_EOB_TOKEN,
                     Extra = 0,
-                    context_tree = SliceProbRow(coefProbs, blockType, band, pt),
+                    CoefProbRowIndex = CoefProbRowIndex(coefProbs, blockType, band, pt),
                     skip_eob_node = 0,
                 });
             }
@@ -179,64 +227,76 @@ namespace Vpx.Net
         }
 
         // 4 block types x 8 coef bands x 3 prev-token contexts = 96 unique
-        // probability rows in the default_coef_probs table. The encoder
-        // hot path calls SliceProbRow up to ~75 times per MB (= ~90,000
-        // calls per 640x480 frame). Each fresh allocation is ~32 bytes
-        // (16 byte header + 11 byte payload aligned to 8); allocating
-        // 90K of those per frame is ~3 MB/sec of GC pressure on a
-        // 30 fps stream, which is exactly the kind of per-frame
-        // allocation the encoder needs to avoid.
-        //
-        // Caching strategy: lazily build a flat vp8_prob[][] keyed by
-        // (type * 24 + band * 3 + ctx) the first time we see a given
-        // coefProbs reference, and reuse on every subsequent call. The
-        // common case (and only case in the current encoder) is the
-        // singleton default_coef_probs.default_coef_probs table.
-        private static vp8_prob[,,,] s_cachedTable;
-        private static vp8_prob[][]  s_cachedRows;
-        private static readonly object s_cacheLock = new object();
+        // probability rows in the default_coef_probs table. Packing uses
+        // a dense row index on each TOKENEXTRA instead of storing a byte[]
+        // reference (smaller token records; same cache).
+        // One flat vp8_prob[][] per coef table instance (reference-keyed) so
+        // parallel encodes/tests with different coefProbs cannot clobber each other.
+        private static readonly ConditionalWeakTable<vp8_prob[,,,], vp8_prob[][]> s_coefRowsByTable =
+            new ConditionalWeakTable<vp8_prob[,,,], vp8_prob[][]>();
 
-        private static vp8_prob[] SliceProbRow(vp8_prob[,,,] coefProbs, int type, int band, int ctx)
+        // Cached delegate so the per-token-pack <see cref="ConditionalWeakTable.GetValue"/>
+        // call doesn't allocate a fresh CreateValueCallback every invocation. Profiler
+        // showed 150k+ method-group-to-delegate allocations per 640x480 keyframe before
+        // this change (~8 MB / frame).
+        private static readonly ConditionalWeakTable<vp8_prob[,,,], vp8_prob[][]>.CreateValueCallback s_buildCoefRows = BuildCoefRows;
+
+        // Per-thread last table + rows: avoids a ConditionalWeakTable GetValue on repeat
+        // packing with the same coefProbs reference (typical: default_coef_probs every
+        // token). Must not be process-wide statics — two threads packing different tables
+        // could otherwise race and return the wrong row array.
+        [System.ThreadStatic] private static vp8_prob[,,,] t_lastCoefKey;
+        [System.ThreadStatic] private static vp8_prob[][] t_lastCoefRows;
+
+        /// <summary>Forces row materialisation for <paramref name="coefProbs"/> (e.g. benchmarks).</summary>
+        internal static void EnsureCoefProbCache(vp8_prob[,,,] coefProbs) => _ = RowsFor(coefProbs);
+
+        private static vp8_prob[][] RowsFor(vp8_prob[,,,] coefProbs)
         {
-            // Fast path: same table reference as the previous cache fill.
-            if (object.ReferenceEquals(coefProbs, s_cachedTable))
-            {
-                return s_cachedRows[type * 24 + band * 3 + ctx];
-            }
+            if (coefProbs == null) throw new ArgumentNullException(nameof(coefProbs));
+            if (ReferenceEquals(coefProbs, t_lastCoefKey))
+                return t_lastCoefRows;
 
-            // Cache miss: build the cache for this table, then return.
-            return BuildCacheAndSlice(coefProbs, type, band, ctx);
+            var rows = s_coefRowsByTable.GetValue(coefProbs, s_buildCoefRows);
+            t_lastCoefKey = coefProbs;
+            t_lastCoefRows = rows;
+            return rows;
         }
 
-        private static vp8_prob[] BuildCacheAndSlice(vp8_prob[,,,] coefProbs, int type, int band, int ctx)
+        private static vp8_prob[][] BuildCoefRows(vp8_prob[,,,] coef)
         {
-            lock (s_cacheLock)
-            {
-                if (!object.ReferenceEquals(coefProbs, s_cachedTable))
-                {
-                    int blockTypes = coefProbs.GetLength(0);
-                    int coefBands  = coefProbs.GetLength(1);
-                    int prevCtx    = coefProbs.GetLength(2);
-                    int nodes      = coefProbs.GetLength(3);
-                    var rows = new vp8_prob[blockTypes * coefBands * prevCtx][];
-                    for (int t = 0; t < blockTypes; t++)
-                        for (int b = 0; b < coefBands; b++)
-                            for (int c = 0; c < prevCtx; c++)
-                            {
-                                var row = new vp8_prob[nodes];
-                                for (int i = 0; i < nodes; i++)
-                                    row[i] = coefProbs[t, b, c, i];
-                                rows[t * (coefBands * prevCtx) + b * prevCtx + c] = row;
-                            }
-                    // Publish atomically so concurrent readers see a fully
-                    // initialised cache.
-                    System.Threading.Interlocked.Exchange(ref s_cachedRows,  rows);
-                    System.Threading.Interlocked.Exchange(ref s_cachedTable, coefProbs);
-                }
-                return s_cachedRows[type * (coefProbs.GetLength(1) * coefProbs.GetLength(2))
-                                  + band * coefProbs.GetLength(2)
-                                  + ctx];
-            }
+            int blockTypes = coef.GetLength(0);
+            int coefBands  = coef.GetLength(1);
+            int prevCtx    = coef.GetLength(2);
+            int nodes      = coef.GetLength(3);
+            var rows = new vp8_prob[blockTypes * coefBands * prevCtx][];
+            for (int t = 0; t < blockTypes; t++)
+                for (int b = 0; b < coefBands; b++)
+                    for (int c = 0; c < prevCtx; c++)
+                    {
+                        var row = new vp8_prob[nodes];
+                        for (int i = 0; i < nodes; i++)
+                            row[i] = coef[t, b, c, i];
+                        rows[t * (coefBands * prevCtx) + b * prevCtx + c] = row;
+                    }
+            return rows;
+        }
+
+        /// <summary>Resolves a coefficient tree probability row for token packing or decode tests.</summary>
+        internal static vp8_prob[] GetCoefProbRowForPack(vp8_prob[,,,] coefProbs, byte rowIndex)
+        {
+            var rows = RowsFor(coefProbs);
+            if (rowIndex >= rows.Length)
+                throw new ArgumentOutOfRangeException(nameof(rowIndex), "Coef probability row index out of range.");
+            return rows[rowIndex];
+        }
+
+        private static byte CoefProbRowIndex(vp8_prob[,,,] coefProbs, int type, int band, int ctx)
+        {
+            _ = RowsFor(coefProbs);
+            int w = coefProbs.GetLength(2);
+            int idx = type * (coefProbs.GetLength(1) * w) + band * w + ctx;
+            return (byte)idx;
         }
     }
 }

--- a/test/SIPSorcery.VP8.Benchmarks/EncodePipelineBenchmarks.cs
+++ b/test/SIPSorcery.VP8.Benchmarks/EncodePipelineBenchmarks.cs
@@ -1,0 +1,146 @@
+using BenchmarkDotNet.Attributes;
+using Vpx.Net;
+
+namespace SIPSorcery.VP8.Benchmarks;
+
+/// <summary>
+/// E2E-ish pipeline timings (Release, warmed BDN). Example host: Apple M1 Max, .NET 10 —
+/// <see cref="Keyframe_Optimized_1280x720"/> mean ~132 ms (DefaultJob); 640×480 <see cref="Keyframe_Optimized"/> is several times faster in wall time.
+/// Run <c>dotnet run -c Release --project test/SIPSorcery.VP8.Benchmarks -- -f *Keyframe_Optimized* -j short</c> on your machine.
+/// <c>Program --dump-profiler</c> prints wall vs scoped-sum for 640×480 and 1280×720 with <see cref="EncodeProfiler"/> enabled (slower; for bucket attribution).
+/// </summary>
+[SimpleJob]
+[MemoryDiagnoser]
+public class EncodePipelineBenchmarks
+{
+    private byte[] _i420640 = null!;
+    private byte[] _i4201280 = null!;
+    /// <summary>Second frame bytes for P-frame encode (after keyframe seeds LAST_FRAME).</summary>
+    private byte[] _i420Inter = null!;
+    private FrameEncoderBuffers _bufLegacy = null!;
+    private FrameEncoderBuffers _bufOpt = null!;
+    private FrameEncoderBuffers _bufMp4 = null!;
+    private FrameEncoderBuffers _bufMp4_1280 = null!;
+    private IVp8FrameEncodePipeline _optMp4 = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        FillRandomI420(640, 480, seed: 42, out _i420640);
+        FillRandomI420(1280, 720, seed: 44, out _i4201280);
+        // Inter frame: small per-pixel perturbation of the keyframe so the
+        // residual is realistic rather than pathologically random (which
+        // overflows the boolhuff partition buffer in the encoder).
+        _i420Inter = new byte[_i420640.Length];
+        var rng = new Random(43);
+        for (int i = 0; i < _i420640.Length; i++)
+        {
+            int delta = rng.Next(-8, 9);
+            int v = _i420640[i] + delta;
+            if (v < 0) v = 0; else if (v > 255) v = 255;
+            _i420Inter[i] = (byte)v;
+        }
+        _bufLegacy = new FrameEncoderBuffers();
+        _bufOpt = new FrameEncoderBuffers();
+        _bufMp4 = new FrameEncoderBuffers();
+        _bufMp4_1280 = new FrameEncoderBuffers();
+        // Optimized pipeline configured for 4 token partitions (log2 = 2).
+        _optMp4 = Vp8FrameEncodePipelineFactory.Create(Vp8EncodePipelineKind.Optimized, log2NumTokenPartitions: 2);
+    }
+
+    private static void FillRandomI420(int w, int h, int seed, out byte[] i420)
+    {
+        int y = w * h, uv = y / 4;
+        i420 = new byte[y + 2 * uv];
+        new Random(seed).NextBytes(i420);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Keyframe_Legacy() =>
+        LegacyVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+            _i420640, 640, 480, 32, _bufLegacy).Count;
+
+    [Benchmark]
+    public int Keyframe_Optimized() =>
+        OptimizedVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+            _i420640, 640, 480, 32, _bufOpt).Count;
+
+    [Benchmark]
+    public int Keyframe_Legacy_1280x720() =>
+        LegacyVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+            _i4201280, 1280, 720, 32, _bufLegacy).Count;
+
+    [Benchmark]
+    public int Keyframe_Optimized_1280x720() =>
+        OptimizedVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+            _i4201280, 1280, 720, 32, _bufOpt).Count;
+
+    /// <summary>Restores LAST_FRAME from <see cref="_i420640"/> before each inter iteration.
+    /// Uses the matching pipeline so each pipeline's reconstruction state is consistent
+    /// across the I-frame seed and the P-frame measurement (previous setup primed both
+    /// pipelines on every iteration, doubling the measured cost).</summary>
+    [IterationSetup(Target = nameof(Inter_Legacy))]
+    public void InterLegacyIterationSetup()
+    {
+        _ = LegacyVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+            _i420640, 640, 480, 32, _bufLegacy);
+    }
+
+    [IterationSetup(Target = nameof(Inter_Optimized))]
+    public void InterOptimizedIterationSetup()
+    {
+        _ = OptimizedVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+            _i420640, 640, 480, 32, _bufOpt);
+    }
+
+    [Benchmark]
+    public int Inter_Legacy() =>
+        LegacyVp8FrameEncodePipeline.Instance.EncodeInterFrameContiguousI420Pooled(
+            _i420Inter, 640, 480, 32, _bufLegacy).Count;
+
+    [Benchmark]
+    public int Inter_Optimized() =>
+        OptimizedVp8FrameEncodePipeline.Instance.EncodeInterFrameContiguousI420Pooled(
+            _i420Inter, 640, 480, 32, _bufOpt).Count;
+
+    // ----- Multi-token-partition (log2N=2 -> 4 partitions packed in parallel) -----
+
+    [Benchmark]
+    public int Keyframe_Optimized_4Part() =>
+        _optMp4.EncodeKeyframeContiguousI420Pooled(_i420640, 640, 480, 32, _bufMp4).Count;
+
+    [Benchmark]
+    public int Keyframe_Optimized_4Part_1280x720() =>
+        _optMp4.EncodeKeyframeContiguousI420Pooled(_i4201280, 1280, 720, 32, _bufMp4_1280).Count;
+
+    [IterationSetup(Target = nameof(Inter_Optimized_4Part))]
+    public void InterOpt4PartIterationSetup()
+    {
+        _ = _optMp4.EncodeKeyframeContiguousI420Pooled(_i420640, 640, 480, 32, _bufMp4);
+    }
+
+    [Benchmark]
+    public int Inter_Optimized_4Part() =>
+        _optMp4.EncodeInterFrameContiguousI420Pooled(_i420Inter, 640, 480, 32, _bufMp4).Count;
+
+    /// <summary>
+    /// One optimized keyframe with <see cref="EncodeProfiler"/> enabled; returns the text report
+    /// (for local phase attribution — timing includes encode plus report formatting).
+    /// </summary>
+    [Benchmark]
+    public string Keyframe_Optimized_EncodeProfilerReport()
+    {
+        EncodeProfiler.Reset();
+        EncodeProfiler.Enabled = true;
+        try
+        {
+            _ = OptimizedVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(
+                _i420640, 640, 480, 32, _bufOpt);
+            return EncodeProfiler.GetReport();
+        }
+        finally
+        {
+            EncodeProfiler.Enabled = false;
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.Benchmarks/EncodePipelineBenchmarks.cs
+++ b/test/SIPSorcery.VP8.Benchmarks/EncodePipelineBenchmarks.cs
@@ -4,8 +4,8 @@ using Vpx.Net;
 namespace SIPSorcery.VP8.Benchmarks;
 
 /// <summary>
-/// E2E-ish pipeline timings (Release, warmed BDN). Example host: Apple M1 Max, .NET 10 —
-/// <see cref="Keyframe_Optimized_1280x720"/> mean ~132 ms (DefaultJob); 640×480 <see cref="Keyframe_Optimized"/> is several times faster in wall time.
+/// E2E-ish pipeline timings (Release, warmed BDN). Example host: Apple M1 Max, .NET 10.0.3 —
+/// <see cref="Keyframe_Optimized_1280x720"/> mean ~78 ms (DefaultJob); 640×480 <see cref="Keyframe_Optimized"/> mean ~26 ms.
 /// Run <c>dotnet run -c Release --project test/SIPSorcery.VP8.Benchmarks -- -f *Keyframe_Optimized* -j short</c> on your machine.
 /// <c>Program --dump-profiler</c> prints wall vs scoped-sum for 640×480 and 1280×720 with <see cref="EncodeProfiler"/> enabled (slower; for bucket attribution).
 /// </summary>

--- a/test/SIPSorcery.VP8.Benchmarks/FdctMicroBenchmarks.cs
+++ b/test/SIPSorcery.VP8.Benchmarks/FdctMicroBenchmarks.cs
@@ -1,0 +1,40 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Vpx.Net;
+
+namespace SIPSorcery.VP8.Benchmarks;
+
+/// <summary>Micro-benchmark for forward 4×4 DCT in isolation (encoder hot path).</summary>
+[SimpleJob]
+public unsafe class FdctMicroBenchmarks
+{
+    private const int N = 4096;
+    private short[] _block = null!;
+    private short[] _out = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _block = new short[16];
+        _out = new short[16];
+        new Random(7).NextBytes(System.Runtime.InteropServices.MemoryMarshal.AsBytes(_block.AsSpan()));
+    }
+
+    /// <summary>Many contiguous 4×4 transforms (pitch 8 bytes) to amortize call overhead.</summary>
+    [Benchmark]
+    public int Fdct4x4_Contiguous_Calls()
+    {
+        int sum = 0;
+        fixed (short* b = _block)
+        fixed (short* o = _out)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                dct.vp8_short_fdct4x4_c(b, o, pitch: 8);
+                sum += o[0];
+            }
+        }
+
+        return sum;
+    }
+}

--- a/test/SIPSorcery.VP8.Benchmarks/IdctMicroBenchmarks.cs
+++ b/test/SIPSorcery.VP8.Benchmarks/IdctMicroBenchmarks.cs
@@ -1,0 +1,80 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Vpx.Net;
+
+namespace SIPSorcery.VP8.Benchmarks;
+
+/// <summary>Micro-benchmark for the encoder-side IDCT + add + clamp fast path
+/// (<see cref="IdctEncoderSimd"/>) compared with the scalar reference
+/// <see cref="idctllm.vp8_short_idct4x4llm_c"/>. The encoder calls the IDCT
+/// 24 times per macroblock for reconstruction; this measures one block
+/// many times to amortize call overhead.</summary>
+[SimpleJob]
+public unsafe class IdctMicroBenchmarks
+{
+    private const int N = 4096;
+    private short[] _coef = null!;
+    private byte[] _pred = null!;
+    private byte[] _dst = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _coef = new short[16];
+        _pred = new byte[16];
+        _dst = new byte[16];
+        var rng = new Random(11);
+        for (int i = 0; i < 16; i++) _coef[i] = (short)rng.Next(-512, 513);
+        rng.NextBytes(_pred);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Idct4x4_Scalar_Reference_Calls()
+    {
+        int s = 0;
+        fixed (short* cp = _coef)
+        fixed (byte* pp = _pred)
+        fixed (byte* dp = _dst)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                idctllm.vp8_short_idct4x4llm_c(cp, pp, 4, dp, 4);
+                s += dp[0];
+            }
+        }
+        return s;
+    }
+
+    [Benchmark]
+    public int Idct4x4_AddBlock_SimdEncoder_Calls()
+    {
+        int s = 0;
+        fixed (short* cp = _coef)
+        fixed (byte* pp = _pred)
+        fixed (byte* dp = _dst)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                IdctEncoderSimd.Idct4x4AddBlock(cp, pp, 4, dp, 4);
+                s += dp[0];
+            }
+        }
+        return s;
+    }
+
+    [Benchmark]
+    public int Idct4x4_AddFlat_SimdEncoder_Calls()
+    {
+        int s = 0;
+        fixed (short* cp = _coef)
+        fixed (byte* dp = _dst)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                IdctEncoderSimd.Idct4x4AddFlat(cp, _pred[0], dp, 4);
+                s += dp[0];
+            }
+        }
+        return s;
+    }
+}

--- a/test/SIPSorcery.VP8.Benchmarks/PackTokensMicroBenchmarks.cs
+++ b/test/SIPSorcery.VP8.Benchmarks/PackTokensMicroBenchmarks.cs
@@ -1,0 +1,60 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Vpx.Net;
+
+namespace SIPSorcery.VP8.Benchmarks;
+
+/// <summary>Micro-benchmark for token packing (partition 1 coefficient entropy).</summary>
+[SimpleJob]
+public unsafe class PackTokensMicroBenchmarks
+{
+    private TOKENEXTRA[] _tokens = null!;
+    private byte[] _outBuf = null!;
+    private BOOL_CODER _bc;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        tokenize.EnsureCoefProbCache(default_coef_probs_c.default_coef_probs);
+
+        // Dense coefficient pattern -> non-trivial token count per block.
+        short[] q =
+        {
+            8, -4, 2, -1,
+            3, 0, 5, -2,
+            -1, 7, 0, 3,
+            2, -3, 1, 0,
+        };
+
+        const int totalTokens = 384;
+        _tokens = new TOKENEXTRA[totalTokens];
+        var blockBuf = new TokenStreamBuffer();
+        int w = 0;
+        while (w < totalTokens)
+        {
+            blockBuf.Clear();
+            _ = tokenize.vp8_tokenize_block(
+                q, firstCoeffIndex: 0, eob: 16,
+                blockType: 3, initialContext: 0,
+                default_coef_probs_c.default_coef_probs, blockBuf);
+            ReadOnlySpan<TOKENEXTRA> span = blockBuf.AsSpan();
+            for (int i = 0; i < span.Length && w < totalTokens; i++)
+                _tokens[w++] = span[i];
+        }
+
+        _outBuf = new byte[8192];
+    }
+
+    [Benchmark]
+    public uint PackTokens_FixedStream()
+    {
+        fixed (byte* p = _outBuf)
+        {
+            boolhuff.vp8_start_encode(ref _bc, p, p + _outBuf.Length);
+            bitstream.vp8_pack_tokens(ref _bc, _tokens.AsSpan());
+            boolhuff.vp8_stop_encode(ref _bc);
+        }
+
+        return _bc.pos;
+    }
+}

--- a/test/SIPSorcery.VP8.Benchmarks/Program.cs
+++ b/test/SIPSorcery.VP8.Benchmarks/Program.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Diagnostics;
+using BenchmarkDotNet.Running;
+using Vpx.Net;
+
+namespace SIPSorcery.VP8.Benchmarks;
+
+internal static class Program
+{
+    private static void Main(string[] args)
+    {
+        if (args.Length > 0 && string.Equals(args[0], "--dump-profiler", StringComparison.Ordinal))
+        {
+            DumpProfilerSample();
+            return;
+        }
+
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+
+    /// <summary>One optimized keyframe per resolution with <see cref="EncodeProfiler"/> enabled; prints wall vs scoped sum + phase breakdown.</summary>
+    private static void DumpProfilerSample()
+    {
+        RunDumpProfilerRow(640, 480, seed: 42);
+        RunDumpProfilerRow(1280, 720, seed: 43);
+    }
+
+    private static void RunDumpProfilerRow(int w, int h, int seed)
+    {
+        int y = w * h, uv = y / 4;
+        var i420 = new byte[y + 2 * uv];
+        new Random(seed).NextBytes(i420);
+        var buffers = new FrameEncoderBuffers();
+
+        EncodeProfiler.Reset();
+        EncodeProfiler.Enabled = true;
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            _ = OptimizedVp8FrameEncodePipeline.Instance.EncodeKeyframeContiguousI420Pooled(i420, w, h, 32, buffers);
+            sw.Stop();
+            Console.WriteLine($"--- {w}×{h} keyframe q=32 ---");
+            Console.WriteLine(EncodeProfiler.FormatWallClockCompare(sw.Elapsed.TotalMilliseconds));
+            Console.WriteLine(EncodeProfiler.GetReport());
+        }
+        finally
+        {
+            EncodeProfiler.Enabled = false;
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.Benchmarks/SIPSorcery.VP8.Benchmarks.csproj
+++ b/test/SIPSorcery.VP8.Benchmarks/SIPSorcery.VP8.Benchmarks.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SIPSorcery.VP8\SIPSorcery.VP8.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/SIPSorcery.VP8.UnitTest/bitstream_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/bitstream_unittest.cs
@@ -170,31 +170,33 @@ namespace Vpx.Net.UnitTest
             // Start the existing decoder bool reader at byte 10, feeding it
             // the bytes produced by our encoder bool coder.
             BOOL_DECODER br = new BOOL_DECODER();
-            // Take a copy because vp8dx_start_decode pins the input pointer.
             byte[] partition = new byte[total - 10 + 8];  // pad for the decoder's lookahead
             System.Array.Copy(buf, 10, partition, 0, total - 10);
 
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+            fixed (byte* pPart = partition)
+            {
+                dboolhuff.vp8dx_start_decode(ref br, pPart, (uint)partition.Length, null, null);
 
-            int colorSpace        = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int clampType         = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int segmentation      = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int filterType        = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int filterLevel       = dboolhuff.vp8_decode_value(ref br, 6);
-            int sharpnessLevel    = dboolhuff.vp8_decode_value(ref br, 3);
-            int modeRefLfDelta    = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int log2NumPartitions = dboolhuff.vp8_decode_value(ref br, 2);
-            int baseQindex        = dboolhuff.vp8_decode_value(ref br, 7);
+                int colorSpace        = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int clampType         = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int segmentation      = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int filterType        = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int filterLevel       = dboolhuff.vp8_decode_value(ref br, 6);
+                int sharpnessLevel    = dboolhuff.vp8_decode_value(ref br, 3);
+                int modeRefLfDelta    = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int log2NumPartitions = dboolhuff.vp8_decode_value(ref br, 2);
+                int baseQindex        = dboolhuff.vp8_decode_value(ref br, 7);
 
-            Assert.Equal(cfg.ColorSpace,    colorSpace);
-            Assert.Equal(cfg.ClampType,     clampType);
-            Assert.Equal(0,                 segmentation);   // we always emit 0
-            Assert.Equal(cfg.FilterType,    filterType);
-            Assert.Equal(cfg.FilterLevel,   filterLevel);
-            Assert.Equal(cfg.SharpnessLevel, sharpnessLevel);
-            Assert.Equal(0,                 modeRefLfDelta); // we always emit 0
-            Assert.Equal(cfg.Log2NumberOfTokenPartitions, log2NumPartitions);
-            Assert.Equal(cfg.BaseQindex,    baseQindex);
+                Assert.Equal(cfg.ColorSpace,    colorSpace);
+                Assert.Equal(cfg.ClampType,     clampType);
+                Assert.Equal(0,                 segmentation);   // we always emit 0
+                Assert.Equal(cfg.FilterType,    filterType);
+                Assert.Equal(cfg.FilterLevel,   filterLevel);
+                Assert.Equal(cfg.SharpnessLevel, sharpnessLevel);
+                Assert.Equal(0,                 modeRefLfDelta); // we always emit 0
+                Assert.Equal(cfg.Log2NumberOfTokenPartitions, log2NumPartitions);
+                Assert.Equal(cfg.BaseQindex,    baseQindex);
+            }
         }
 
         // ---------- helper ----------

--- a/test/SIPSorcery.VP8.UnitTest/boolhuff_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/boolhuff_unittest.cs
@@ -83,28 +83,28 @@ namespace Vpx.Net.UnitTest
                     }
 
                     BOOL_DECODER br = new BOOL_DECODER();
-                    //encrypt_buffer(bw_buffer, kBufferSize);
-                    //vp8dx_start_decode(&br, bw_buffer, kBufferSize, test_decrypt_cb,
-                    //  reinterpret_cast<void*>(bw_buffer));
-                    dboolhuff.vp8dx_start_decode(ref br, bw_buffer, kBufferSize);
-
-                    //bit_rnd.Reset(random_seed);
-                    rnd = new Random(random_seed);
-                    for (int i = 0; i < kBitsToTest; ++i)
+                    fixed (byte* pBuf = bw_buffer)
                     {
-                        if (bit_method == 2)
-                        {
-                            bit = (i & 1);
-                        }
-                        else if (bit_method == 3)
-                        {
-                            bit = rnd.Next(0, 1);
-                        }
-                        /*GTEST_ASSERT_EQ(vp8dx_decode_bool(&br, probas[i]), bit)
-                          << "pos: " << i << " / " << kBitsToTest
-                          << " bit_method: " << bit_method << " method: " << method;*/
+                        dboolhuff.vp8dx_start_decode(ref br, pBuf, (uint)kBufferSize, null, null);
 
-                        Assert.Equal(dboolhuff.vp8dx_decode_bool(ref br, probas[i]), bit);
+                        //bit_rnd.Reset(random_seed);
+                        rnd = new Random(random_seed);
+                        for (int i = 0; i < kBitsToTest; ++i)
+                        {
+                            if (bit_method == 2)
+                            {
+                                bit = (i & 1);
+                            }
+                            else if (bit_method == 3)
+                            {
+                                bit = rnd.Next(0, 1);
+                            }
+                            /*GTEST_ASSERT_EQ(vp8dx_decode_bool(&br, probas[i]), bit)
+                              << "pos: " << i << " / " << kBitsToTest
+                              << " bit_method: " << bit_method << " method: " << method;*/
+
+                            Assert.Equal(dboolhuff.vp8dx_decode_bool(ref br, probas[i]), bit);
+                        }
                     }
                 }
             }

--- a/test/SIPSorcery.VP8.UnitTest/dct_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/dct_unittest.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: dct_unittest.cs
 //
 // Description: Unit tests for the VP8 forward DCT (encoder side, src/dct.cs).
@@ -94,6 +94,82 @@ namespace Vpx.Net.UnitTest
         /// 4x4 DCT/IDCT pair. Uses prediction = 128 so [0,255] clipping in
         /// vp8_short_idct4x4llm_c does not engage.
         /// </summary>
+        [Fact]
+        public void Fdct8x4_MatchesTwoSideBySideFdct4x4_ReferenceLayout()
+        {
+            // Layout matches libvpx vp8_short_fdct8x4_c: two 4×4 column groups in one 8×4
+            // input region; pitch between rows is 16 bytes (8 shorts per row).
+            short* input = stackalloc short[32];
+            var rng = new System.Random(42);
+            for (int i = 0; i < 32; i++)
+                input[i] = (short)rng.Next(-32, 33);
+
+            short* out8 = stackalloc short[32];
+            short* outL = stackalloc short[16];
+            short* outR = stackalloc short[16];
+
+            dct.vp8_short_fdct8x4_c(input, out8, pitch: 16);
+            dct.vp8_short_fdct4x4_c(input, outL, pitch: 16);
+            dct.vp8_short_fdct4x4_c(input + 4, outR, pitch: 16);
+
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.True(out8[i] == outL[i], $"left 4×4 mismatch at i={i}: batch={out8[i]} ref={outL[i]}");
+                Assert.True(out8[i + 16] == outR[i], $"right 4×4 mismatch at i={i}: batch={out8[i + 16]} ref={outR[i]}");
+            }
+        }
+
+        /// <summary>
+        /// Random 8×4 residuals with pitch 16 (libvpx block layout): SIMD row path must stay bit-identical to scalar reference.
+        /// </summary>
+        [Fact]
+        public unsafe void Fdct8x4_Pitch16_MatchesPiecewise4x4_ManySeeds()
+        {
+            var rng = new System.Random(2026);
+            short* strip = stackalloc short[32];
+            short* expected = stackalloc short[32];
+            short* got = stackalloc short[32];
+            for (int iter = 0; iter < 256; iter++)
+            {
+                for (int i = 0; i < 32; i++)
+                    strip[i] = (short)rng.Next(-64, 65);
+
+                dct.vp8_short_fdct8x4_c(strip, expected, pitch: 16);
+                dct.vp8_short_fdct4x4_c(strip, got, pitch: 16);
+                dct.vp8_short_fdct4x4_c(strip + 4, got + 16, pitch: 16);
+                for (int i = 0; i < 32; i++)
+                    Assert.True(expected[i] == got[i], $"iter {iter} i={i} expected={expected[i]} got={got[i]}");
+            }
+        }
+
+        /// <summary>
+        /// Row then column passes (as used internally) must match the monolithic reference
+        /// for dense random residuals (contiguous 4×4, pitch 8).
+        /// </summary>
+        [Fact]
+        public unsafe void Fdct4x4_SplitRowColumn_MatchesMonolithic_ManySeeds()
+        {
+            var rng = new System.Random(777);
+            short* input = stackalloc short[16];
+            short* expected = stackalloc short[16];
+            short* got = stackalloc short[16];
+            for (int iter = 0; iter < 512; iter++)
+            {
+                for (int i = 0; i < 16; i++)
+                    input[i] = (short)rng.Next(-512, 513);
+
+                dct.vp8_short_fdct4x4_c(input, expected, 8);
+                dct.vp8_fdct4x4_row_pass(input, got, 8);
+                dct.vp8_fdct4x4_column_pass_inplace(got);
+
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(expected[i] == got[i],
+                        $"iter {iter} i={i} expected={expected[i]} got={got[i]}");
+                }
+            }
+        }
+
         [Fact]
         public void Fdct4x4_RoundTripWithIdct_RecoversInputWithinTolerance()
         {

--- a/test/SIPSorcery.VP8.UnitTest/encode_pipeline_parity_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/encode_pipeline_parity_unittest.cs
@@ -1,0 +1,98 @@
+//-----------------------------------------------------------------------------
+// Encoded bitstream parity: Legacy vs Optimized encoder pipelines must match.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using SIPSorceryMedia.Abstractions;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public class encode_pipeline_parity_unittest
+    {
+        public static TheoryData<Vp8EncodePipelineKind, Vp8EncodePipelineKind> PipelinePairs => new TheoryData<Vp8EncodePipelineKind, Vp8EncodePipelineKind>
+        {
+            { Vp8EncodePipelineKind.Legacy, Vp8EncodePipelineKind.Optimized },
+        };
+
+        [Theory]
+        [MemberData(nameof(PipelinePairs))]
+        public void Keyframe_16x16_ContiguousI420_Matches(Vp8EncodePipelineKind a, Vp8EncodePipelineKind b)
+        {
+            var buf = MakeGradientI420(16, 16);
+            var encA = Vp8FrameEncodePipelineFactory.Create(a);
+            var encB = Vp8FrameEncodePipelineFactory.Create(b);
+            var fb = new FrameEncoderBuffers();
+            byte[] yuv = buf;
+            byte[] outA = encA.EncodeKeyframeContiguousI420(yuv, 16, 16, 32, fb);
+            fb.LastFrameValid = false;
+            byte[] outB = encB.EncodeKeyframeContiguousI420(yuv, 16, 16, 32, fb);
+            Assert.Equal(outA, outB);
+        }
+
+        [Theory]
+        [MemberData(nameof(PipelinePairs))]
+        public void Keyframe_640x480_TestPattern_File_Matches(Vp8EncodePipelineKind a, Vp8EncodePipelineKind b)
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "testpattern.i420");
+            if (!File.Exists(path))
+            {
+                return;
+            }
+            byte[] yuv = File.ReadAllBytes(path);
+            const int w = 640, h = 480;
+            Assert.Equal(w * h * 3 / 2, yuv.Length);
+            var encA = Vp8FrameEncodePipelineFactory.Create(a);
+            var encB = Vp8FrameEncodePipelineFactory.Create(b);
+            var fbA = new FrameEncoderBuffers();
+            var fbB = new FrameEncoderBuffers();
+            byte[] outA = encA.EncodeKeyframeContiguousI420(yuv, w, h, 32, fbA);
+            byte[] outB = encB.EncodeKeyframeContiguousI420(yuv, w, h, 32, fbB);
+            Assert.Equal(outA, outB);
+        }
+
+        [Theory]
+        [MemberData(nameof(PipelinePairs))]
+        public void Inter_AfterKey_Matches(Vp8EncodePipelineKind a, Vp8EncodePipelineKind b)
+        {
+            var encA = Vp8FrameEncodePipelineFactory.Create(a);
+            var encB = Vp8FrameEncodePipelineFactory.Create(b);
+            var fbA = new FrameEncoderBuffers();
+            var fbB = new FrameEncoderBuffers();
+            byte[] yuv = MakeGradientI420(16, 16);
+            byte[] keyA = encA.EncodeKeyframeContiguousI420(yuv, 16, 16, 48, fbA);
+            byte[] keyB = encB.EncodeKeyframeContiguousI420(yuv, 16, 16, 48, fbB);
+            Assert.Equal(keyA, keyB);
+            for (int i = 0; i < yuv.Length; i++) yuv[i] = (byte)((yuv[i] + 17) & 0xff);
+            byte[] interA = encA.EncodeInterFrameContiguousI420(yuv, 16, 16, 48, fbA);
+            byte[] interB = encB.EncodeInterFrameContiguousI420(yuv, 16, 16, 48, fbB);
+            Assert.Equal(interA, interB);
+        }
+
+        [Fact]
+        public void VP8Codec_Default_IsOptimized()
+        {
+            using var c = new VP8Codec();
+            var field = typeof(VP8Codec).GetField("_encodePipeline",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(field);
+            var pipeline = field.GetValue(c);
+            Assert.Same(OptimizedVp8FrameEncodePipeline.Instance, pipeline);
+        }
+
+        private static byte[] MakeGradientI420(int width, int height)
+        {
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var buf = new byte[ySize + 2 * cSize];
+            int i = 0;
+            for (int y = 0; y < height; y++)
+            for (int x = 0; x < width; x++)
+                buf[i++] = (byte)((x + y * 3) & 0xff);
+            for (int j = 0; j < cSize; j++) buf[i++] = (byte)(80 + (j & 31));
+            for (int j = 0; j < cSize; j++) buf[i++] = (byte)(120 + (j & 31));
+            return buf;
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.UnitTest/encode_profiler_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/encode_profiler_unittest.cs
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------------
+// Warm regression / diagnostic: run one keyframe encode with profiling enabled
+// and assert the phase report contains the expected buckets (Fdct, SimdMemOps,
+// PackTokens, etc.). Uses the SIMD memory-ops path to exercise SimdMemOps timing.
+//-----------------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public class encode_profiler_unittest
+    {
+        [Fact]
+        public void EncodeProfiler_KeyframeContiguousI420_AttributesPhases()
+        {
+            const int W = 64, H = 64;
+            int ySize = W * H;
+            int cSize = (W / 2) * (H / 2);
+            var i420 = new byte[ySize + 2 * cSize];
+            for (int i = 0; i < i420.Length; i++)
+                i420[i] = (byte)((i * 7 + 13) & 0xFF);
+
+            EncodeProfiler.Reset();
+            EncodeProfiler.Enabled = true;
+            try
+            {
+                var buffers = new FrameEncoderBuffers();
+                _ = frame_encoder.EncodeKeyframeWithBuffersContiguousI420(
+                    i420, W, H, qIndex: 40, buffers, SpanSimdEncoderMemoryOps.Instance);
+            }
+            finally
+            {
+                EncodeProfiler.Enabled = false;
+            }
+
+            string report = EncodeProfiler.GetReport();
+            Assert.Contains("Vp8EncodeProfiler", report);
+            Assert.Contains("FirstPartitionHeader", report);
+            Assert.Contains("Phase1MbScalarCtx", report);
+            Assert.Contains("Phase2FirstPartitionBits", report);
+            Assert.Contains("Fdct", report);
+            Assert.Contains("SimdMemOps", report);
+            Assert.Contains("Quantize", report);
+            Assert.Contains("Tokenize", report);
+            Assert.Contains("PackTokens", report);
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.UnitTest/idct_encoder_simd_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/idct_encoder_simd_unittest.cs
@@ -1,0 +1,251 @@
+//-----------------------------------------------------------------------------
+// Filename: idct_encoder_simd_unittest.cs
+//
+// Description: Bit-exactness fuzz tests for the encoder-side SIMD fast path
+// IdctEncoderSimd vs the scalar reference idctllm.vp8_short_idct4x4llm_c.
+//
+// Author(s):
+// Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class idct_encoder_simd_unittest
+    {
+        // ----------------- helpers -----------------
+
+        private static void ScalarReference(short[] input, byte[] pred, int predStride, byte[] dst, int dstStride)
+        {
+            fixed (short* inP = input)
+            fixed (byte* predP = pred)
+            fixed (byte* dstP = dst)
+            {
+                idctllm.vp8_short_idct4x4llm_c(inP, predP, predStride, dstP, dstStride);
+            }
+        }
+
+        private static void RunSimdFlat(short[] input, byte pred, byte[] dst, int dstStride)
+        {
+            fixed (short* inP = input)
+            fixed (byte* dstP = dst)
+            {
+                IdctEncoderSimd.Idct4x4AddFlat(inP, pred, dstP, dstStride);
+            }
+        }
+
+        private static void RunSimdBlock(short[] input, byte[] pred, int predStride, byte[] dst, int dstStride)
+        {
+            fixed (short* inP = input)
+            fixed (byte* predP = pred)
+            fixed (byte* dstP = dst)
+            {
+                IdctEncoderSimd.Idct4x4AddBlock(inP, predP, predStride, dstP, dstStride);
+            }
+        }
+
+        private static void Assert4x4Equal(byte[] a, int aStride, byte[] b, int bStride, int aOffsetX = 0, int aOffsetY = 0, int bOffsetX = 0, int bOffsetY = 0)
+        {
+            for (int r = 0; r < 4; r++)
+            for (int c = 0; c < 4; c++)
+                Assert.Equal(a[(aOffsetY + r) * aStride + aOffsetX + c], b[(bOffsetY + r) * bStride + bOffsetX + c]);
+        }
+
+        // ----------------- bit-exact zero coefficient -----------------
+
+        [Fact]
+        public void Idct4x4AddFlat_ZeroCoefs_MatchesScalar()
+        {
+            short[] coef = new short[16];
+            byte[] predBuf = new byte[16];
+            byte[] dstScalar = new byte[16];
+
+            for (int p = 0; p < 256; p += 17)
+            {
+                Array.Fill(predBuf, (byte)p);
+                ScalarReference(coef, predBuf, 4, dstScalar, 4);
+
+                byte[] dstSimd = new byte[16];
+                RunSimdFlat(coef, (byte)p, dstSimd, 4);
+                Assert4x4Equal(dstScalar, 4, dstSimd, 4);
+            }
+        }
+
+        [Fact]
+        public void Idct4x4AddBlock_ZeroCoefs_MatchesScalar_PerPixelPred()
+        {
+            short[] coef = new short[16];
+            var rng = new Random(0xC0FFEE);
+
+            for (int trial = 0; trial < 32; trial++)
+            {
+                byte[] predBuf = new byte[16];
+                rng.NextBytes(predBuf);
+
+                byte[] dstScalar = new byte[16];
+                ScalarReference(coef, predBuf, 4, dstScalar, 4);
+
+                byte[] dstSimd = new byte[16];
+                RunSimdBlock(coef, predBuf, 4, dstSimd, 4);
+                Assert4x4Equal(dstScalar, 4, dstSimd, 4);
+            }
+        }
+
+        // ----------------- bit-exact small fixed pattern -----------------
+
+        [Fact]
+        public void Idct4x4AddFlat_SmallFixedPattern_MatchesScalar()
+        {
+            // Single non-zero DC -> uniform shift after the 2-pass.
+            short[] coef = new short[16];
+            coef[0] = 32;
+
+            byte pred = 100;
+            byte[] predBuf = new byte[16];
+            Array.Fill(predBuf, pred);
+
+            byte[] dstScalar = new byte[16];
+            ScalarReference(coef, predBuf, 4, dstScalar, 4);
+
+            byte[] dstSimd = new byte[16];
+            RunSimdFlat(coef, pred, dstSimd, 4);
+
+            Assert4x4Equal(dstScalar, 4, dstSimd, 4);
+        }
+
+        // ----------------- fuzz: random coefs, flat pred -----------------
+
+        [Fact]
+        public void Idct4x4AddFlat_Fuzz_ManySeeds_MatchesScalar()
+        {
+            // Pick coef ranges that exercise the fixed-point multiplies and
+            // saturation paths but stay in libvpx-realistic bands. Real
+            // dequantized coefs are bounded by ~[-2048, 2047] in practice
+            // (after multiplying quant-by-zigzag-coef), and idct adds a
+            // factor of ~2.6 in the worst case.
+            for (int seed = 0; seed < 64; seed++)
+            {
+                var rng = new Random(seed);
+
+                short[] coef = new short[16];
+                for (int i = 0; i < 16; i++)
+                {
+                    coef[i] = (short)rng.Next(-1024, 1025);
+                }
+
+                byte pred = (byte)rng.Next(0, 256);
+                byte[] predBuf = new byte[16];
+                Array.Fill(predBuf, pred);
+
+                byte[] dstScalar = new byte[16];
+                ScalarReference(coef, predBuf, 4, dstScalar, 4);
+
+                byte[] dstSimd = new byte[16];
+                RunSimdFlat(coef, pred, dstSimd, 4);
+
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(dstScalar[i] == dstSimd[i],
+                        $"seed={seed} idx={i} expected={dstScalar[i]} got={dstSimd[i]} pred={pred}");
+                }
+            }
+        }
+
+        // ----------------- fuzz: random coefs, per-pixel pred, strided -----------------
+
+        [Fact]
+        public void Idct4x4AddBlock_Fuzz_ManySeeds_MatchesScalar_StridedDst()
+        {
+            const int dstStride = 24;
+            const int predStride = 32;
+
+            for (int seed = 0; seed < 64; seed++)
+            {
+                var rng = new Random(seed * 17 + 1);
+
+                short[] coef = new short[16];
+                for (int i = 0; i < 16; i++) coef[i] = (short)rng.Next(-1024, 1025);
+
+                byte[] predFull = new byte[predStride * 8];
+                rng.NextBytes(predFull);
+                byte[] dstScalarFull = new byte[dstStride * 8];
+                byte[] dstSimdFull = new byte[dstStride * 8];
+
+                int predOffsetX = 3;
+                int predOffsetY = 2;
+                int dstOffsetX = 5;
+                int dstOffsetY = 1;
+
+                fixed (short* inP = coef)
+                fixed (byte* predP = predFull)
+                fixed (byte* dstP = dstScalarFull)
+                {
+                    idctllm.vp8_short_idct4x4llm_c(inP,
+                        predP + predOffsetY * predStride + predOffsetX, predStride,
+                        dstP + dstOffsetY * dstStride + dstOffsetX, dstStride);
+                }
+
+                fixed (short* inP = coef)
+                fixed (byte* predP = predFull)
+                fixed (byte* dstP = dstSimdFull)
+                {
+                    IdctEncoderSimd.Idct4x4AddBlock(inP,
+                        predP + predOffsetY * predStride + predOffsetX, predStride,
+                        dstP + dstOffsetY * dstStride + dstOffsetX, dstStride);
+                }
+
+                for (int r = 0; r < 4; r++)
+                for (int c = 0; c < 4; c++)
+                {
+                    int idx = (dstOffsetY + r) * dstStride + dstOffsetX + c;
+                    Assert.True(dstScalarFull[idx] == dstSimdFull[idx],
+                        $"seed={seed} r={r} c={c} expected={dstScalarFull[idx]} got={dstSimdFull[idx]}");
+                }
+            }
+        }
+
+        // ----------------- saturation corners -----------------
+
+        [Fact]
+        public void Idct4x4AddFlat_LargePositiveCoefs_ClampsTo255()
+        {
+            short[] coef = new short[16];
+            for (int i = 0; i < 16; i++) coef[i] = 1024;
+
+            byte pred = 200;
+            byte[] predBuf = new byte[16];
+            Array.Fill(predBuf, pred);
+
+            byte[] dstScalar = new byte[16];
+            ScalarReference(coef, predBuf, 4, dstScalar, 4);
+
+            byte[] dstSimd = new byte[16];
+            RunSimdFlat(coef, pred, dstSimd, 4);
+
+            Assert4x4Equal(dstScalar, 4, dstSimd, 4);
+        }
+
+        [Fact]
+        public void Idct4x4AddFlat_LargeNegativeCoefs_ClampsToZero()
+        {
+            short[] coef = new short[16];
+            for (int i = 0; i < 16; i++) coef[i] = -1024;
+
+            byte pred = 50;
+            byte[] predBuf = new byte[16];
+            Array.Fill(predBuf, pred);
+
+            byte[] dstScalar = new byte[16];
+            ScalarReference(coef, predBuf, 4, dstScalar, 4);
+
+            byte[] dstSimd = new byte[16];
+            RunSimdFlat(coef, pred, dstSimd, 4);
+
+            Assert4x4Equal(dstScalar, 4, dstSimd, 4);
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.UnitTest/inter_frame_header_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/inter_frame_header_unittest.cs
@@ -132,53 +132,56 @@ namespace Vpx.Net.UnitTest
             System.Array.Copy(buf, boolStart, partition, 0, total - boolStart);
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+            fixed (byte* pPart = partition)
+            {
+                dboolhuff.vp8dx_start_decode(ref br, pPart, (uint)partition.Length, null, null);
 
-            // Read the same fields the writer emitted, in the same order.
-            int segmentation       = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int filterType         = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int filterLevel        = dboolhuff.vp8_decode_value(ref br, 6);
-            int sharpnessLevel     = dboolhuff.vp8_decode_value(ref br, 3);
-            int modeRefLfDelta     = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int log2NumPartitions  = dboolhuff.vp8_decode_value(ref br, 2);
-            int baseQindex         = dboolhuff.vp8_decode_value(ref br, 7);
-            // 5x put_delta_q. With all delta-q values zero, each one
-            // emits a single 0 bit (no delta).
-            int dqY1Dc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int dqY2Dc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int dqY2Ac   = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int dqUvDc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int dqUvAc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            // Inter-only fields.
-            int refreshGolden      = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int refreshAltRef      = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int copyBufferToGf     = dboolhuff.vp8_decode_value(ref br, 2);   // refreshGolden==0 -> read 2 bits
-            int copyBufferToArf    = dboolhuff.vp8_decode_value(ref br, 2);   // refreshAltRef==0 -> read 2 bits
-            int signBiasGolden     = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int signBiasAltRef     = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int refreshEntropy     = dboolhuff.vp8dx_decode_bool(ref br, 128);
-            int refreshLastFrame   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                // Read the same fields the writer emitted, in the same order.
+                int segmentation       = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int filterType         = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int filterLevel        = dboolhuff.vp8_decode_value(ref br, 6);
+                int sharpnessLevel     = dboolhuff.vp8_decode_value(ref br, 3);
+                int modeRefLfDelta     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int log2NumPartitions  = dboolhuff.vp8_decode_value(ref br, 2);
+                int baseQindex         = dboolhuff.vp8_decode_value(ref br, 7);
+                // 5x put_delta_q. With all delta-q values zero, each one
+                // emits a single 0 bit (no delta).
+                int dqY1Dc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int dqY2Dc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int dqY2Ac   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int dqUvDc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int dqUvAc   = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                // Inter-only fields.
+                int refreshGolden      = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int refreshAltRef      = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int copyBufferToGf     = dboolhuff.vp8_decode_value(ref br, 2);   // refreshGolden==0 -> read 2 bits
+                int copyBufferToArf    = dboolhuff.vp8_decode_value(ref br, 2);   // refreshAltRef==0 -> read 2 bits
+                int signBiasGolden     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int signBiasAltRef     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int refreshEntropy     = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                int refreshLastFrame   = dboolhuff.vp8dx_decode_bool(ref br, 128);
 
-            Assert.Equal(0,                  segmentation);
-            Assert.Equal(cfg.FilterType,     filterType);
-            Assert.Equal(cfg.FilterLevel,    filterLevel);
-            Assert.Equal(cfg.SharpnessLevel, sharpnessLevel);
-            Assert.Equal(0,                  modeRefLfDelta);
-            Assert.Equal(cfg.Log2NumberOfTokenPartitions, log2NumPartitions);
-            Assert.Equal(cfg.BaseQindex,     baseQindex);
-            Assert.Equal(0,                  dqY1Dc);
-            Assert.Equal(0,                  dqY2Dc);
-            Assert.Equal(0,                  dqY2Ac);
-            Assert.Equal(0,                  dqUvDc);
-            Assert.Equal(0,                  dqUvAc);
-            Assert.Equal(0,                  refreshGolden);
-            Assert.Equal(0,                  refreshAltRef);
-            Assert.Equal(0,                  copyBufferToGf);
-            Assert.Equal(0,                  copyBufferToArf);
-            Assert.Equal(0,                  signBiasGolden);
-            Assert.Equal(0,                  signBiasAltRef);
-            Assert.Equal(1,                  refreshEntropy);
-            Assert.Equal(1,                  refreshLastFrame);
+                Assert.Equal(0,                  segmentation);
+                Assert.Equal(cfg.FilterType,     filterType);
+                Assert.Equal(cfg.FilterLevel,    filterLevel);
+                Assert.Equal(cfg.SharpnessLevel, sharpnessLevel);
+                Assert.Equal(0,                  modeRefLfDelta);
+                Assert.Equal(cfg.Log2NumberOfTokenPartitions, log2NumPartitions);
+                Assert.Equal(cfg.BaseQindex,     baseQindex);
+                Assert.Equal(0,                  dqY1Dc);
+                Assert.Equal(0,                  dqY2Dc);
+                Assert.Equal(0,                  dqY2Ac);
+                Assert.Equal(0,                  dqUvDc);
+                Assert.Equal(0,                  dqUvAc);
+                Assert.Equal(0,                  refreshGolden);
+                Assert.Equal(0,                  refreshAltRef);
+                Assert.Equal(0,                  copyBufferToGf);
+                Assert.Equal(0,                  copyBufferToArf);
+                Assert.Equal(0,                  signBiasGolden);
+                Assert.Equal(0,                  signBiasAltRef);
+                Assert.Equal(1,                  refreshEntropy);
+                Assert.Equal(1,                  refreshLastFrame);
+            }
         }
 
         [Fact]
@@ -216,30 +219,33 @@ namespace Vpx.Net.UnitTest
             System.Array.Copy(buf, boolStart, partition, 0, total - boolStart);
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+            fixed (byte* pPart = partition)
+            {
+                dboolhuff.vp8dx_start_decode(ref br, pPart, (uint)partition.Length, null, null);
 
-            // Skip past the fields before delta-q.
-            dboolhuff.vp8dx_decode_bool(ref br, 128);            // segmentation
-            dboolhuff.vp8dx_decode_bool(ref br, 128);            // filterType
-            dboolhuff.vp8_decode_value(ref br, 6);               // filterLevel
-            dboolhuff.vp8_decode_value(ref br, 3);               // sharpness
-            dboolhuff.vp8dx_decode_bool(ref br, 128);            // modeRefLfDelta
-            dboolhuff.vp8_decode_value(ref br, 2);               // log2partitions
-            dboolhuff.vp8_decode_value(ref br, 7);               // baseQindex
+                // Skip past the fields before delta-q.
+                dboolhuff.vp8dx_decode_bool(ref br, 128);            // segmentation
+                dboolhuff.vp8dx_decode_bool(ref br, 128);            // filterType
+                dboolhuff.vp8_decode_value(ref br, 6);               // filterLevel
+                dboolhuff.vp8_decode_value(ref br, 3);               // sharpness
+                dboolhuff.vp8dx_decode_bool(ref br, 128);            // modeRefLfDelta
+                dboolhuff.vp8_decode_value(ref br, 2);               // log2partitions
+                dboolhuff.vp8_decode_value(ref br, 7);               // baseQindex
 
-            // Delta-q fields. Each is: 1 bit "is non-zero?" then
-            // (if non-zero) 4-bit magnitude + 1 bit sign.
-            int y1dc = ReadDeltaQ(ref br);
-            int y2dc = ReadDeltaQ(ref br);
-            int y2ac = ReadDeltaQ(ref br);
-            int uvdc = ReadDeltaQ(ref br);
-            int uvac = ReadDeltaQ(ref br);
+                // Delta-q fields. Each is: 1 bit "is non-zero?" then
+                // (if non-zero) 4-bit magnitude + 1 bit sign.
+                int y1dc = ReadDeltaQ(ref br);
+                int y2dc = ReadDeltaQ(ref br);
+                int y2ac = ReadDeltaQ(ref br);
+                int uvdc = ReadDeltaQ(ref br);
+                int uvac = ReadDeltaQ(ref br);
 
-            Assert.Equal(cfg.Y1DcDeltaQ, y1dc);
-            Assert.Equal(cfg.Y2DcDeltaQ, y2dc);
-            Assert.Equal(cfg.Y2AcDeltaQ, y2ac);
-            Assert.Equal(cfg.UvDcDeltaQ, uvdc);
-            Assert.Equal(cfg.UvAcDeltaQ, uvac);
+                Assert.Equal(cfg.Y1DcDeltaQ, y1dc);
+                Assert.Equal(cfg.Y2DcDeltaQ, y2dc);
+                Assert.Equal(cfg.Y2AcDeltaQ, y2ac);
+                Assert.Equal(cfg.UvDcDeltaQ, uvdc);
+                Assert.Equal(cfg.UvAcDeltaQ, uvac);
+            }
         }
 
         private static int ReadDeltaQ(ref BOOL_DECODER br)

--- a/test/SIPSorcery.VP8.UnitTest/inter_mb_mode_bits_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/inter_mb_mode_bits_unittest.cs
@@ -81,10 +81,13 @@ namespace Vpx.Net.UnitTest
             byte[] partition = FinishAndCopy(ref bc, buf);
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+            fixed (byte* p = partition)
+            {
+                dboolhuff.vp8dx_start_decode(ref br, p, (uint)partition.Length, null, null);
 
-            int decoded = treereader.vp8_treed_read(ref br, entropymode.vp8_mv_ref_tree, probs);
-            Assert.Equal((int)mode, decoded);
+                int decoded = treereader.vp8_treed_read(ref br, entropymode.vp8_mv_ref_tree, probs);
+                Assert.Equal((int)mode, decoded);
+            }
         }
 
         // ---------- WriteInterMbAsIntra ----------
@@ -98,10 +101,13 @@ namespace Vpx.Net.UnitTest
             byte[] partition = FinishAndCopy(ref bc, buf);
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+            fixed (byte* p = partition)
+            {
+                dboolhuff.vp8dx_start_decode(ref br, p, (uint)partition.Length, null, null);
 
-            int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
-            Assert.Equal(0, isInter);
+                int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
+                Assert.Equal(0, isInter);
+            }
         }
 
         // ---------- WriteInterMbRefAndMode round-trip ----------
@@ -147,28 +153,31 @@ namespace Vpx.Net.UnitTest
             byte[] partition = FinishAndCopy(ref bc, buf);
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
-
-            // Mirror decodemv.read_mb_modes_mv ref-frame parsing.
-            int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
-            Assert.Equal(1, isInter);
-
-            int notLast = dboolhuff.vp8dx_decode_bool(ref br, probLast);
-            int decodedRef;
-            if (notLast == 0)
+            fixed (byte* p = partition)
             {
-                decodedRef = (int)MV_REFERENCE_FRAME.LAST_FRAME;
-            }
-            else
-            {
-                int isAlt = dboolhuff.vp8dx_decode_bool(ref br, probGf);
-                decodedRef = 2 + isAlt;
-            }
-            Assert.Equal((int)refFrame, decodedRef);
+                dboolhuff.vp8dx_start_decode(ref br, p, (uint)partition.Length, null, null);
 
-            int decodedMode = treereader.vp8_treed_read(
-                ref br, entropymode.vp8_mv_ref_tree, modeProbs);
-            Assert.Equal((int)mode, decodedMode);
+                // Mirror decodemv.read_mb_modes_mv ref-frame parsing.
+                int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
+                Assert.Equal(1, isInter);
+
+                int notLast = dboolhuff.vp8dx_decode_bool(ref br, probLast);
+                int decodedRef;
+                if (notLast == 0)
+                {
+                    decodedRef = (int)MV_REFERENCE_FRAME.LAST_FRAME;
+                }
+                else
+                {
+                    int isAlt = dboolhuff.vp8dx_decode_bool(ref br, probGf);
+                    decodedRef = 2 + isAlt;
+                }
+                Assert.Equal((int)refFrame, decodedRef);
+
+                int decodedMode = treereader.vp8_treed_read(
+                    ref br, entropymode.vp8_mv_ref_tree, modeProbs);
+                Assert.Equal((int)mode, decodedMode);
+            }
         }
 
         [Fact]
@@ -206,17 +215,20 @@ namespace Vpx.Net.UnitTest
             for (int j = 0; j < 4; j++) modeProbs[j] = (byte)modecont.vp8_mode_contexts[0, j];
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, partition, (uint)partition.Length);
+            fixed (byte* p = partition)
+            {
+                dboolhuff.vp8dx_start_decode(ref br, p, (uint)partition.Length, null, null);
 
-            int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
-            Assert.Equal(1, isInter);
+                int isInter = dboolhuff.vp8dx_decode_bool(ref br, probIntra);
+                Assert.Equal(1, isInter);
 
-            int notLast = dboolhuff.vp8dx_decode_bool(ref br, probLast);
-            Assert.Equal(0, notLast);   // LAST -> 0
+                int notLast = dboolhuff.vp8dx_decode_bool(ref br, probLast);
+                Assert.Equal(0, notLast);   // LAST -> 0
 
-            int decodedMode = treereader.vp8_treed_read(
-                ref br, entropymode.vp8_mv_ref_tree, modeProbs);
-            Assert.Equal((int)MB_PREDICTION_MODE.ZEROMV, decodedMode);
+                int decodedMode = treereader.vp8_treed_read(
+                    ref br, entropymode.vp8_mv_ref_tree, modeProbs);
+                Assert.Equal((int)MB_PREDICTION_MODE.ZEROMV, decodedMode);
+            }
         }
 
         // ---------- vp8_treed_write byte-shape regression ----------

--- a/test/SIPSorcery.VP8.UnitTest/multi_partition_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/multi_partition_unittest.cs
@@ -1,0 +1,272 @@
+//-----------------------------------------------------------------------------
+// Multi-token-partition encoder round-trips: encode keyframe + inter for
+// log2_nbr_of_dct_partitions in {0, 1, 2, 3} (1 / 2 / 4 / 8 token
+// partitions) and verify the libvpx decoder accepts the bitstream and
+// recovers pixels within tolerance. Also extends pipeline parity to
+// cover every partition count.
+//
+// Bit-exactness is preserved for log2N == 0 (the existing tests cover
+// that). For log2N > 0 the encoder produces a different bitstream
+// because tokens are split across partitions and a (N-1)*3-byte size
+// table is inserted after partition 0; what we assert is decoder
+// round-trip correctness, not bit-equality with the single-partition
+// path.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+using SIPSorceryMedia.Abstractions;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class multi_partition_unittest
+    {
+        public static TheoryData<int> Log2PartitionCounts => new TheoryData<int>
+        {
+            0, 1, 2, 3,
+        };
+
+        public static TheoryData<Vp8EncodePipelineKind, int> PipelineAndPartitions => new TheoryData<Vp8EncodePipelineKind, int>
+        {
+            { Vp8EncodePipelineKind.Legacy,    0 },
+            { Vp8EncodePipelineKind.Legacy,    1 },
+            { Vp8EncodePipelineKind.Legacy,    2 },
+            { Vp8EncodePipelineKind.Legacy,    3 },
+            { Vp8EncodePipelineKind.Optimized, 0 },
+            { Vp8EncodePipelineKind.Optimized, 1 },
+            { Vp8EncodePipelineKind.Optimized, 2 },
+            { Vp8EncodePipelineKind.Optimized, 3 },
+        };
+
+        // ---------- Keyframe round-trip across log2N ----------
+
+        [Theory]
+        [MemberData(nameof(PipelineAndPartitions))]
+        public void EncodeKeyframe_Checkerboard128x128_RoundTripsForLog2N(Vp8EncodePipelineKind kind, int log2N)
+        {
+            // 128x128 = 8x8 MB grid. Wide enough for log2N=3 (8 partitions,
+            // 1 row per partition) and tall enough that log2N=2 / 1 each
+            // get multiple rows.
+            const int W = 128, H = 128;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            byte[] frame = EncodeKeyframe(kind, log2N, yuv, W, H, qIndex: 32);
+            byte[] decoded = DecodeI420(frame, W, H);
+
+            AssertWithin(yuv, decoded, tol: 16);
+        }
+
+        [Theory]
+        [MemberData(nameof(Log2PartitionCounts))]
+        public void EncodeKeyframe_FlatGrey16x16_RoundTripsExactly(int log2N)
+        {
+            // Smallest possible frame (1 MB row). Stresses the
+            // empty-partition stitch path for log2N >= 1.
+            const int W = 16, H = 16;
+            byte[] yuv = MakeFlatI420(W, H, y: 128, u: 128, v: 128);
+
+            byte[] frame = EncodeKeyframe(Vp8EncodePipelineKind.Optimized, log2N, yuv, W, H, qIndex: 32);
+            byte[] decoded = DecodeI420(frame, W, H);
+
+            AssertExact(yuv, decoded);
+        }
+
+        // ---------- Inter round-trip across log2N ----------
+
+        [Theory]
+        [MemberData(nameof(PipelineAndPartitions))]
+        public void EncodeInter_Checkerboard128x128_AfterKeyRoundTripsForLog2N(Vp8EncodePipelineKind kind, int log2N)
+        {
+            const int W = 128, H = 128;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            // Encode keyframe and inter through the same VP8Codec instance
+            // so LAST_FRAME state is consistent.
+            using var codec = new VP8Codec(kind, log2N);
+            codec.BaseQIndex = 32;
+
+            byte[] keyFrame = codec.EncodeVideo(W, H, yuv, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.NotNull(keyFrame);
+
+            byte[] yuvInter = (byte[])yuv.Clone();
+            for (int i = 0; i < yuvInter.Length; i++) yuvInter[i] = (byte)((yuvInter[i] + 13) & 0xff);
+
+            byte[] interFrame = codec.EncodeVideo(W, H, yuvInter, VideoPixelFormatsEnum.I420, VideoCodecsEnum.VP8);
+            Assert.NotNull(interFrame);
+
+            // Decode both frames sequentially through one decoder and
+            // compare the second decoded frame against the inter source.
+            var ctx = new vpx_codec_ctx_t();
+            var algo = vp8_dx.vpx_codec_vp8_dx();
+            var cfg = new vpx_codec_dec_cfg_t { threads = 1 };
+            Assert.Equal(vpx_codec_err_t.VPX_CODEC_OK,
+                vpx_decoder.vpx_codec_dec_init(ctx, algo, cfg, 0));
+
+            DecodeFrame(ctx, keyFrame);     // seeds LAST_FRAME
+            byte[] decoded = DecodeFrame(ctx, interFrame, W, H);
+
+            AssertWithin(yuvInter, decoded, tol: 24);
+        }
+
+        // ---------- Pipeline parity at each log2N ----------
+
+        [Theory]
+        [MemberData(nameof(Log2PartitionCounts))]
+        public void Keyframe_LegacyVsOptimized_BitExactPerLog2N(int log2N)
+        {
+            const int W = 128, H = 128;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            var encA = Vp8FrameEncodePipelineFactory.Create(Vp8EncodePipelineKind.Legacy, log2N);
+            var encB = Vp8FrameEncodePipelineFactory.Create(Vp8EncodePipelineKind.Optimized, log2N);
+            var fbA = new FrameEncoderBuffers();
+            var fbB = new FrameEncoderBuffers();
+
+            byte[] outA = encA.EncodeKeyframeContiguousI420(yuv, W, H, 32, fbA);
+            byte[] outB = encB.EncodeKeyframeContiguousI420(yuv, W, H, 32, fbB);
+            Assert.Equal(outA, outB);
+        }
+
+        [Theory]
+        [MemberData(nameof(Log2PartitionCounts))]
+        public void Inter_LegacyVsOptimized_BitExactPerLog2N(int log2N)
+        {
+            const int W = 128, H = 128;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            var encA = Vp8FrameEncodePipelineFactory.Create(Vp8EncodePipelineKind.Legacy, log2N);
+            var encB = Vp8FrameEncodePipelineFactory.Create(Vp8EncodePipelineKind.Optimized, log2N);
+            var fbA = new FrameEncoderBuffers();
+            var fbB = new FrameEncoderBuffers();
+
+            byte[] keyA = encA.EncodeKeyframeContiguousI420(yuv, W, H, 32, fbA);
+            byte[] keyB = encB.EncodeKeyframeContiguousI420(yuv, W, H, 32, fbB);
+            Assert.Equal(keyA, keyB);
+
+            byte[] yuvInter = (byte[])yuv.Clone();
+            for (int i = 0; i < yuvInter.Length; i++) yuvInter[i] = (byte)((yuvInter[i] + 13) & 0xff);
+
+            byte[] interA = encA.EncodeInterFrameContiguousI420(yuvInter, W, H, 32, fbA);
+            byte[] interB = encB.EncodeInterFrameContiguousI420(yuvInter, W, H, 32, fbB);
+            Assert.Equal(interA, interB);
+        }
+
+        // ---------- Header bit sanity ----------
+
+        [Fact]
+        public void EncodeKeyframe_Log2N3_HeaderEncodesEightPartitions()
+        {
+            // log2N=3 -> 2-bit field with value 3 in the header (bits read
+            // by the decoder as log2_nbr_of_dct_partitions). Decoder must
+            // then read 7 size table entries and 8 partitions. Our
+            // round-trip test above verifies the decoder round-trips
+            // correctly; this test just sanity-checks the encoded
+            // bitstream is non-empty and not the same as log2N=0.
+            const int W = 32, H = 32;
+            byte[] yuv = MakeCheckerboardI420(W, H, dark: 50, light: 200);
+
+            byte[] frame0 = EncodeKeyframe(Vp8EncodePipelineKind.Optimized, 0, yuv, W, H, qIndex: 32);
+            byte[] frame3 = EncodeKeyframe(Vp8EncodePipelineKind.Optimized, 3, yuv, W, H, qIndex: 32);
+
+            // log2N=3 inserts a (8-1)*3 = 21-byte size table; total
+            // bitstream must be at least 21 bytes longer than the
+            // single-partition equivalent (more in practice because the
+            // extra bool-coder flush bytes per partition also add up).
+            Assert.True(frame3.Length >= frame0.Length + 21,
+                $"log2N=3 frame ({frame3.Length} bytes) should be at least 21 bytes larger than log2N=0 frame ({frame0.Length} bytes)");
+        }
+
+        // ---------- helpers ----------
+
+        private static byte[] EncodeKeyframe(Vp8EncodePipelineKind kind, int log2N, byte[] i420, int w, int h, int qIndex)
+        {
+            var enc = Vp8FrameEncodePipelineFactory.Create(kind, log2N);
+            var fb = new FrameEncoderBuffers();
+            return enc.EncodeKeyframeContiguousI420(i420, w, h, qIndex, fb);
+        }
+
+        private static byte[] DecodeI420(byte[] frame, int width, int height)
+        {
+            var ctx = new vpx_codec_ctx_t();
+            var algo = vp8_dx.vpx_codec_vp8_dx();
+            var cfg = new vpx_codec_dec_cfg_t { threads = 1 };
+            Assert.Equal(vpx_codec_err_t.VPX_CODEC_OK,
+                vpx_decoder.vpx_codec_dec_init(ctx, algo, cfg, 0));
+            return DecodeFrame(ctx, frame, width, height);
+        }
+
+        private static byte[] DecodeFrame(vpx_codec_ctx_t ctx, byte[] frame, int width = 0, int height = 0)
+        {
+            fixed (byte* pFrame = frame)
+            {
+                var decRes = vpx_decoder.vpx_codec_decode(ctx, pFrame, (uint)frame.Length, IntPtr.Zero, 0);
+                Assert.Equal(vpx_codec_err_t.VPX_CODEC_OK, decRes);
+            }
+
+            IntPtr iter = IntPtr.Zero;
+            var img = vpx_decoder.vpx_codec_get_frame(ctx, iter);
+            Assert.NotNull(img);
+
+            int w = width  != 0 ? width  : (int)img.d_w;
+            int h = height != 0 ? height : (int)img.d_h;
+            int sz = w * h, csz = (w / 2) * (h / 2);
+            byte[] outYuv = new byte[sz + 2 * csz];
+
+            for (int row = 0; row < h; row++)
+            {
+                Marshal.Copy((IntPtr)(img.planes[0] + row * img.stride[0]), outYuv, row * w, w);
+                if (row < h / 2)
+                {
+                    Marshal.Copy((IntPtr)(img.planes[1] + row * img.stride[1]), outYuv, sz + row * (w / 2), w / 2);
+                    Marshal.Copy((IntPtr)(img.planes[2] + row * img.stride[2]), outYuv, sz + csz + row * (w / 2), w / 2);
+                }
+            }
+            return outYuv;
+        }
+
+        private static byte[] MakeFlatI420(int width, int height, byte y, byte u, byte v)
+        {
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var b = new byte[ySize + 2 * cSize];
+            for (int i = 0; i < ySize; i++) b[i] = y;
+            for (int i = 0; i < cSize; i++) b[ySize + i] = u;
+            for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = v;
+            return b;
+        }
+
+        private static byte[] MakeCheckerboardI420(int width, int height, byte dark, byte light)
+        {
+            int ySize = width * height;
+            int cSize = (width / 2) * (height / 2);
+            var b = new byte[ySize + 2 * cSize];
+            for (int row = 0; row < height; row++)
+                for (int col = 0; col < width; col++)
+                    b[row * width + col] = ((((row >> 1) ^ (col >> 1)) & 1) != 0) ? dark : light;
+            for (int i = 0; i < cSize; i++) b[ySize + i] = 128;
+            for (int i = 0; i < cSize; i++) b[ySize + cSize + i] = 128;
+            return b;
+        }
+
+        private static void AssertExact(byte[] expected, byte[] actual)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+                Assert.True(expected[i] == actual[i],
+                    "Pixel " + i + " differs: src=" + expected[i] + " decoded=" + actual[i]);
+        }
+
+        private static void AssertWithin(byte[] expected, byte[] actual, int tol)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                int d = actual[i] - expected[i];
+                Assert.True(d >= -tol && d <= tol,
+                    "Pixel " + i + " err " + d + " exceeds tolerance " + tol +
+                    " (src=" + expected[i] + " decoded=" + actual[i] + ")");
+            }
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.UnitTest/pack_tokens_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/pack_tokens_unittest.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: pack_tokens_unittest.cs
 //
 // Description: Unit tests for the VP8 token bitstream writer (encoder side,
@@ -22,19 +22,30 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Xunit;
+
+using vp8_prob = System.Byte;
 
 namespace Vpx.Net.UnitTest
 {
     public unsafe class pack_tokens_unittest
     {
-        // A flat 11-element prob row of 128s, used for the libvpx reference
-        // captures so the boolean-coder math is independent of any specific
-        // probability context (every node has the same "fair coin" prob).
-        // Real encodes use the per-(type,band,ctx) probability rows.
-        private static readonly byte[] s_flatProbs =
-            { 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
+        // All-128 coef table: every row matches the flat 11×128 reference
+        // captures. Any CoefProbRowIndex 0..95 is valid for these tests.
+        private static readonly vp8_prob[,,,] s_all128Coef = CreateAll128CoefTable();
+
+        private static vp8_prob[,,,] CreateAll128CoefTable()
+        {
+            var t = new vp8_prob[4, 8, 3, 11];
+            for (int i = 0; i < t.GetLength(0); i++)
+                for (int j = 0; j < t.GetLength(1); j++)
+                    for (int k = 0; k < t.GetLength(2); k++)
+                        for (int n = 0; n < t.GetLength(3); n++)
+                            t[i, j, k, n] = 128;
+            return t;
+        }
 
         // ---------- Bit-exact reference checks against libvpx ----------
 
@@ -46,9 +57,7 @@ namespace Vpx.Net.UnitTest
         public void PackTokens_EobOnly_MatchesLibvpxReference()
         {
             byte[] expected = { 0x00, 0x00 };
-            AssertPackedBytes(expected, new[] {
-                Eob(),
-            });
+            AssertPackedBytes(expected, new[] { Eob() }, s_all128Coef);
         }
 
         /// <summary>
@@ -62,7 +71,7 @@ namespace Vpx.Net.UnitTest
             AssertPackedBytes(expected, new[] {
                 Tok(entropy.ONE_TOKEN, extra: 0),
                 Eob(),
-            });
+            }, s_all128Coef);
         }
 
         /// <summary>
@@ -85,7 +94,7 @@ namespace Vpx.Net.UnitTest
                 Tok(entropy.ZERO_TOKEN,   0, skip: 0),
                 Tok(entropy.ONE_TOKEN,    1, skip: 1),
                 Eob(),
-            });
+            }, s_all128Coef);
         }
 
         /// <summary>
@@ -102,7 +111,7 @@ namespace Vpx.Net.UnitTest
                 Tok(entropy.DCT_VAL_CATEGORY4, extra: 12),
                 Tok(entropy.DCT_VAL_CATEGORY2, extra: 3),
                 Eob(),
-            });
+            }, s_all128Coef);
         }
 
         // ---------- Round-trip: tokenize -> pack -> bool-decode -> token reconstruction ----------
@@ -124,27 +133,65 @@ namespace Vpx.Net.UnitTest
             short[] q = new short[16];
             q[0] = 1; q[1] = 0; q[4] = 0; q[8] = -3; q[5] = 0; q[2] = 2; q[3] = 0; q[6] = -1;
 
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             tokenize.vp8_tokenize_block(
                 q, firstCoeffIndex: 0, eob: 8,
                 blockType: 3, initialContext: 0,
                 coefProbs: default_coef_probs_c.default_coef_probs,
                 output: tokens);
 
-            byte[] packed = PackToBytes(tokens);
+            byte[] packed = PackToBytes(tokens.AsSpan(), default_coef_probs_c.default_coef_probs);
 
-            // Decode back. We need the same probability rows the encoder
-            // used; for a per-(type, band, ctx) decode we'd recompute them
-            // identically — but in this round-trip the encoder embedded
-            // them in TOKENEXTRA.context_tree, so we can just read them
-            // from there as we walk.
-            var decoded = DecodeTokens(packed, tokens);
+            var decoded = DecodeTokens(packed, tokens, default_coef_probs_c.default_coef_probs);
             Assert.Equal(tokens.Count, decoded.Count);
             for (int i = 0; i < tokens.Count; i++)
             {
                 Assert.Equal(tokens[i].Token, decoded[i].Token);
                 Assert.Equal(tokens[i].Extra, decoded[i].Extra);
             }
+        }
+
+        /// <summary>
+        /// GetCoefProbRowForPack uses a per-thread RowsFor cache; concurrent
+        /// threads with different coef tables must not see cross-wired rows.
+        /// </summary>
+        [Fact]
+        public void GetCoefProbRowForPack_TwoThreadsDistinctTables_RowMatchesTable()
+        {
+            var tableA = CreateAll128CoefTable();
+            var tableB = CreateAll128CoefTable();
+            tableB[0, 0, 0, 0] = 42;
+
+            const byte rowIndex = 0;
+            const int iterations = 8000;
+            object gate = new object();
+            Exception first = null;
+
+            void Work(vp8_prob[,,,] t)
+            {
+                byte expect = t[0, 0, 0, 0];
+                try
+                {
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        var row = tokenize.GetCoefProbRowForPack(t, rowIndex);
+                        Assert.Equal(expect, row[0]);
+                    }
+                }
+                catch (Exception e)
+                {
+                    lock (gate) { first ??= e; }
+                }
+            }
+
+            var thA = new System.Threading.Thread(() => Work(tableA));
+            var thB = new System.Threading.Thread(() => Work(tableB));
+            thA.Start();
+            thB.Start();
+            thA.Join();
+            thB.Join();
+            if (first != null)
+                throw first;
         }
 
         // ---------- helpers ----------
@@ -156,7 +203,7 @@ namespace Vpx.Net.UnitTest
                 Token = (byte)token,
                 Extra = (short)extra,
                 skip_eob_node = (byte)skip,
-                context_tree = s_flatProbs,
+                CoefProbRowIndex = 0,
             };
         }
 
@@ -165,14 +212,14 @@ namespace Vpx.Net.UnitTest
             return Tok(entropy.DCT_EOB_TOKEN, 0);
         }
 
-        private static byte[] PackToBytes(IList<TOKENEXTRA> tokens)
+        private static byte[] PackToBytes(ReadOnlySpan<TOKENEXTRA> tokens, vp8_prob[,,,] coefProbs)
         {
             byte[] buf = new byte[256];
             BOOL_CODER bc = new BOOL_CODER();
             fixed (byte* p = buf)
             {
                 boolhuff.vp8_start_encode(ref bc, p, p + buf.Length);
-                bitstream.vp8_pack_tokens(ref bc, tokens);
+                bitstream.vp8_pack_tokens(ref bc, tokens, coefProbs);
                 boolhuff.vp8_stop_encode(ref bc);
             }
             byte[] result = new byte[bc.pos];
@@ -180,9 +227,9 @@ namespace Vpx.Net.UnitTest
             return result;
         }
 
-        private static void AssertPackedBytes(byte[] expected, IList<TOKENEXTRA> tokens)
+        private static void AssertPackedBytes(byte[] expected, ReadOnlySpan<TOKENEXTRA> tokens, vp8_prob[,,,] coefProbs)
         {
-            byte[] got = PackToBytes(tokens);
+            byte[] got = PackToBytes(tokens, coefProbs);
             Assert.Equal(expected.Length, got.Length);
             for (int i = 0; i < expected.Length; i++)
             {
@@ -193,11 +240,8 @@ namespace Vpx.Net.UnitTest
 
         // Walk the same coef tree + per-category extra-bit trees the encoder
         // used, reading bits from the existing decoder's bool reader to
-        // reconstruct each (Token, Extra) pair. We use the encoder's
-        // TOKENEXTRA stream as the "schedule" telling us when EOB-skip and
-        // which prob row to read with — exactly the information a real
-        // decoder reconstructs from its own state machine.
-        private static List<(int Token, int Extra)> DecodeTokens(byte[] packed, IList<TOKENEXTRA> reference)
+        // reconstruct each (Token, Extra) pair.
+        private static List<(int Token, int Extra)> DecodeTokens(byte[] packed, TokenStreamBuffer reference, vp8_prob[,,,] coefProbs)
         {
             // Pad with zeros for the bool reader's lookahead.
             byte[] padded = new byte[packed.Length + 8];
@@ -210,7 +254,7 @@ namespace Vpx.Net.UnitTest
             for (int idx = 0; idx < reference.Count; idx++)
             {
                 var refTok = reference[idx];
-                byte[] probs = refTok.context_tree;
+                byte[] probs = tokenize.GetCoefProbRowForPack(coefProbs, refTok.CoefProbRowIndex);
 
                 // Walk vp8_coef_tree until terminal (negative).
                 int i = (refTok.skip_eob_node != 0) ? 2 : 0;
@@ -252,10 +296,6 @@ namespace Vpx.Net.UnitTest
 
                 result.Add((token, extra));
 
-                // Stop decoding after EOB so we don't read past the meaningful
-                // bits (the round-trip test passes the full reference list,
-                // so we won't actually terminate here, but a real decoder
-                // would).
                 if (token == entropy.DCT_EOB_TOKEN)
                 {
                     // continue — the test feeds in everything after EOB too,

--- a/test/SIPSorcery.VP8.UnitTest/pack_tokens_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/pack_tokens_unittest.cs
@@ -248,60 +248,64 @@ namespace Vpx.Net.UnitTest
             System.Array.Copy(packed, padded, packed.Length);
 
             BOOL_DECODER br = new BOOL_DECODER();
-            dboolhuff.vp8dx_start_decode(ref br, padded, (uint)padded.Length);
-
             var result = new List<(int, int)>(reference.Count);
-            for (int idx = 0; idx < reference.Count; idx++)
+            fixed (byte* pPad = padded)
             {
-                var refTok = reference[idx];
-                byte[] probs = tokenize.GetCoefProbRowForPack(coefProbs, refTok.CoefProbRowIndex);
+                dboolhuff.vp8dx_start_decode(ref br, pPad, (uint)padded.Length, null, null);
 
-                // Walk vp8_coef_tree until terminal (negative).
-                int i = (refTok.skip_eob_node != 0) ? 2 : 0;
-                int token;
-                while (true)
+                for (int idx = 0; idx < reference.Count; idx++)
                 {
-                    int bit = dboolhuff.vp8dx_decode_bool(ref br, probs[i >> 1]);
-                    int next = entropy.vp8_coef_tree[i + bit];
-                    if (next <= 0)
-                    {
-                        token = -next;
-                        break;
-                    }
-                    i = next;
-                }
+                    var refTok = reference[idx];
+                    byte[] probs = tokenize.GetCoefProbRowForPack(coefProbs, refTok.CoefProbRowIndex);
 
-                int extra = 0;
-                var b = entropy.vp8_extra_bits[token];
-                if (b.base_val != 0)
-                {
-                    // Walk the per-category extra-bit tree to reconstruct
-                    // the magnitude bits, then read the sign.
-                    int magnitude = 0;
-                    if (b.Len != 0)
+                    // Walk vp8_coef_tree until terminal (negative).
+                    int i = (refTok.skip_eob_node != 0) ? 2 : 0;
+                    int token;
+                    while (true)
                     {
-                        int j = 0;
-                        for (int step = 0; step < b.Len; step++)
+                        int bit = dboolhuff.vp8dx_decode_bool(ref br, probs[i >> 1]);
+                        int next = entropy.vp8_coef_tree[i + bit];
+                        if (next <= 0)
                         {
-                            int bit = dboolhuff.vp8dx_decode_bool(ref br, b.prob[j >> 1]);
-                            magnitude = (magnitude << 1) | bit;
-                            int next = b.tree[j + bit];
-                            if (next == 0) break;
-                            j = next;
+                            token = -next;
+                            break;
                         }
+                        i = next;
                     }
-                    int sign = dboolhuff.vp8dx_decode_bool(ref br, 128);
-                    extra = (magnitude << 1) | sign;
-                }
 
-                result.Add((token, extra));
+                    int extra = 0;
+                    var b = entropy.vp8_extra_bits[token];
+                    if (b.base_val != 0)
+                    {
+                        // Walk the per-category extra-bit tree to reconstruct
+                        // the magnitude bits, then read the sign.
+                        int magnitude = 0;
+                        if (b.Len != 0)
+                        {
+                            int j = 0;
+                            for (int step = 0; step < b.Len; step++)
+                            {
+                                int bit = dboolhuff.vp8dx_decode_bool(ref br, b.prob[j >> 1]);
+                                magnitude = (magnitude << 1) | bit;
+                                int next = b.tree[j + bit];
+                                if (next == 0) break;
+                                j = next;
+                            }
+                        }
+                        int sign = dboolhuff.vp8dx_decode_bool(ref br, 128);
+                        extra = (magnitude << 1) | sign;
+                    }
 
-                if (token == entropy.DCT_EOB_TOKEN)
-                {
-                    // continue — the test feeds in everything after EOB too,
-                    // which mirrors how the encoder serialised them.
+                    result.Add((token, extra));
+
+                    if (token == entropy.DCT_EOB_TOKEN)
+                    {
+                        // continue — the test feeds in everything after EOB too,
+                        // which mirrors how the encoder serialised them.
+                    }
                 }
             }
+
             return result;
         }
     }

--- a/test/SIPSorcery.VP8.UnitTest/quantize_encoder_simd_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/quantize_encoder_simd_unittest.cs
@@ -1,0 +1,166 @@
+//-----------------------------------------------------------------------------
+// Filename: quantize_encoder_simd_unittest.cs
+//
+// Description: Bit-exactness fuzz tests comparing the SIMD quantizer
+// (QuantizeEncoderSimd.RegularQuantizeB) against the scalar reference
+// (quantize.vp8_regular_quantize_b_arrays).
+//
+// Author(s):
+// Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class quantize_encoder_simd_unittest
+    {
+        // libvpx-style quant table for dequant=8, moderate quality.
+        private static short[] Repeat16(short v)
+        {
+            var a = new short[16];
+            for (int i = 0; i < 16; i++) a[i] = v;
+            return a;
+        }
+
+        private static int RunScalar(short[] coeff, short[] zbin, short[] zboost, short[] round, short[] quant,
+            short[] qshift, short[] dequant, short zbinExtra, out short[] q, out short[] dq)
+        {
+            q = new short[16];
+            dq = new short[16];
+            fixed (short* cP = coeff)
+            fixed (short* zbP = zbin)
+            fixed (short* zbsP = zboost)
+            fixed (short* rP = round)
+            fixed (short* qvP = quant)
+            fixed (short* qsP = qshift)
+            fixed (short* dqvP = dequant)
+            fixed (short* qP = q)
+            fixed (short* dqP = dq)
+            {
+                return quantize.vp8_regular_quantize_b_arrays(cP, zbP, zbsP, rP, qvP, qsP, dqvP, qP, dqP, zbinExtra);
+            }
+        }
+
+        private static int RunSimd(short[] coeff, short[] zbin, short[] zboost, short[] round, short[] quant,
+            short[] qshift, short[] dequant, short zbinExtra, out short[] q, out short[] dq)
+        {
+            q = new short[16];
+            dq = new short[16];
+            fixed (short* cP = coeff)
+            fixed (short* zbP = zbin)
+            fixed (short* zbsP = zboost)
+            fixed (short* rP = round)
+            fixed (short* qvP = quant)
+            fixed (short* qsP = qshift)
+            fixed (short* dqvP = dequant)
+            fixed (short* qP = q)
+            fixed (short* dqP = dq)
+            {
+                return QuantizeEncoderSimd.RegularQuantizeB(cP, zbP, zbsP, rP, qvP, qsP, dqvP, qP, dqP, zbinExtra);
+            }
+        }
+
+        [Fact]
+        public void Quantize_ZeroInput_MatchesScalar()
+        {
+            short[] coeff = new short[16];
+            int eobS = RunScalar(coeff, Repeat16(4), Repeat16(0), Repeat16(4), Repeat16(1),
+                Repeat16(8192), Repeat16(8), 0, out var qS, out var dqS);
+            int eobM = RunSimd(coeff, Repeat16(4), Repeat16(0), Repeat16(4), Repeat16(1),
+                Repeat16(8192), Repeat16(8), 0, out var qM, out var dqM);
+
+            Assert.Equal(eobS, eobM);
+            Assert.Equal(qS, qM);
+            Assert.Equal(dqS, dqM);
+        }
+
+        [Fact]
+        public void Quantize_Fuzz_FlatTables_MatchesScalar()
+        {
+            short[] zbin = Repeat16(4);
+            short[] zboost = Repeat16(0);
+            short[] round = Repeat16(4);
+            short[] quant = Repeat16(1);
+            short[] qshift = Repeat16(8192);
+            short[] dequant = Repeat16(8);
+
+            for (int seed = 0; seed < 64; seed++)
+            {
+                var rng = new Random(seed * 37 + 5);
+                short[] coeff = new short[16];
+                for (int i = 0; i < 16; i++) coeff[i] = (short)rng.Next(-2048, 2049);
+
+                int eobS = RunScalar(coeff, zbin, zboost, round, quant, qshift, dequant, 0, out var qS, out var dqS);
+                int eobM = RunSimd(coeff, zbin, zboost, round, quant, qshift, dequant, 0, out var qM, out var dqM);
+
+                Assert.True(eobS == eobM, $"seed={seed} eobS={eobS} eobM={eobM}");
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(qS[i] == qM[i], $"seed={seed} i={i} qS={qS[i]} qM={qM[i]}");
+                    Assert.True(dqS[i] == dqM[i], $"seed={seed} i={i} dqS={dqS[i]} dqM={dqM[i]}");
+                }
+            }
+        }
+
+        [Fact]
+        public void Quantize_Fuzz_NonUniformTables_MatchesScalar()
+        {
+            // Use realistic-looking nonuniform tables drawn from libvpx Y plane
+            // for a moderate Q.
+            short[] zbin = { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+            short[] zboost = { 0, 0, 8, 8, 5, 4, 4, 5, 6, 7, 8, 12, 14, 18, 20, 24 };
+            short[] round = { 8, 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+            short[] quant = { 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+            short[] qshift = { 8192, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096 };
+            short[] dequant = { 8, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16 };
+
+            for (int seed = 0; seed < 64; seed++)
+            {
+                var rng = new Random(seed * 41 + 11);
+                short[] coeff = new short[16];
+                for (int i = 0; i < 16; i++) coeff[i] = (short)rng.Next(-2048, 2049);
+                short zbinExtra = (short)rng.Next(0, 16);
+
+                int eobS = RunScalar(coeff, zbin, zboost, round, quant, qshift, dequant, zbinExtra, out var qS, out var dqS);
+                int eobM = RunSimd(coeff, zbin, zboost, round, quant, qshift, dequant, zbinExtra, out var qM, out var dqM);
+
+                Assert.True(eobS == eobM, $"seed={seed} eobS={eobS} eobM={eobM}");
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(qS[i] == qM[i], $"seed={seed} i={i} qS={qS[i]} qM={qM[i]}");
+                    Assert.True(dqS[i] == dqM[i], $"seed={seed} i={i} dqS={dqS[i]} dqM={dqM[i]}");
+                }
+            }
+        }
+
+        [Fact]
+        public void Quantize_Fuzz_LargeCoefRange_MatchesScalar()
+        {
+            // Real-world dq coefficients can range up to ~8000 — exercise that band.
+            short[] zbin = Repeat16(150);
+            short[] zboost = { 0, 0, 8, 8, 5, 4, 4, 5, 6, 7, 8, 12, 14, 18, 20, 24 };
+            short[] round = Repeat16(80);
+            short[] quant = Repeat16(20000);
+            short[] qshift = Repeat16(2);
+            short[] dequant = Repeat16(20);
+
+            for (int seed = 0; seed < 32; seed++)
+            {
+                var rng = new Random(seed * 53 + 7);
+                short[] coeff = new short[16];
+                for (int i = 0; i < 16; i++) coeff[i] = (short)rng.Next(-8000, 8001);
+
+                int eobS = RunScalar(coeff, zbin, zboost, round, quant, qshift, dequant, 0, out var qS, out var dqS);
+                int eobM = RunSimd(coeff, zbin, zboost, round, quant, qshift, dequant, 0, out var qM, out var dqM);
+
+                Assert.Equal(eobS, eobM);
+                Assert.Equal(qS, qM);
+                Assert.Equal(dqS, dqM);
+            }
+        }
+    }
+}

--- a/test/SIPSorcery.VP8.UnitTest/quantize_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/quantize_unittest.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: quantize_unittest.cs
 //
 // Description: Unit tests for the VP8 forward quantizer (encoder side,
@@ -20,6 +20,7 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using Vpx.Net;
 using Xunit;
 
 namespace Vpx.Net.UnitTest
@@ -114,7 +115,111 @@ namespace Vpx.Net.UnitTest
             Assert.Equal(expectedDq, dqcoeff);
         }
 
+        /// <summary>
+        /// Non-zero <c>zrun_zbin_boost</c> table: still bit-identical to scalar widening-only reference.
+        /// </summary>
+        [Fact]
+        public void Quantize_NonUniformZrunBoost_MatchesScalarReference()
+        {
+            short[] coeff;
+            short[] zbin = Repeat16((short)4);
+            short[] zboost = new short[16];
+            for (int i = 0; i < 16; i++)
+                zboost[i] = (short)(i * 3);
+            short[] round = Repeat16((short)4);
+            short[] quant = Repeat16((short)1);
+            short[] quantShift = Repeat16((short)8192);
+            short[] dequant = Repeat16((short)8);
+
+            var rng = new System.Random(321);
+            for (int t = 0; t < 64; t++)
+            {
+                coeff = new short[16];
+                for (int i = 0; i < 16; i++)
+                    coeff[i] = (short)rng.Next(-120, 121);
+
+                int eSimd = RunQuantizeTables(coeff, zbin, zboost, round, quant, quantShift, dequant, out short[] qS, out short[] dqS);
+                int eRef = RunQuantizeTablesScalarRef(coeff, zbin, zboost, round, quant, quantShift, dequant, out short[] qR, out short[] dqR);
+
+                Assert.Equal(eRef, eSimd);
+                Assert.Equal(qR, qS);
+                Assert.Equal(dqR, dqS);
+            }
+        }
+
         // ---------- helpers ----------
+
+        private static int RunQuantizeTables(
+            short[] coeff, short[] zbin, short[] zrunBoost, short[] round, short[] quant, short[] quantShift, short[] dequant,
+            out short[] qcoeff, out short[] dqcoeff)
+        {
+            qcoeff = new short[16];
+            dqcoeff = new short[16];
+
+            fixed (short* coefP = coeff)
+            fixed (short* zbinP = zbin)
+            fixed (short* zboostP = zrunBoost)
+            fixed (short* roundP = round)
+            fixed (short* quantP = quant)
+            fixed (short* quantShiftP = quantShift)
+            fixed (short* dequantP = dequant)
+            fixed (short* qcoeffP = qcoeff)
+            fixed (short* dqcoeffP = dqcoeff)
+            {
+                return quantize.vp8_regular_quantize_b_arrays(
+                    coefP, zbinP, zboostP, roundP, quantP, quantShiftP, dequantP,
+                    qcoeffP, dqcoeffP, zbin_extra: 0);
+            }
+        }
+
+        /// <summary>Pure C# duplicate of the quantize loop (no SIMD in widen/clear) for regression checks.</summary>
+        private static int RunQuantizeTablesScalarRef(
+            short[] coeff, short[] zbin, short[] zrunBoost, short[] round, short[] quant, short[] quantShift, short[] dequant,
+            out short[] qcoeff, out short[] dqcoeff)
+        {
+            qcoeff = new short[16];
+            dqcoeff = new short[16];
+            for (int i = 0; i < 16; i++)
+            {
+                qcoeff[i] = 0;
+                dqcoeff[i] = 0;
+            }
+
+            int eob = -1;
+            int zbin_boost_idx = 0;
+            int[] coeff32 = new int[16];
+            for (int j = 0; j < 16; j++)
+                coeff32[j] = coeff[j];
+
+            for (int i = 0; i < 16; ++i)
+            {
+                int rc = entropy.vp8_default_zig_zag1d[i];
+                int z = coeff32[rc];
+
+                int zbin_thr = zbin[rc] + zrunBoost[zbin_boost_idx] + 0;
+                zbin_boost_idx++;
+
+                int sz = (z >> 31);
+                int x = (z ^ sz) - sz;
+
+                if (x >= zbin_thr)
+                {
+                    x += round[rc];
+                    int y = ((((x * quant[rc]) >> 16) + x) * quantShift[rc]) >> 16;
+                    x = (y ^ sz) - sz;
+                    qcoeff[rc] = (short)x;
+                    dqcoeff[rc] = (short)(x * dequant[rc]);
+
+                    if (y != 0)
+                    {
+                        eob = i;
+                        zbin_boost_idx = 0;
+                    }
+                }
+            }
+
+            return eob + 1;
+        }
 
         private static int RunQuantize(short[] coeff, out short[] qcoeff, out short[] dqcoeff)
         {

--- a/test/SIPSorcery.VP8.UnitTest/tokenize_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/tokenize_unittest.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: tokenize_unittest.cs
 //
 // Description: Unit tests for the VP8 coefficient tokenizer (encoder side,
@@ -22,7 +22,6 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace Vpx.Net.UnitTest
@@ -105,7 +104,7 @@ namespace Vpx.Net.UnitTest
         [Fact]
         public void TokenizeBlock_AllZero_EmitsSingleEob()
         {
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             bool nonzero = tokenize.vp8_tokenize_block(
                 new short[16], firstCoeffIndex: 0, eob: 0,
                 blockType: 3, initialContext: 0,
@@ -124,7 +123,7 @@ namespace Vpx.Net.UnitTest
         public void TokenizeBlock_DcOnly_5_MatchesReference()
         {
             short[] q = new short[16]; q[0] = 5;
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             bool nonzero = tokenize.vp8_tokenize_block(
                 q, firstCoeffIndex: 0, eob: 1,
                 blockType: 3, initialContext: 0,
@@ -145,7 +144,7 @@ namespace Vpx.Net.UnitTest
         public void TokenizeBlock_DcAndOneAc_MatchesReference()
         {
             short[] q = new short[16]; q[0] = 5; q[1] = 2;
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             bool nonzero = tokenize.vp8_tokenize_block(
                 q, firstCoeffIndex: 0, eob: 2,
                 blockType: 3, initialContext: 0,
@@ -175,7 +174,7 @@ namespace Vpx.Net.UnitTest
         {
             short[] q = new short[16];
             q[0] = 1; q[1] = 0; q[4] = 0; q[8] = -3; q[5] = 0; q[2] = 2; q[3] = 0; q[6] = -1;
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             bool nonzero = tokenize.vp8_tokenize_block(
                 q, firstCoeffIndex: 0, eob: 8,
                 blockType: 3, initialContext: 0,
@@ -202,7 +201,7 @@ namespace Vpx.Net.UnitTest
         public void TokenizeBlock_YNoDc_OneAcCoefficient_MatchesReference()
         {
             short[] q = new short[16]; q[1] = 2;
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             bool nonzero = tokenize.vp8_tokenize_block(
                 q, firstCoeffIndex: 1, eob: 2,
                 blockType: 0, initialContext: 0,
@@ -224,7 +223,7 @@ namespace Vpx.Net.UnitTest
         public void TokenizeBlock_LargeCoefs_CategoryAndSign_MatchesReference()
         {
             short[] q = new short[16]; q[0] = 25; q[1] = -8;
-            var tokens = new List<TOKENEXTRA>();
+            var tokens = new TokenStreamBuffer();
             bool nonzero = tokenize.vp8_tokenize_block(
                 q, firstCoeffIndex: 0, eob: 2,
                 blockType: 3, initialContext: 0,
@@ -240,7 +239,7 @@ namespace Vpx.Net.UnitTest
 
         // ---------- helpers ----------
 
-        private static void AssertTokens(List<TOKENEXTRA> got, params (int token, int extra, int skipEob)[] expected)
+        private static void AssertTokens(TokenStreamBuffer got, params (int token, int extra, int skipEob)[] expected)
         {
             Assert.Equal(expected.Length, got.Count);
             for (int i = 0; i < expected.Length; i++)

--- a/test/SIPSorcery.VP8.UnitTest/walsh_encoder_simd_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/walsh_encoder_simd_unittest.cs
@@ -1,0 +1,234 @@
+//-----------------------------------------------------------------------------
+// Filename: walsh_encoder_simd_unittest.cs
+//
+// Description: Bit-exactness fuzz tests for the encoder-side SIMD fast paths
+// for forward/inverse 4x4 Walsh-Hadamard, vs the scalar references.
+//
+// Author(s):
+// Claude Opus 4.7 (commissioned by Aaron Clauson).
+//
+// License: BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Vpx.Net.UnitTest
+{
+    public unsafe class walsh_encoder_simd_unittest
+    {
+        // Scalar reference for the inverse Walsh used by the encoder. Same shape as
+        // mb_encoder.InverseWalsh4x4Into but unsafe-friendly.
+        private static void InverseWalshScalarReference(short* input, short* output)
+        {
+            int* tmp = stackalloc int[16];
+            int a1, b1, c1, d1, a2, b2, c2, d2;
+
+            for (int i = 0; i < 4; i++)
+            {
+                a1 = input[i * 4 + 0] + input[i * 4 + 3];
+                b1 = input[i * 4 + 1] + input[i * 4 + 2];
+                c1 = input[i * 4 + 1] - input[i * 4 + 2];
+                d1 = input[i * 4 + 0] - input[i * 4 + 3];
+
+                tmp[i * 4 + 0] = a1 + b1;
+                tmp[i * 4 + 1] = c1 + d1;
+                tmp[i * 4 + 2] = a1 - b1;
+                tmp[i * 4 + 3] = d1 - c1;
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                a1 = tmp[0 * 4 + i] + tmp[3 * 4 + i];
+                b1 = tmp[1 * 4 + i] + tmp[2 * 4 + i];
+                c1 = tmp[1 * 4 + i] - tmp[2 * 4 + i];
+                d1 = tmp[0 * 4 + i] - tmp[3 * 4 + i];
+
+                a2 = a1 + b1;
+                b2 = c1 + d1;
+                c2 = a1 - b1;
+                d2 = d1 - c1;
+
+                output[0 * 4 + i] = (short)((a2 + 3) >> 3);
+                output[1 * 4 + i] = (short)((b2 + 3) >> 3);
+                output[2 * 4 + i] = (short)((c2 + 3) >> 3);
+                output[3 * 4 + i] = (short)((d2 + 3) >> 3);
+            }
+        }
+
+        // ----------------- Forward Walsh -----------------
+
+        [Fact]
+        public void Walsh4x4_ZeroInput_MatchesScalar()
+        {
+            short[] input = new short[16];
+            short[] expected = new short[16];
+            short[] actual = new short[16];
+
+            fixed (short* inP = input)
+            fixed (short* expP = expected)
+            fixed (short* actP = actual)
+            {
+                dct.vp8_short_walsh4x4_c(inP, expP, pitch: 8);
+                WalshEncoderSimd.Walsh4x4(inP, actP, pitch: 8);
+            }
+
+            for (int i = 0; i < 16; i++) Assert.Equal(expected[i], actual[i]);
+        }
+
+        [Fact]
+        public void Walsh4x4_Fuzz_ManySeeds_MatchesScalar()
+        {
+            for (int seed = 0; seed < 64; seed++)
+            {
+                var rng = new Random(seed * 31 + 17);
+
+                short[] input = new short[16];
+                for (int i = 0; i < 16; i++)
+                {
+                    // Walsh forward sees DC coefficients of 4x4 residual blocks; range
+                    // typically [-512, 512] after the 16x16-mode subtract+fdct pipeline,
+                    // but we test a wider range to catch overflow.
+                    input[i] = (short)rng.Next(-2048, 2049);
+                }
+
+                short[] expected = new short[16];
+                short[] actual = new short[16];
+
+                fixed (short* inP = input)
+                fixed (short* expP = expected)
+                fixed (short* actP = actual)
+                {
+                    dct.vp8_short_walsh4x4_c(inP, expP, pitch: 8);
+                    WalshEncoderSimd.Walsh4x4(inP, actP, pitch: 8);
+                }
+
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(expected[i] == actual[i],
+                        $"seed={seed} idx={i} expected={expected[i]} got={actual[i]} input[{i}]={input[i]}");
+                }
+            }
+        }
+
+        [Fact]
+        public void Walsh4x4_StridedInput_MatchesScalar()
+        {
+            // Walsh is sometimes called with non-contiguous inputs (`pitch != 8`)
+            // when the source coefficients live in a strided 16-coeff layout.
+            // Validate both paths handle pitch=16 (8 shorts).
+            for (int seed = 0; seed < 16; seed++)
+            {
+                var rng = new Random(seed * 7);
+                short[] input = new short[32];
+                for (int i = 0; i < 32; i++) input[i] = (short)rng.Next(-1024, 1025);
+
+                short[] expected = new short[16];
+                short[] actual = new short[16];
+
+                fixed (short* inP = input)
+                fixed (short* expP = expected)
+                fixed (short* actP = actual)
+                {
+                    dct.vp8_short_walsh4x4_c(inP, expP, pitch: 16);
+                    WalshEncoderSimd.Walsh4x4(inP, actP, pitch: 16);
+                }
+
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(expected[i] == actual[i],
+                        $"seed={seed} idx={i} expected={expected[i]} got={actual[i]}");
+                }
+            }
+        }
+
+        // ----------------- Inverse Walsh -----------------
+
+        [Fact]
+        public void InverseWalsh4x4_ZeroInput_MatchesScalar()
+        {
+            short[] input = new short[16];
+            short[] expected = new short[16];
+            short[] actual = new short[16];
+
+            fixed (short* inP = input)
+            fixed (short* expP = expected)
+            fixed (short* actP = actual)
+            {
+                InverseWalshScalarReference(inP, expP);
+                WalshEncoderSimd.InverseWalsh4x4(inP, actP);
+            }
+
+            for (int i = 0; i < 16; i++) Assert.Equal(expected[i], actual[i]);
+        }
+
+        [Fact]
+        public void InverseWalsh4x4_Fuzz_ManySeeds_MatchesScalar()
+        {
+            for (int seed = 0; seed < 64; seed++)
+            {
+                var rng = new Random(seed * 41 + 9);
+
+                short[] input = new short[16];
+                for (int i = 0; i < 16; i++) input[i] = (short)rng.Next(-2048, 2049);
+
+                short[] expected = new short[16];
+                short[] actual = new short[16];
+
+                fixed (short* inP = input)
+                fixed (short* expP = expected)
+                fixed (short* actP = actual)
+                {
+                    InverseWalshScalarReference(inP, expP);
+                    WalshEncoderSimd.InverseWalsh4x4(inP, actP);
+                }
+
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.True(expected[i] == actual[i],
+                        $"seed={seed} idx={i} expected={expected[i]} got={actual[i]} input[{i}]={input[i]}");
+                }
+            }
+        }
+
+        [Fact]
+        public void Walsh_Then_InverseWalsh_RoundTripsApproximately()
+        {
+            // The walsh+inv-walsh pair is dimensionally a 1/8-energy roundtrip due
+            // to the *4 scale and >>3. So input * 4 = output after roundtrip (with
+            // some rounding loss when nonzero). This test checks that the SIMD
+            // path's roundtrip is identical to the scalar pair's roundtrip.
+            for (int seed = 0; seed < 16; seed++)
+            {
+                var rng = new Random(seed);
+
+                short[] input = new short[16];
+                for (int i = 0; i < 16; i++) input[i] = (short)rng.Next(-128, 129);
+
+                short[] fwdScalar = new short[16];
+                short[] fwdSimd = new short[16];
+                short[] roundScalar = new short[16];
+                short[] roundSimd = new short[16];
+
+                fixed (short* inP = input)
+                fixed (short* fS = fwdScalar)
+                fixed (short* fM = fwdSimd)
+                fixed (short* rS = roundScalar)
+                fixed (short* rM = roundSimd)
+                {
+                    dct.vp8_short_walsh4x4_c(inP, fS, pitch: 8);
+                    WalshEncoderSimd.Walsh4x4(inP, fM, pitch: 8);
+
+                    InverseWalshScalarReference(fS, rS);
+                    WalshEncoderSimd.InverseWalsh4x4(fM, rM);
+                }
+
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.Equal(fwdScalar[i], fwdSimd[i]);
+                    Assert.Equal(roundScalar[i], roundSimd[i]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves end-to-end **VP8 encode throughput** in `SIPSorcery.VP8` while keeping **bit-exact parity** on the default single-partition (`log2 = 0`) path and adding **decoder round-trip** coverage for optional multi-partition streams.

### What "Legacy", "Optimized", and "four-part" mean here

- **Legacy** — The **scalar** encode pipeline (`LegacyVp8FrameEncodePipeline`): same stages as always, **no** SIMD/intrinsic fast paths (`IEncoderMemoryOps.UseSimdEncoderKernels` off for this pipeline). Useful as the reference for parity tests and apples-to-apples regressions.

- **Optimized** — The **SIMD-capable** pipeline (`OptimizedVp8FrameEncodePipeline` via `Vp8FrameEncodePipelineFactory`): FDCT / Walsh / quantize / IDCT and related helpers can use **x64 SSE2/SSE4.1** or **ARM64 AdvSimd** where implemented. This is the main throughput path; it still uses **one** token partition (`log2 = 0`) unless you configure multi-partition (below).

- **Four-part (multi-partition tokens)** — Not "4×4" in the **transform-block** sense (VP8 still uses 4×4 residuals everywhere). Here it means **four parallel VP8 token bitstreams** (`log2NumTokenPartitions = 2`, i.e. 2^2 = 4 partitions), with per-partition packing and a stitched output. Benchmarks label this **`Keyframe_Optimized_4Part`** / **`Inter_Optimized_4Part`**. Only the **Optimized** factory path is set up this way in the benches; **Legacy** stays single-partition for comparison.

### Key changes

- **Encode pipeline kinds (`Legacy` vs `Optimized`)**  
  SIMD/intrinsic work runs only on the **Optimized** pipeline (`Vp8FrameEncodePipelineFactory`, `IEncoderMemoryOps.UseSimdEncoderKernels`). The **Legacy** path remains **scalar** for apples-to-apples comparison and regression safety.

- **SIMD kernels (x64 SSE2/SSE4.1, ARM64 AdvSimd)**  
  Optional paths for FDCT / Walsh / quantize / IDCT and related residual helpers (`*EncoderSimd.cs`, `EncoderMemoryOps`, `mb_encoder` dispatch). Scalar implementations stay the reference in `dct` / `quantize` where applicable.

- **PackTokens hot path**  
  `vp8_pack_tokens` (Span path) hoists `BOOL_CODER` state and inlines the bool coder loop to cut per-token overhead (`bitstream.cs`).

- **Pooled bitstream output**  
  `ArraySegment<byte>` / "Pooled" API returns a slice over `FrameEncoderBuffers.OutBuf` instead of allocating + copying every frame; `byte[]` entry points remain as copy-out wrappers.

- **Multi–token-partition encoding** (`log2` 0..3)  
  Parallel per-partition pack (partition = MB row `r & (N-1)`), stitch of the `(N-1)*3` size table and partition bytes, header `log2_nbr_of_dct_partitions` wired in `bitstream` validation. **`OutBuf` is pinned** for the whole encode so `BOOL_CODER`'s raw pointers stay valid under GC pressure.

- **Correctness / perf hygiene**  
  `tokenize`: per-thread last coef-row cache for `ConditionalWeakTable` fast path (avoids cross-thread wrong-row races); shared `ValidateLog2TokenPartitions`; reused `PartitionLengthsScratch` for multi-partition lengths.

- **Diagnostics & CI**  
  Optional `EncodeProfiler` phase buckets (**thread-local** enable flag so parallel xUnit does not flip profiling for other tests); **BenchmarkDotNet** project for pipeline/micro benches; optional **GitHub Actions** workflow for VP8 (`vp8-encoder-ci.yml`).

Scope is roughly **~6k** line churn (one squashed commit on the branch for ease of push); content naturally groups into **SIMD/pipeline**, **pack**, **pooling**, **multi-partition**, **profiler/benchmarks/CI**, **test/review fixes**.

## Performance (local BenchmarkDotNet)

**Host:** macOS Tahoe 26.3, **Apple M1 Max** (10 cores), **.NET SDK 10.0.103**, runtime **.NET 10.0.3**, Arm64 RyuJIT (**AdvSimd** available).

**Project:** `test/SIPSorcery.VP8.Benchmarks`, filter `EncodePipelineBenchmarks`, **DefaultJob** (warm, out-of-process child).

### Keyframes (random I420, q=32; one full encode per iteration)

| Method | Resolution | Mean | Note |
|:---|:---|---:|:---|
| `Keyframe_Legacy` | 640×480 | 27.91 ms | Scalar baseline |
| `Keyframe_Optimized` | 640×480 | 25.95 ms | ~7% faster than Legacy |
| `Keyframe_Legacy` | 1280×720 | 83.35 ms | |
| `Keyframe_Optimized` | 1280×720 | 78.16 ms | ~6% faster than Legacy |
| `Keyframe_Optimized_4Part` | 640×480 | 10.94 ms | Four token partitions; ~61% less time than Legacy @ 640×480 (~2.5×); higher alloc (~4.2 KB vs ~1.6 KB in BDN managed view) |
| `Keyframe_Optimized_4Part` | 1280×720 | 32.73 ms | |

### Inter (640×480; InvocationCount=1, ~5–8 ms/iter — directional only)

| Method | Mean |
|:---|---:|
| `Inter_Legacy` | 7.49 ms |
| `Inter_Optimized` | 5.86 ms |
| `Inter_Optimized_4Part` | 4.23 ms |

**How to read BenchmarkDotNet `Ratio`:** in this class the baseline is **`Keyframe_Legacy` @ 640×480**; ratios vs that row are **not** "Legacy vs Optimized at the same resolution" for 720p rows. Prefer the explicit ms table above for cross-resolution comparisons.

**Reproduce (Release):**

```
dotnet run -c Release --project test/SIPSorcery.VP8.Benchmarks -- --filter '*EncodePipelineBenchmarks*' -e github
```

## Testing

- **Unit tests**: existing VP8 unit tests updated/extended where touched; new coverage includes:
  - **Legacy vs Optimized parity** for contiguous I420 encode (`encode_pipeline_parity_unittest`).
  - **Multi-partition** keyframe + inter **decoder round-trips** and header sanity (`multi_partition_unittest`).
  - SIMD-focused tests for fdct/quantize/idct/walsh where added.
  - **Pack tokens** reference checks + **two-thread `GetCoefProbRowForPack` stress** (`pack_tokens_unittest`).
  - **Bool decoder**: `vp8dx_start_decode`-style helpers that held unpinned pointers were removed; tests pin buffers for decode spans.
- **Rationale**: pack/token paths dominate profile time; parity tests lock the default layout to the scalar/Legacy reference, while multi-partition tests assert **spec-correct streams** and decoder acceptance (layout differs from single-partition by design for `log2 > 0`).
- **Known environment caveats**: two tests require **GDI+** / Windows-oriented image APIs; CI excludes them on non-Windows-friendly hosts (`vp8-encoder-ci.yml` filter). Benchmarks are **Release** / **BenchmarkDotNet** and are meant for perf signal, not functional correctness.

## Splitting / stacking

Maintainers prefer a **smaller review**: I'm happy to **rework this into a stacked series**.

- **~5 PRs** (coarse): SIMD+pipeline → pack fast path → pooled output → multi-partition (+pinning) → profiler/benchmarks+CI
- **~20 PRs** (fine): e.g. SIMD split per kernel + infra, multi-partition split (plumbing / buffers / parallel pack / stitch / pin / tests), benchmarks split per bench + workflow — as outlined in review discussion.

If you want a stack, specify preferred **granularity** and **base branch naming**; I can branch and open dependent PRs from this same fork.
