### PR TITLE
fix: guard NetServices NetworkChange subscription against platform throw (#1614)

### DIFF
--- a/src/SIPSorcery/sys/Net/NetServices.cs
+++ b/src/SIPSorcery/sys/Net/NetServices.cs
@@ -103,14 +103,31 @@ namespace SIPSorcery.Sys
 
         static NetServices()
         {
-            NetworkChange.NetworkAddressChanged += (_, _) =>
+            try
             {
-                // Clear cached addresses if the state of the local network interfaces change.
-                m_localAddressTable.Clear();
-                _localIPAddresses = null;
-                _internetDefaultAddress = null;
-                _internetDefaultIPv6Address = null;
-            };
+                NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                // Some runtimes (notably Unity's Windows-shipped Mono, see
+                // issue #1614) implement the NetworkChange type but throw
+                // when anything subscribes. Without this guard the static
+                // ctor — and therefore the first RTCPeerConnection() — fails
+                // with TypeInitializationException. The behavioural cost is
+                // that m_localAddressTable will not be invalidated when
+                // adapters come and go on those runtimes; entries stay
+                // cached for the process lifetime.
+                logger.LogWarning(ex, "NetworkChange.NetworkAddressChanged is not supported on this runtime; the local-address cache will not auto-invalidate on adapter changes.");
+            }
+        }
+
+        private static void OnNetworkAddressChanged(object sender, EventArgs e)
+        {
+            // Clear cached addresses if the state of the local network interfaces change.
+            m_localAddressTable.Clear();
+            _localIPAddresses = null;
+            _internetDefaultAddress = null;
+            _internetDefaultIPv6Address = null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes [#1614](https://github.com/sipsorcery-org/sipsorcery/issues/1614). The `SIPSorcery.Sys.NetServices` static constructor subscribes to `NetworkInformation.NetworkChange.NetworkAddressChanged` unconditionally. Some runtimes — notably **Unity's Windows-shipped Mono** — *implement* the type but **throw `PlatformNotSupportedException` from the add accessor**, which causes the type initializer to fail. The first `new RTCPeerConnection()` then throws `TypeInitializationException` and SIPSorcery is unusable in Unity Editor on Windows.

There's no API to probe support ahead of time (the .NET docs only annotate `illumos`/`solaris` as `[UnsupportedOSPlatform]`; Unity's Mono lies about being Windows). So this wraps the single subscription in a **narrow** `try/catch (PlatformNotSupportedException)` and extracts the handler to a named method. On runtimes that throw, we log a warning at the subscription point and proceed.

**Behavioural cost on affected runtimes:** `m_localAddressTable` won't be invalidated when adapters come and go, so cached local addresses stay stale until process restart. That's acceptable for a long-running media app and is far better than an unconstructable peer connection. The failure mode is observable (logged) rather than silent.

## Verification

- Built `src/SIPSorcery/SIPSorcery.csproj` for `netstandard2.1` — clean.
- Re-ran the Unity smoke-test harness locally (Unity 6000.4.7f1 Editor on Windows). The test that previously reproduced the bug — `CanConstructRtcPeerConnectionOnUnityRuntime` — now **passes**:

  ```
  testcasecount=1 passed=1 failed=0  result=Passed
  Test run completed. Exiting with code 0 (Ok). Run completed.
  ```

- The `smoke-test-windows` CI job (added in #1617) should flip green on this PR; the `smoke-test` Linux job stays green (it was unaffected by the bug since Linux Mono implements `NetworkChange` correctly).

## Test plan

- [x] `dotnet build src/SIPSorcery/SIPSorcery.csproj -c Release -f netstandard2.1`
- [x] Unity 6000.4.7f1 PlayMode smoke test passes locally on Windows
- [ ] CI: `unity-smoke-test / smoke-test (Linux)` stays green
- [ ] CI: `unity-smoke-test / smoke-test-windows` flips from red → green
- [ ] CI: existing core test suites stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)