### PR TITLE
fix webrtc sdp renegotiation

### DIFF
--- a/src/SIPSorcery/net/RTP/RTPSession.cs
+++ b/src/SIPSorcery/net/RTP/RTPSession.cs
@@ -1280,8 +1280,15 @@ namespace SIPSorcery.Net
                             remoteRtcpEP = rtpSessionConfig.IsRtcpMultiplexed ? remoteRtpEP : new IPEndPoint(remoteRtpEP.Address, remoteRtpEP.Port + 1);
                         }
 
-                        currentMediaStream.DestinationEndPoint = (remoteRtpEP != null && remoteRtpEP.Port != SDP.IGNORE_RTP_PORT_NUMBER) ? remoteRtpEP : currentMediaStream.DestinationEndPoint;
-                        currentMediaStream.ControlDestinationEndPoint = (remoteRtcpEP != null && remoteRtcpEP.Port != SDP.IGNORE_RTP_PORT_NUMBER) ? remoteRtcpEP : currentMediaStream.ControlDestinationEndPoint;
+                        // When ICE manages the transport (WebRTC/multiplexed), the ICE layer
+                        // sets DestinationEndPoint via SetGlobalDestination when the connection
+                        // is established. Don't overwrite it from SDP during renegotiation.
+                        // For non-ICE (SIP), the SDP address IS the destination.
+                        if (!rtpSessionConfig.IsMediaMultiplexed || currentMediaStream.DestinationEndPoint == null)
+                        {
+                            currentMediaStream.DestinationEndPoint = (remoteRtpEP != null && remoteRtpEP.Port != SDP.IGNORE_RTP_PORT_NUMBER) ? remoteRtpEP : currentMediaStream.DestinationEndPoint;
+                            currentMediaStream.ControlDestinationEndPoint = (remoteRtcpEP != null && remoteRtcpEP.Port != SDP.IGNORE_RTP_PORT_NUMBER) ? remoteRtcpEP : currentMediaStream.ControlDestinationEndPoint;
+                        }
 
                         logger.LogDebug("Setting remote {SdpMediaType} track with sdp destination {DestinationEndPoint} and control destination {ControlDestinationEndPoint}.", currentMediaStream.MediaType, currentMediaStream.DestinationEndPoint, currentMediaStream.ControlDestinationEndPoint);
                     }

--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -263,11 +263,14 @@ namespace SIPSorcery.Net
                 lock (_renegotiationLock)
                 {
                     _requireRenegotiation = value;
-                    //Remove Remote Description
-                    if (_requireRenegotiation)
-                    {
-                        RemoteDescription = null;
-                    }
+
+                    // RemoteDescription is intentionally preserved during renegotiation.
+                    // createBaseSdp() needs it to maintain the m-line order from the
+                    // previous offer/answer exchange (RFC 3264 §8).
+                    // if (_requireRenegotiation)
+                    // {
+                    //     RemoteDescription = null;
+                    // }
                 }
 
                 //Remove NegotiationTask when state not stable
@@ -1162,9 +1165,13 @@ namespace SIPSorcery.Net
             };
 
             // Media announcements must be in the same order in the offer and answer.
+            // Existing media types reuse their index from the previous answer; new types
+            // (not present in RemoteDescription) are appended after all existing m-lines
+            // per RFC 3264 §8.
             int mediaIndex = 0;
             int audioMediaIndex = 0;
             int videoMediaIndex = 0;
