### PR TITLE
Fix thread leak in RTCSctpTransport.cs

### DIFF
--- a/src/SIPSorcery/net/SCTP/SctpAssociation.cs
+++ b/src/SIPSorcery/net/SCTP/SctpAssociation.cs
@@ -396,6 +396,7 @@ namespace SIPSorcery.Net
                             string abortReason = (chunk as SctpAbortChunk).GetAbortReason();
                             logger.LogWarning("SCTP packet ABORT chunk received from remote party, reason {AbortReason}.", abortReason);
                             _wasAborted = true;
+                            _dataSender?.Close();
                             OnAbortReceived?.Invoke(abortReason);
                             break;
 
@@ -537,6 +538,7 @@ namespace SIPSorcery.Net
 
                         case var ct when ct == SctpChunkType.SHUTDOWN && State == SctpAssociationState.Established:
                             // TODO: Check outstanding data chunks.
+                            _dataSender?.Close();
                             var shutdownAck = new SctpChunk(SctpChunkType.SHUTDOWN_ACK);
                             SendChunk(shutdownAck);
                             SetState(SctpAssociationState.ShutdownAckSent);

--- a/src/SIPSorcery/net/WebRTC/RTCSctpTransport.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCSctpTransport.cs
@@ -199,6 +199,12 @@ namespace SIPSorcery.Net
                     {
                         RTCSctpAssociation?.Shutdown();
                     }
+                    else
+                    {
+                        // If not connected (e.g. still in Connecting state), Shutdown() won't be called
+                        // which means the data sender thread won't be stopped. Abort ensures cleanup.
+                        RTCSctpAssociation?.Abort(new SctpErrorUserInitiatedAbort { AbortReason = "SCTP transport closing." });
+                    }
                     _isClosed = true;
                 }
             }


### PR DESCRIPTION
If connection is aborted datasenders aren't always disposed - thread leak fix