+            int nextNewMLineIndex = RemoteDescription?.Media.Count ?? 0;
             foreach (var mediaStream in mediaStreamList)
             {
                 int mindex = 0;
@@ -1192,9 +1199,14 @@ namespace SIPSorcery.Net
 
                 if (mindex == SDP.MEDIA_INDEX_NOT_PRESENT)
                 {
-                    logger.LogWarning("Media announcement for {Kind} omitted due to no reciprocal remote announcement.", mediaStream.LocalTrack.Kind);
+                    // New media type added after the initial offer/answer — append it
+                    // after all existing m-lines so the ordering of previously negotiated
+                    // m-lines is preserved (RFC 3264 §8).
+                    mindex = nextNewMLineIndex;
+                    midTag = nextNewMLineIndex.ToString();
+                    nextNewMLineIndex++;
                 }
-                else
+
                 {
                     SDPMediaAnnouncement announcement = new SDPMediaAnnouncement(
                      mediaStream.LocalTrack.Kind,

--- a/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
@@ -1,0 +1,313 @@
+//-----------------------------------------------------------------------------
+// Filename: RTCPeerConnectionRenegotiationUnitTest.cs
+//
+// Description: Unit tests for WebRTC SDP renegotiation — adding tracks after
+// the initial offer/answer exchange. Covers m-line ordering preservation
+// (RFC 3264 §8), new media type inclusion, and ICE endpoint stability.
+//
+// History:
+// 08 May 2026  Contributors    Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using SIPSorceryMedia.Abstractions;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class RTCPeerConnectionRenegotiationUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public RTCPeerConnectionRenegotiationUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// When a video-only offer/answer completes and an audio track is added
+        /// afterwards, the renegotiation offer must contain both m-lines with
+        /// video preserving its original index (mid:0) and audio appended (mid:1).
+        /// </summary>
+        [Fact]
+        public void RenegotiationOfferPreservesVideoMLineAndAppendsAudio()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            // --- Offerer: start with video only ---
+            RTCPeerConnection offerer = new RTCPeerConnection(null);
+            var videoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            offerer.addTrack(videoTrack);
+
+            // Initial offer — video only.
+            var initialOffer = offerer.createOffer(new RTCOfferOptions());
+            Assert.NotNull(initialOffer?.sdp);
+            var initialOfferSdp = SDP.ParseSDPDescription(initialOffer.sdp);
+            Assert.Single(initialOfferSdp.Media);
+            Assert.Equal(SDPMediaTypesEnum.video, initialOfferSdp.Media[0].Media);
+
+            logger.LogDebug("Initial offer SDP:\n{Sdp}", initialOffer.sdp);
+
+            // --- Answerer: accept video ---
+            RTCPeerConnection answerer = new RTCPeerConnection(null);
+            var answerVideoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            answerer.addTrack(answerVideoTrack);
+
+            var setResult = answerer.setRemoteDescription(initialOffer);
+            Assert.Equal(SetDescriptionResultEnum.OK, setResult);
+
+            var answer = answerer.createAnswer();
+            Assert.NotNull(answer?.sdp);
+
+            logger.LogDebug("Answer SDP:\n{Sdp}", answer.sdp);
+
+            // Offerer processes the answer.
+            setResult = offerer.setRemoteDescription(answer);
+            Assert.Equal(SetDescriptionResultEnum.OK, setResult);
+
+            // --- Add audio track after initial handshake ---
+            var audioTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.audio, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
+                });
+            offerer.addTrack(audioTrack);
+
+            // Renegotiation offer — must have both video and audio.
+            var renegOffer = offerer.createOffer(new RTCOfferOptions());
+            Assert.NotNull(renegOffer?.sdp);
+            var renegOfferSdp = SDP.ParseSDPDescription(renegOffer.sdp);
+
+            logger.LogDebug("Renegotiation offer SDP:\n{Sdp}", renegOffer.sdp);
+
+            Assert.Equal(2, renegOfferSdp.Media.Count);
+            Assert.Equal(SDPMediaTypesEnum.video, renegOfferSdp.Media[0].Media);
+            Assert.Equal(SDPMediaTypesEnum.audio, renegOfferSdp.Media[1].Media);
+            Assert.Equal("0", renegOfferSdp.Media[0].MediaID);
+            Assert.Equal("1", renegOfferSdp.Media[1].MediaID);
+
+            offerer.close();
+            answerer.close();
+
+            logger.LogDebug("-----------------------------------------");
+        }
+
+        /// <summary>
+        /// When an audio-only offer/answer completes and a video track is added
+        /// afterwards, the renegotiation offer must preserve audio at its original
+        /// index and append video.
+        /// </summary>
+        [Fact]
+        public void RenegotiationOfferPreservesAudioMLineAndAppendsVideo()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            RTCPeerConnection offerer = new RTCPeerConnection(null);
+            var audioTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.audio, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
+                });
+            offerer.addTrack(audioTrack);
+
+            var initialOffer = offerer.createOffer(new RTCOfferOptions());
+            var initialOfferSdp = SDP.ParseSDPDescription(initialOffer.sdp);
+            Assert.Single(initialOfferSdp.Media);
+            Assert.Equal(SDPMediaTypesEnum.audio, initialOfferSdp.Media[0].Media);
+
+            // Answerer accepts audio.
+            RTCPeerConnection answerer = new RTCPeerConnection(null);
+            var answerAudioTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.audio, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
+                });
+            answerer.addTrack(answerAudioTrack);
+            answerer.setRemoteDescription(initialOffer);
+            var answer = answerer.createAnswer();
+            offerer.setRemoteDescription(answer);
+
+            // Add video after handshake.
+            var videoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            offerer.addTrack(videoTrack);
+
+            var renegOffer = offerer.createOffer(new RTCOfferOptions());
+            var renegOfferSdp = SDP.ParseSDPDescription(renegOffer.sdp);
+
+            logger.LogDebug("Renegotiation offer SDP:\n{Sdp}", renegOffer.sdp);
+
+            Assert.Equal(2, renegOfferSdp.Media.Count);
+            Assert.Equal(SDPMediaTypesEnum.audio, renegOfferSdp.Media[0].Media);
+            Assert.Equal(SDPMediaTypesEnum.video, renegOfferSdp.Media[1].Media);
+            Assert.Equal("0", renegOfferSdp.Media[0].MediaID);
+            Assert.Equal("1", renegOfferSdp.Media[1].MediaID);
+
+            offerer.close();
+            answerer.close();
+
+            logger.LogDebug("-----------------------------------------");
+        }
+
+        /// <summary>
+        /// The RemoteDescription must not be nulled when RequireRenegotiation is
+        /// set to true (e.g. by addTrack). createBaseSdp() needs it to look up
+        /// existing m-line indices.
+        /// </summary>
+        [Fact]
+        public void RemoteDescriptionPreservedAfterAddTrack()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            RTCPeerConnection offerer = new RTCPeerConnection(null);
+            var videoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            offerer.addTrack(videoTrack);
+
+            var offer = offerer.createOffer(new RTCOfferOptions());
+
+            RTCPeerConnection answerer = new RTCPeerConnection(null);
+            var answerTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            answerer.addTrack(answerTrack);
+            answerer.setRemoteDescription(offer);
+            var answer = answerer.createAnswer();
+
+            offerer.setRemoteDescription(answer);
+            Assert.NotNull(offerer.RemoteDescription);
+
+            // Adding a new track should NOT clear RemoteDescription.
+            var audioTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.audio, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
+                });
+            offerer.addTrack(audioTrack);
+
+            Assert.NotNull(offerer.RemoteDescription);
+
+            offerer.close();
+            answerer.close();
+
+            logger.LogDebug("-----------------------------------------");
+        }
+
+        /// <summary>
+        /// In multiplexed (WebRTC/BUNDLE) mode, SetRemoteDescription must not
+        /// overwrite a stream's DestinationEndPoint once ICE has established it.
+        /// The existing IGNORE_RTP_PORT_NUMBER guard only protects port-9 m-lines;
+        /// the first m-line in a browser answer typically carries the real ICE
+        /// candidate port which would otherwise overwrite the ICE endpoint.
+        /// </summary>
+        [Fact]
+        public void MultiplexedDestinationEndPointPreservedOnRenegotiation()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            // Multiplexed + secure = WebRTC mode.
+            RTPSession rtpSession = new RTPSession(new RtpSessionConfig
+            {
+                IsMediaMultiplexed = true,
+                IsRtcpMultiplexed = true,
+            });
+
+            var videoTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.video, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
+                });
+            rtpSession.addTrack(videoTrack);
+
+            // Simulate initial offer/answer — set a remote description with a real port.
+            string initialAnswerSdp =
+@"v=0
+o=- 1000 0 IN IP4 127.0.0.1
+s=-
+c=IN IP4 192.168.1.100
+t=0 0
+m=video 50000 RTP/AVP 96
+a=rtpmap:96 VP8/90000
+a=recvonly";
+            var initialAnswer = SDP.ParseSDPDescription(initialAnswerSdp);
+            var result = rtpSession.SetRemoteDescription(SIP.App.SdpType.answer, initialAnswer);
+            Assert.Equal(SetDescriptionResultEnum.OK, result);
+
+            // Simulate ICE setting the real endpoint (as SetGlobalDestination does).
+            var iceEndPoint = new System.Net.IPEndPoint(
+                System.Net.IPAddress.Parse("10.0.0.1"), 12345);
+            rtpSession.VideoStream.SetDestination(iceEndPoint, iceEndPoint);
+            Assert.Equal(iceEndPoint, rtpSession.VideoStream.DestinationEndPoint);
+
+            // Add audio track for renegotiation.
+            var audioTrack = new MediaStreamTrack(
+                SDPMediaTypesEnum.audio, false,
+                new List<SDPAudioVideoMediaFormat>
+                {
+                    new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
+                });
+            rtpSession.addTrack(audioTrack);
+
+            // Simulate renegotiation answer — browser uses a real port for video
+            // (selected ICE candidate port) and port 9 for bundled audio.
+            string renegAnswerSdp =
+@"v=0
+o=- 1000 1 IN IP4 127.0.0.1
+s=-
+c=IN IP4 192.168.1.100
+t=0 0
+m=video 50000 RTP/AVP 96
+a=rtpmap:96 VP8/90000
+a=recvonly
+m=audio 9 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=recvonly";
+            var renegAnswer = SDP.ParseSDPDescription(renegAnswerSdp);
+            result = rtpSession.SetRemoteDescription(SIP.App.SdpType.answer, renegAnswer);
+            Assert.Equal(SetDescriptionResultEnum.OK, result);
+
+            // Video DestinationEndPoint must still be the ICE endpoint, not the SDP address.
+            Assert.Equal(iceEndPoint, rtpSession.VideoStream.DestinationEndPoint);
+
+            rtpSession.Close("normal");
+
+            logger.LogDebug("-----------------------------------------");
+        }
+    }
+}

--- a/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
@@ -34,6 +34,9 @@ namespace SIPSorcery.Net.UnitTests
         /// When a video-only offer/answer completes and an audio track is added
         /// afterwards, the renegotiation offer must contain both m-lines with
         /// video preserving its original index (mid:0) and audio appended (mid:1).
+        /// Without the fix, either audio is omitted entirely (MEDIA_INDEX_NOT_PRESENT
+        /// caused it to be dropped) or m-line order is wrong (RemoteDescription was
+        /// nulled, falling back to insertion-order indices).
         /// </summary>
         [Fact]
         public void RenegotiationOfferPreservesVideoMLineAndAppendsAudio()
@@ -41,7 +44,6 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            // --- Offerer: start with video only ---
             RTCPeerConnection offerer = new RTCPeerConnection(null);
             var videoTrack = new MediaStreamTrack(
                 SDPMediaTypesEnum.video, false,
@@ -60,49 +62,52 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug("Initial offer SDP:\n{Sdp}", initialOffer.sdp);
 
-            // --- Answerer: accept video ---
+            // Answerer accepts video.
             RTCPeerConnection answerer = new RTCPeerConnection(null);
-            var answerVideoTrack = new MediaStreamTrack(
+            answerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.video, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
-                });
-            answerer.addTrack(answerVideoTrack);
+                }));
 
             var setResult = answerer.setRemoteDescription(initialOffer);
             Assert.Equal(SetDescriptionResultEnum.OK, setResult);
-
             var answer = answerer.createAnswer();
             Assert.NotNull(answer?.sdp);
 
-            logger.LogDebug("Answer SDP:\n{Sdp}", answer.sdp);
-
-            // Offerer processes the answer.
+            // Offerer processes the answer — RemoteDescription is now set.
             setResult = offerer.setRemoteDescription(answer);
             Assert.Equal(SetDescriptionResultEnum.OK, setResult);
 
-            // --- Add audio track after initial handshake ---
-            var audioTrack = new MediaStreamTrack(
+            // Add audio track after initial handshake completes.
+            offerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.audio, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
-                });
-            offerer.addTrack(audioTrack);
+                }));
 
-            // Renegotiation offer — must have both video and audio.
+            // Renegotiation offer must have both m-lines in correct order.
             var renegOffer = offerer.createOffer(new RTCOfferOptions());
             Assert.NotNull(renegOffer?.sdp);
-            var renegOfferSdp = SDP.ParseSDPDescription(renegOffer.sdp);
+            var renegSdp = SDP.ParseSDPDescription(renegOffer.sdp);
 
             logger.LogDebug("Renegotiation offer SDP:\n{Sdp}", renegOffer.sdp);
 
-            Assert.Equal(2, renegOfferSdp.Media.Count);
-            Assert.Equal(SDPMediaTypesEnum.video, renegOfferSdp.Media[0].Media);
-            Assert.Equal(SDPMediaTypesEnum.audio, renegOfferSdp.Media[1].Media);
-            Assert.Equal("0", renegOfferSdp.Media[0].MediaID);
-            Assert.Equal("1", renegOfferSdp.Media[1].MediaID);
+            Assert.Equal(2, renegSdp.Media.Count);
+
+            // Video must keep its original position and mid.
+            Assert.Equal(SDPMediaTypesEnum.video, renegSdp.Media[0].Media);
+            Assert.Equal("0", renegSdp.Media[0].MediaID);
+            Assert.Contains(renegSdp.Media[0].MediaFormats.Values,
+                f => f.Name().ToUpper() == "VP8");
+
+            // Audio must be appended after video.
+            Assert.Equal(SDPMediaTypesEnum.audio, renegSdp.Media[1].Media);
+            Assert.Equal("1", renegSdp.Media[1].MediaID);
+            Assert.Contains(renegSdp.Media[1].MediaFormats.Values,
+                f => f.Name().ToUpper() == "PCMU");
 
             offerer.close();
             answerer.close();
@@ -111,9 +116,8 @@ namespace SIPSorcery.Net.UnitTests
         }
 
         /// <summary>
-        /// When an audio-only offer/answer completes and a video track is added
-        /// afterwards, the renegotiation offer must preserve audio at its original
-        /// index and append video.
+        /// Mirror of the above test with the media types reversed: audio-only
+        /// initial handshake, then video added via renegotiation.
         /// </summary>
         [Fact]
         public void RenegotiationOfferPreservesAudioMLineAndAppendsVideo()
@@ -122,51 +126,53 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
             RTCPeerConnection offerer = new RTCPeerConnection(null);
-            var audioTrack = new MediaStreamTrack(
+            offerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.audio, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
-                });
-            offerer.addTrack(audioTrack);
+                }));
 
             var initialOffer = offerer.createOffer(new RTCOfferOptions());
             var initialOfferSdp = SDP.ParseSDPDescription(initialOffer.sdp);
             Assert.Single(initialOfferSdp.Media);
             Assert.Equal(SDPMediaTypesEnum.audio, initialOfferSdp.Media[0].Media);
 
-            // Answerer accepts audio.
             RTCPeerConnection answerer = new RTCPeerConnection(null);
-            var answerAudioTrack = new MediaStreamTrack(
+            answerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.audio, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
-                });
-            answerer.addTrack(answerAudioTrack);
+                }));
             answerer.setRemoteDescription(initialOffer);
             var answer = answerer.createAnswer();
             offerer.setRemoteDescription(answer);
 
             // Add video after handshake.
-            var videoTrack = new MediaStreamTrack(
+            offerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.video, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
-                });
-            offerer.addTrack(videoTrack);
+                }));
 
             var renegOffer = offerer.createOffer(new RTCOfferOptions());
-            var renegOfferSdp = SDP.ParseSDPDescription(renegOffer.sdp);
+            var renegSdp = SDP.ParseSDPDescription(renegOffer.sdp);
 
             logger.LogDebug("Renegotiation offer SDP:\n{Sdp}", renegOffer.sdp);
 
-            Assert.Equal(2, renegOfferSdp.Media.Count);
-            Assert.Equal(SDPMediaTypesEnum.audio, renegOfferSdp.Media[0].Media);
-            Assert.Equal(SDPMediaTypesEnum.video, renegOfferSdp.Media[1].Media);
-            Assert.Equal("0", renegOfferSdp.Media[0].MediaID);
-            Assert.Equal("1", renegOfferSdp.Media[1].MediaID);
+            Assert.Equal(2, renegSdp.Media.Count);
+
+            Assert.Equal(SDPMediaTypesEnum.audio, renegSdp.Media[0].Media);
+            Assert.Equal("0", renegSdp.Media[0].MediaID);
+            Assert.Contains(renegSdp.Media[0].MediaFormats.Values,
+                f => f.Name().ToUpper() == "PCMU");
+
+            Assert.Equal(SDPMediaTypesEnum.video, renegSdp.Media[1].Media);
+            Assert.Equal("1", renegSdp.Media[1].MediaID);
+            Assert.Contains(renegSdp.Media[1].MediaFormats.Values,
+                f => f.Name().ToUpper() == "VP8");
 
             offerer.close();
             answerer.close();
@@ -175,9 +181,11 @@ namespace SIPSorcery.Net.UnitTests
         }
 
         /// <summary>
-        /// The RemoteDescription must not be nulled when RequireRenegotiation is
-        /// set to true (e.g. by addTrack). createBaseSdp() needs it to look up
-        /// existing m-line indices.
+        /// <summary>
+        /// RemoteDescription must survive addTrack so that createBaseSdp can
+        /// look up existing m-line indices during renegotiation. Without the fix,
+        /// RequireRenegotiation = true nulls RemoteDescription and the renegotiation
+        /// offer falls back to sequential indices (wrong order).
         /// </summary>
         [Fact]
         public void RemoteDescriptionPreservedAfterAddTrack()
@@ -186,40 +194,44 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
             RTCPeerConnection offerer = new RTCPeerConnection(null);
-            var videoTrack = new MediaStreamTrack(
+            offerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.video, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
-                });
-            offerer.addTrack(videoTrack);
+                }));
 
             var offer = offerer.createOffer(new RTCOfferOptions());
 
             RTCPeerConnection answerer = new RTCPeerConnection(null);
-            var answerTrack = new MediaStreamTrack(
+            answerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.video, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
-                });
-            answerer.addTrack(answerTrack);
+                }));
             answerer.setRemoteDescription(offer);
             var answer = answerer.createAnswer();
 
             offerer.setRemoteDescription(answer);
-            Assert.NotNull(offerer.RemoteDescription);
 
-            // Adding a new track should NOT clear RemoteDescription.
-            var audioTrack = new MediaStreamTrack(
+            // Capture the RemoteDescription content before addTrack.
+            var remoteDescBefore = offerer.RemoteDescription?.ToString();
+            Assert.NotNull(remoteDescBefore);
+            Assert.Contains("m=video", remoteDescBefore);
+
+            // addTrack triggers RequireRenegotiation = true.
+            offerer.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.audio, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
-                });
-            offerer.addTrack(audioTrack);
+                }));
 
+            // RemoteDescription must still be intact with the same content.
             Assert.NotNull(offerer.RemoteDescription);
+            var remoteDescAfter = offerer.RemoteDescription.ToString();
+            Assert.Equal(remoteDescBefore, remoteDescAfter);
 
             offerer.close();
             answerer.close();
@@ -227,12 +239,13 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("-----------------------------------------");
         }
 
-        /// <summary>
         /// In multiplexed (WebRTC/BUNDLE) mode, SetRemoteDescription must not
         /// overwrite a stream's DestinationEndPoint once ICE has established it.
         /// The existing IGNORE_RTP_PORT_NUMBER guard only protects port-9 m-lines;
         /// the first m-line in a browser answer typically carries the real ICE
         /// candidate port which would otherwise overwrite the ICE endpoint.
+        /// Without the fix, video RTP is sent to the SDP address instead of the
+        /// ICE-negotiated endpoint, breaking media delivery.
         /// </summary>
         [Fact]
         public void MultiplexedDestinationEndPointPreservedOnRenegotiation()
@@ -240,22 +253,20 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            // Multiplexed + secure = WebRTC mode.
             RTPSession rtpSession = new RTPSession(new RtpSessionConfig
             {
                 IsMediaMultiplexed = true,
                 IsRtcpMultiplexed = true,
             });
 
-            var videoTrack = new MediaStreamTrack(
+            rtpSession.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.video, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000)
-                });
-            rtpSession.addTrack(videoTrack);
+                }));
 
-            // Simulate initial offer/answer — set a remote description with a real port.
+            // Initial answer with a real port (as browsers send for the first m-line).
             string initialAnswerSdp =
 @"v=0
 o=- 1000 0 IN IP4 127.0.0.1
@@ -265,27 +276,26 @@ t=0 0
 m=video 50000 RTP/AVP 96
 a=rtpmap:96 VP8/90000
 a=recvonly";
-            var initialAnswer = SDP.ParseSDPDescription(initialAnswerSdp);
-            var result = rtpSession.SetRemoteDescription(SIP.App.SdpType.answer, initialAnswer);
+            var result = rtpSession.SetRemoteDescription(
+                SIP.App.SdpType.answer, SDP.ParseSDPDescription(initialAnswerSdp));
             Assert.Equal(SetDescriptionResultEnum.OK, result);
 
-            // Simulate ICE setting the real endpoint (as SetGlobalDestination does).
+            // Simulate ICE establishing the real endpoint.
             var iceEndPoint = new System.Net.IPEndPoint(
                 System.Net.IPAddress.Parse("10.0.0.1"), 12345);
             rtpSession.VideoStream.SetDestination(iceEndPoint, iceEndPoint);
             Assert.Equal(iceEndPoint, rtpSession.VideoStream.DestinationEndPoint);
 
-            // Add audio track for renegotiation.
-            var audioTrack = new MediaStreamTrack(
+            // Add audio for renegotiation.
+            rtpSession.addTrack(new MediaStreamTrack(
                 SDPMediaTypesEnum.audio, false,
                 new List<SDPAudioVideoMediaFormat>
                 {
                     new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU)
-                });
-            rtpSession.addTrack(audioTrack);
+                }));
 
-            // Simulate renegotiation answer — browser uses a real port for video
-            // (selected ICE candidate port) and port 9 for bundled audio.
+            // Renegotiation answer — browser uses real port for video, port 9 for
+            // bundled audio (standard Chrome behavior).
             string renegAnswerSdp =
 @"v=0
 o=- 1000 1 IN IP4 127.0.0.1
@@ -298,11 +308,11 @@ a=recvonly
 m=audio 9 RTP/AVP 0
 a=rtpmap:0 PCMU/8000
 a=recvonly";
-            var renegAnswer = SDP.ParseSDPDescription(renegAnswerSdp);
-            result = rtpSession.SetRemoteDescription(SIP.App.SdpType.answer, renegAnswer);
+            result = rtpSession.SetRemoteDescription(
+                SIP.App.SdpType.answer, SDP.ParseSDPDescription(renegAnswerSdp));
             Assert.Equal(SetDescriptionResultEnum.OK, result);
 
-            // Video DestinationEndPoint must still be the ICE endpoint, not the SDP address.
+            // Video DestinationEndPoint must still be the ICE endpoint.
             Assert.Equal(iceEndPoint, rtpSession.VideoStream.DestinationEndPoint);
 
             rtpSession.Close("normal");


### PR DESCRIPTION
Unfortunately #1551 did not fix the renegotiation issues I was facing in #1476. I've tested end to end and found 3 separate issues preventing WebRTC renegotiation from working when adding tracks after the initial offer/answer. The changes made in this PR I was able to confirm that adding audio or video first, then forcing a delay and adding the other maintains proper ordering.

**1. `RemoteDescription` nulled on renegotiation**

The `RequireRenegotiation` setter clears `RemoteDescription`, so `createBaseSdp()` loses the previous m-line layout and falls back to sequential indices via `MediaInsertionOrder`. However, `RTCPeerConnection`'s constructor pre-creates a primary audio stream (`addSingleTrack(videoAsPrimary: false)`), which grabs `InsertionOrder=1` before any user tracks are added. When video is added first via `addTrack`, it gets `InsertionOrder=2`, and audio added later reuses the constructor's stream at `InsertionOrder=1` — producing audio before video in the renegotiation offer, violating RFC 3264 §8.

**2. New media types omitted from renegotiation offers**

`GetIndexForMediaType()` returns `MEDIA_INDEX_NOT_PRESENT` for tracks not in the previous answer, and `createBaseSdp()` drops them entirely. Tracks added after the initial handshake can never appear in a renegotiation offer.

**3. ICE `DestinationEndPoint` overwritten during renegotiation**

`SetRemoteDescription` unconditionally sets `DestinationEndPoint` from the SDP connection address. In WebRTC with BUNDLE, the browser's answer carries the selected ICE candidate port on the first m-line (not port 9), so the overwrite replaces the ICE-negotiated endpoint. Video stops flowing; audio survives because bundled m-lines use port 9 (`IGNORE_RTP_PORT_NUMBER`) which skips the overwrite.

---

### Observed behavior

**Before fix** (video-first, audio added later via `addTrack`):

```
Initial offer:   m=video mid:0                        ✓
Renegotiation:   m=audio mid:0, m=video mid:1         ✗ wrong order
Browser error:   "The order of m-lines in subsequent offer doesn't
                  match order from previous offer/answer"
```

When `RemoteDescription` was preserved but new types still omitted:

```
Renegotiation:   m=video mid:0                         ✗ audio missing
```

When both were fixed, video froze on renegotiation because `DestinationEndPoint` was overwritten with the SDP address instead of the ICE endpoint.

**After fix:**

```
Initial offer:   m=video mid:0
Renegotiation:   m=video mid:0, m=audio mid:1          ✓
Video + audio both flow without interruption.
```
