### PR TITLE
Test logging refactoring

### DIFF
--- a/test/SIPSorcery.VP8.TestVectors/SIPSorcery.VP8.TestVectors.csproj
+++ b/test/SIPSorcery.VP8.TestVectors/SIPSorcery.VP8.TestVectors.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -17,9 +18,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SIPSorcery.VP8.TestVectors/TestLogger.cs
+++ b/test/SIPSorcery.VP8.TestVectors/TestLogger.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: TestLogger.cs
 //
 // Description: Helper class for test logging.
@@ -14,8 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
-using Serilog;
-using Serilog.Extensions.Logging;
+using MartinCostello.Logging.XUnit;
 
 namespace Vpx.Net.TestVectors
 {
@@ -23,14 +22,16 @@ namespace Vpx.Net.TestVectors
     {
         public static ILoggerFactory GetLogger(Xunit.Abstractions.ITestOutputHelper output)
         {
-            string template = "{Timestamp:HH:mm:ss.ffff} [{Level}] {Scope} {Message}{NewLine}{Exception}";
-            var serilog = new LoggerConfiguration()
-                .MinimumLevel.Is(Serilog.Events.LogEventLevel.Debug)
-                .Enrich.WithProperty("ThreadId", System.Threading.Thread.CurrentThread.ManagedThreadId)
-                .WriteTo.TestOutput(output, outputTemplate: template)
-                .WriteTo.Console(outputTemplate: template)
-                .CreateLogger();
-            return new SerilogLoggerFactory(serilog);
+            var options = new XUnitLoggerOptions
+            {
+                Filter = (category, level) => level >= LogLevel.Debug
+            };
+            var loggerProvider = new XUnitLoggerProvider(output, options);
+
+            return LoggerFactory.Create(builder =>
+            {
+                builder.AddProvider(loggerProvider);
+            });
         }
     }
 }

--- a/test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj
+++ b/test/SIPSorcery.VP8.UnitTest/SIPSorcery.VP8.UnitTest.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -18,9 +19,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SIPSorcery.VP8.UnitTest/TestLogger.cs
+++ b/test/SIPSorcery.VP8.UnitTest/TestLogger.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
-using Serilog;
-using Serilog.Extensions.Logging;
+﻿using MartinCostello.Logging.XUnit;
+using Microsoft.Extensions.Logging;
 
 namespace Vpx.Net.UnitTest
 {
@@ -8,17 +7,16 @@ namespace Vpx.Net.UnitTest
     {
         public static ILoggerFactory GetLogger(Xunit.Abstractions.ITestOutputHelper output)
         {
-            string template = "{Timestamp:HH:mm:ss.ffff} [{Level}] {Scope} {Message}{NewLine}{Exception}";
-            //var loggerFactory = new Microsoft.Extensions.Logging.LoggerFactory();
-            var serilog = new LoggerConfiguration()
-                .MinimumLevel.Is(Serilog.Events.LogEventLevel.Debug)
-                .Enrich.WithProperty("ThreadId", System.Threading.Thread.CurrentThread.ManagedThreadId)
-                .WriteTo.TestOutput(output, outputTemplate: template)
-                .WriteTo.Console(outputTemplate: template)
-                .CreateLogger();
-            //SIPSorcery.LogFactory.Set(new SerilogLoggerFactory(serilog));
-            //return new SerilogLoggerProvider(serilog).CreateLogger("unit");
-            return new SerilogLoggerFactory(serilog);
+            var options = new XUnitLoggerOptions
+            {
+                Filter = (category, level) => level >= LogLevel.Debug
+            };
+            var loggerProvider = new XUnitLoggerProvider(output, options);
+
+            return LoggerFactory.Create(builder =>
+            {
+                builder.AddProvider(loggerProvider);
+            });
         }
     }
 }

--- a/test/SIPSorceryMedia.Abstractions.UnitTest/PixelConverterTest.cs
+++ b/test/SIPSorceryMedia.Abstractions.UnitTest/PixelConverterTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: PixelConverterTest.cs
 //
 // Description: Unit tests for the pixel conversion methods.
@@ -110,7 +110,7 @@ namespace SIPSorceryMedia.Abstractions.UnitTest
         public unsafe void ConvertKnownNV12ToBGRTest()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int width = 640;
             int height = 480;
@@ -285,7 +285,7 @@ namespace SIPSorceryMedia.Abstractions.UnitTest
         public unsafe void ConvertNV12ToI420Test()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int width = 640;
             int height = 480;
@@ -316,7 +316,7 @@ namespace SIPSorceryMedia.Abstractions.UnitTest
         public unsafe void ConvertI420ToNV12Test()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int width = 640;
             int height = 480;
@@ -347,7 +347,7 @@ namespace SIPSorceryMedia.Abstractions.UnitTest
         public void RoundtripNV12ToI420Test()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int width = 640;
             int height = 480;
@@ -372,7 +372,7 @@ namespace SIPSorceryMedia.Abstractions.UnitTest
         public void RoundtripI420ToNV12Test()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int width = 640;
             int height = 480;

--- a/test/SIPSorceryMedia.Abstractions.UnitTest/SIPSorceryMedia.Abstractions.UnitTest.csproj
+++ b/test/SIPSorceryMedia.Abstractions.UnitTest/SIPSorceryMedia.Abstractions.UnitTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -19,9 +19,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SIPSorceryMedia.Abstractions.UnitTest/TestHelper.cs
+++ b/test/SIPSorceryMedia.Abstractions.UnitTest/TestHelper.cs
@@ -1,0 +1,9 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace SIPSorceryMedia.Abstractions.UnitTest
+{
+    public static class TestHelper
+    {
+        public static string GetCurrentMethodName([CallerMemberName] string methodName = default) => methodName;
+    }
+}

--- a/test/SIPSorceryMedia.Abstractions.UnitTest/TestLogger.cs
+++ b/test/SIPSorceryMedia.Abstractions.UnitTest/TestLogger.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Serilog;
-using Serilog.Extensions.Logging;
+using MartinCostello.Logging.XUnit;
 
 namespace SIPSorceryMedia.Abstractions.UnitTest
 {
@@ -8,14 +7,16 @@ namespace SIPSorceryMedia.Abstractions.UnitTest
     {
         public static ILoggerFactory GetLogger(Xunit.Abstractions.ITestOutputHelper output)
         {
-            string template = "{Timestamp:HH:mm:ss.ffff} [{Level}] {Scope} {Message}{NewLine}{Exception}";
-            var serilog = new LoggerConfiguration()
-                .MinimumLevel.Is(Serilog.Events.LogEventLevel.Debug)
-                .Enrich.WithProperty("ThreadId", System.Threading.Thread.CurrentThread.ManagedThreadId)
-                .WriteTo.TestOutput(output, outputTemplate: template)
-                .WriteTo.Console(outputTemplate: template)
-                .CreateLogger();
-            return new SerilogLoggerFactory(serilog);
+            var options = new XUnitLoggerOptions
+            {
+                Filter = (category, level) => level >= LogLevel.Debug
+            };
+            var loggerProvider = new XUnitLoggerProvider(output, options);
+            
+            return LoggerFactory.Create(builder =>
+            {
+                builder.AddProvider(loggerProvider);
+            });
         }
     }
 }

--- a/test/integration/app/SIPUserAgentUnitTest.cs
+++ b/test/integration/app/SIPUserAgentUnitTest.cs
@@ -51,8 +51,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task BlindTransferUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             transport.AddSIPChannel(new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0)));
@@ -106,8 +106,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task BlindTransferCancelUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             transport.AddSIPChannel(new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0)));
@@ -165,8 +165,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task HangupUserAgentUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             MockSIPChannel mockChannel = new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0));
@@ -232,8 +232,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task IncomingCallNoSdpUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             transport.AddSIPChannel(new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0)));
@@ -272,8 +272,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task IncomingCallNoSdpWithACKUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             transport.AddSIPChannel(new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0)));
@@ -337,8 +337,8 @@ a=sendrecv" + m_CRLF + m_CRLF;
         [Fact]
         public async Task AnswerAudioOnlyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
@@ -378,8 +378,8 @@ a=sendrecv";
         [Fact]
         public async Task PlaceCallUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -422,8 +422,8 @@ a=sendrecv";
         [Fact]
         public async Task PlaceCallUsingSDPDescriptorWithEmptyContentUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -468,8 +468,8 @@ a=sendrecv";
         [Fact]
         public async Task PlaceCallUsingSDPDescriptorWithWrongContentFailsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -512,8 +512,8 @@ a=sendrecv";
         [Fact]
         public async Task PlaceCallUsingSDPDescriptorWithCustomContentUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -563,8 +563,8 @@ a=sendrecv";
         [Fact]
         public async Task PlaceCallUsingSDPDescriptorWithCustomMultiPartContentUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -632,8 +632,8 @@ Content-type: text/plain; charset=us-ascii
         [Fact]
         public async Task PlaceCallMismatchedCapabilitiesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -676,8 +676,8 @@ Content-type: text/plain; charset=us-ascii
         [Fact]
         public async Task HandleMissingAudioTrackOnAnswerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
@@ -723,8 +723,8 @@ a=sendrecv";
         [Fact]
         public async Task HandleInvalidSdpPortOnAnswerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
@@ -771,8 +771,8 @@ a=sendrecv";
         [Fact]
         public async Task CheckCanPlaceCallUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // This transport will act as the call receiver. It allows the test to provide a 
             // tailored response to an incoming call.
@@ -838,8 +838,8 @@ a=sendrecv";
         [Fact]
         public async Task HandleInvalidSdpPortOnPlaceCallUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // This transport will act as the call receiver. It allows the test to provide a 
             // tailored response to an incoming call.
@@ -914,8 +914,8 @@ a=sendrecv";
         [Fact]
         public async Task AttendedTransfereeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // User agents A and B can use the same transport as they don't auto-answer incoming calls.
             SIPTransport sipTransportCaller = new SIPTransport();
@@ -1000,8 +1000,8 @@ a=sendrecv";
         [Fact]
         public async Task CancelCallUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport aliceTransport = new SIPTransport();
             aliceTransport.AddSIPChannel(new SIPUDPChannel(IPAddress.Loopback, 0));
@@ -1037,8 +1037,8 @@ a=sendrecv";
         [Fact]
         public async Task HangupOutgoingCallUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);
@@ -1086,8 +1086,8 @@ a=sendrecv";
         [Fact]
         public async Task HangupIncomingCallUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport serverTransport = new SIPTransport();
             SIPUDPChannel udpChannel = new SIPUDPChannel(IPAddress.Loopback, 0);

--- a/test/integration/core/SIPDnsUnitTest.cs
+++ b/test/integration/core/SIPDnsUnitTest.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DnsClient;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.IntegrationTests
@@ -40,8 +41,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task ResolveHostFromServiceTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -58,8 +59,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task LookupLocalHostnameTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -84,8 +85,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         {
             try
             {
-                logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-                logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+                logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+                logger.BeginScope(TestHelper.GetCurrentMethodName());
 
                 //SIPDNSManager.UseNAPTRLookups = true;
 
@@ -117,8 +118,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task ResolveNoSRVFromCacheTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -148,8 +149,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task ResolveWithSRVFromCacheTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -175,8 +176,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task ResolveSIPServiceAsyncTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
             //var result = await SIPDNSManager.ResolveAsync(SIPURI.ParseSIPURIRelaxed("sip:reg.sip-trunk.telekom.de;transport=tcp"));
@@ -195,8 +196,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task ResolveHostFromSecureSIPURITest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -216,8 +217,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task ResolveNonExistentServiceTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
             var result = await SIPDns.ResolveAsync(SIPURI.ParseSIPURIRelaxed("sipsorceryx.com"), false, cts.Token);
@@ -231,8 +232,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task NonRespondingDNSServerTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var originalClient = SIPDns.LookupClient;
 
@@ -265,8 +266,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task LookupCNAMETest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             CancellationTokenSource cts = new CancellationTokenSource();
 

--- a/test/integration/core/SIPTransportIntegrationTest.cs
+++ b/test/integration/core/SIPTransportIntegrationTest.cs
@@ -27,6 +27,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.IntegrationTests
@@ -50,8 +51,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Trait("Category", "IPv6")]
         public async Task IPv6LoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (!Socket.OSSupportsIPv6)
             {
@@ -107,8 +108,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task IPv4LoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             ManualResetEventSlim serverReadyEvent = new ManualResetEventSlim(false);
             CancellationTokenSource cancelServer = new CancellationTokenSource();
@@ -158,8 +159,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Trait("Category", "IPv6")]
         public async Task IPv6TcpLoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (!Socket.OSSupportsIPv6)
             {
@@ -213,8 +214,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task IPv4TcpLoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             ManualResetEventSlim serverReadyEvent = new ManualResetEventSlim(false);
             CancellationTokenSource cancelServer = new CancellationTokenSource();
@@ -269,8 +270,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task IPv4TcpLoopbackConsecutiveSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // This test fails on WSL and Linux due to closed TCP sockets going into the TIME_WAIT state.
             // See comment in SIPTCPChannel.OnSIPStreamDisconnected for additional info.
@@ -332,8 +333,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Trait("Category", "IPv6")]
         public async Task IPv6TlsLoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (!Socket.OSSupportsIPv6)
             {
@@ -407,8 +408,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task IPv4TlsLoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -486,8 +487,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task TcpTrickleReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             TaskCompletionSource<bool> testComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -591,8 +592,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task WebSocketLoopbackSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var serverChannel = new SIPWebSocketChannel(IPAddress.Loopback, 9000);
             var clientChannel = new SIPClientWebSocketChannel();
@@ -636,8 +637,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         [Fact]
         public async Task WebSocketLoopbackLargeSendReceiveTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var serverChannel = new SIPWebSocketChannel(IPAddress.Loopback, 9001);
             var clientChannel = new SIPClientWebSocketChannel();
@@ -690,8 +691,8 @@ namespace SIPSorcery.SIP.IntegrationTests
         public async Task TlsDoesNotGetStuckOnIncompleteTcpConnection()
         {
             // Arrange
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             ManualResetEventSlim serverReadyEvent = new ManualResetEventSlim(false);
             CancellationTokenSource cancelServer = new CancellationTokenSource();

--- a/test/integration/net/DNS/DNSUnitTest.cs
+++ b/test/integration/net/DNS/DNSUnitTest.cs
@@ -21,6 +21,7 @@ using DnsClient;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.SIP;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.IntegrationTests
@@ -43,8 +44,8 @@ namespace SIPSorcery.Net.IntegrationTests
         //[Fact]
         public async Task LookupAnyRecordTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DNSResponse result = DNSManager.Lookup("dns.google", QType.ANY, 100, null, false, false);
             var result = await SIPDns.LookupClient.QueryAsync("dns.google", QueryType.ANY);
@@ -75,8 +76,8 @@ namespace SIPSorcery.Net.IntegrationTests
         //[Fact]
         public async Task LookupAnyRecordAsyncCacheTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //1.queue dns lookup for async resolution
             //DNSResponse result = DNSManager.Lookup("dns.google", QType.ANY, 1, null, false, true);
@@ -112,8 +113,8 @@ namespace SIPSorcery.Net.IntegrationTests
         //[Fact(Skip = "Need to investigate why this fails on Appveyor Windows CI.")]
         public async Task LookupARecordMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DNSResponse result = DNSManager.Lookup("www.sipsorcery.com", QType.A, 10, null, false, false);
             var result = await SIPDns.LookupClient.QueryAsync("www.sipsorcery.com", QueryType.A);
@@ -135,8 +136,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupAAAARecordMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DNSResponse result = DNSManager.Lookup("www.google.com", QType.AAAA, 10, null, false, false);
             var result = await SIPDns.LookupClient.QueryAsync("www.google.com", QueryType.AAAA);
@@ -171,8 +172,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupSrvRecordMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DNSResponse result = DNSManager.Lookup(SIPDNSConstants.SRV_SIP_UDP_QUERY_PREFIX + "sipsorcery.com", QType.SRV, 10, null, false, false);
             var result = await SIPDns.LookupClient.QueryAsync(SIPDNSConstants.SRV_SIP_UDP_QUERY_PREFIX + "sipsorcery.com", QueryType.SRV);
@@ -192,8 +193,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void LookupCurrentHostNameMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string localHostname = System.Net.Dns.GetHostName();
 

--- a/test/integration/net/DtlsSrtp/DtlsSrtpTransportUnitTest.cs
+++ b/test/integration/net/DtlsSrtp/DtlsSrtpTransportUnitTest.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 using SIPSorcery.Net.SharpSRTP.DTLSSRTP;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.IntegrationTests
@@ -37,8 +38,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void CreateClientInstanceUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var crypto = new BcTlsCrypto();
             (var tlsCert, var pvtKey) = DtlsUtils.CreateSelfSignedTlsCert(crypto);
@@ -53,8 +54,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void CreateServerInstanceUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             DtlsSrtpTransport dtlsTransport = new DtlsSrtpTransport(new DtlsSrtpServer(new BcTlsCrypto()));
 
@@ -68,8 +69,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task DoHandshakeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var dtlsClient = new DtlsSrtpClient(new BcTlsCrypto());
             var dtlsServer = new DtlsSrtpServer(new BcTlsCrypto());
@@ -126,8 +127,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task DoHandshakeClientTimeoutUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             DtlsSrtpTransport dtlsClientTransport = new DtlsSrtpTransport(new DtlsSrtpClient(new BcTlsCrypto()));
             dtlsClientTransport.TimeoutMilliseconds = 2000;
@@ -143,8 +144,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task DoHandshakeServerTimeoutUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             DtlsSrtpTransport dtlsServerTransport = new DtlsSrtpTransport(new DtlsSrtpServer(new BcTlsCrypto()));
             dtlsServerTransport.TimeoutMilliseconds = 2000;

--- a/test/integration/net/DtlsSrtp/DtlsUtilsUnitTest.cs
+++ b/test/integration/net/DtlsSrtp/DtlsUtilsUnitTest.cs
@@ -16,6 +16,7 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.IntegrationTests
@@ -41,8 +42,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void CreateSelfSignedCertifcateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             (var tlsCert, var pvtKey) = DtlsUtils.CreateSelfSignedTlsCert(crypto);
 
@@ -58,8 +59,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void GetCertifcateFingerprintUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             (var tlsCert, var pvtKey) = DtlsUtils.CreateSelfSignedTlsCert(crypto);
             Assert.NotNull(tlsCert);
@@ -81,8 +82,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void LoadSecretFromArchiveUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
 #if NETCOREAPP
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -110,8 +111,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void BouncyCertFromCoreFxCert()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
 #if NETCOREAPP
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/test/integration/net/ICE/RtpIceChannelIntegrationTest.cs
+++ b/test/integration/net/ICE/RtpIceChannelIntegrationTest.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -41,8 +42,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void CreateInstanceUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession rtpSession = new RTPSession(true, true, true);
 
@@ -61,8 +62,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void GetHostCandidatesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannel = new RtpIceChannel(null, RTCIceComponent.rtp, null);
 
@@ -86,8 +87,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void GetHostCandidatesForRTPBindUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localAddress = NetServices.InternetDefaultAddress;
             var rtpIceChannel = new RtpIceChannel(localAddress, RTCIceComponent.rtp, null);
@@ -113,8 +114,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void SortChecklistUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannel = new RtpIceChannel(null, RTCIceComponent.rtp, null);
             rtpIceChannel.StartGathering();
@@ -145,8 +146,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task ChecklistConstructionUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannel = new RtpIceChannel(null, RTCIceComponent.rtp, null);
             rtpIceChannel.StartGathering();
@@ -181,8 +182,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task ChecklistProcessingUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannel = new RtpIceChannel(null, RTCIceComponent.rtp, null);
             rtpIceChannel.StartGathering();
@@ -216,8 +217,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task ChecklistProcessingToFailStateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannel = new RtpIceChannel(null, RTCIceComponent.rtp, null);
             rtpIceChannel.StartGathering();
@@ -257,8 +258,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task CheckSuccessfulConnectionForHostCandidatesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannelA = new RtpIceChannel();
             rtpIceChannelA.IsController = true;
@@ -308,8 +309,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task CheckStunServerGetServerRefelxiveCandidateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             using (MockTurnServer mockStunServer = new MockTurnServer())
             {
@@ -354,8 +355,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task CheckTurnServerGetRelayCandidateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             using (MockTurnServer mockTurnServer = new MockTurnServer())
             {
@@ -401,8 +402,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void CheckSuccessfulConnectionForRelayCandidatesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             using (MockTurnServer mockTurnServer = new MockTurnServer())
             {
@@ -472,8 +473,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task CheckPeerReflexiveReplacedByHostCandidatesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpIceChannelA = new RtpIceChannel();
             rtpIceChannelA.IsController = true;
@@ -550,8 +551,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task CheckIPAddressOnlyStunServerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             using (MockTurnServer mockStunServer = new MockTurnServer())
             {
@@ -597,8 +598,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void AddMulitpleIceServersTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var iceServers = new List<RTCIceServer> 
             {

--- a/test/integration/net/RTP/RTPChannelIntegrationTest.cs
+++ b/test/integration/net/RTP/RTPChannelIntegrationTest.cs
@@ -23,6 +23,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -45,8 +46,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task MultipleRtpChannelLoopbackUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             const int PACKET_LENGTH = 100;
 

--- a/test/integration/net/STUN/STUNDnsUnitTest.cs
+++ b/test/integration/net/STUN/STUNDnsUnitTest.cs
@@ -18,6 +18,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.IntegrationTests
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupLocalhostTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("localhost", out var stunUri);
             var result = await STUNDns.Resolve(stunUri);
@@ -56,8 +57,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupLocalhostIPv6TestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("localhost", out var stunUri);
             var result = await STUNDns.Resolve(stunUri, true);
@@ -86,8 +87,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupPrivateNetworkHostTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string localHostname = Dns.GetHostName();
 
@@ -114,8 +115,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupPrivateNetworkHostIPv6TestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string localHostname = Dns.GetHostName();
 
@@ -156,8 +157,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupHostWithExplicitPortTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("stun.l.google.com:19302", out var stunUri);
             var result = await STUNDns.Resolve(stunUri);
@@ -173,8 +174,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupHostPreferIPv6TestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("www.google.com", out var stunUri);
             var result = await STUNDns.Resolve(stunUri, true);
@@ -194,8 +195,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupHostPreferIPv6FallbackTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("www.sipsorcery.com", out var stunUri);
             var result = await STUNDns.Resolve(stunUri, true);
@@ -212,8 +213,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupWithSRVTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("sipsorcery.com", out var stunUri);
             var result = await STUNDns.Resolve(stunUri);
@@ -229,8 +230,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupWithSRVTestPreferIPv6Method()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("sipsorcery.com", out var stunUri);
             var result = await STUNDns.Resolve(stunUri, true);
@@ -249,8 +250,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupNonExistentHostTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("idontexist", out var stunUri);
             var result = await STUNDns.Resolve(stunUri, true);
@@ -266,8 +267,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public async Task LookupNonExistentCanoncialHostTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNUri.TryParse("somehost.fsdfergerw.com", out var stunUri);
             var result = await STUNDns.Resolve(stunUri, true);

--- a/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
+++ b/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -43,8 +44,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void GenerateLocalOfferUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPeerConnection pc = new RTCPeerConnection(null);
             var offer = pc.createOffer(new RTCOfferOptions());
@@ -69,8 +70,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void GenerateLocalOfferWithAudioTrackUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPeerConnection pc = new RTCPeerConnection(null);
             var audioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) });
@@ -95,8 +96,8 @@ namespace SIPSorcery.Net.IntegrationTests
         [Fact]
         public void CheckAudioVideoMediaIdentifierTagsAreReusedForAnswerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // In this SDP, the audio media identifier's tag is "bar" and the video media identifier's tag is "foo"
             string remoteSdp =
@@ -229,8 +230,8 @@ a=ssrc:4165955869 label:video0";
         [Fact]
         public void CheckDataChannelMediaIdentifierTagsAreReusedForAnswerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // In this SDP, the datachannel1's media identifier's tag is "application1"
             string remoteSdp =
@@ -284,8 +285,8 @@ a=max-message-size:262144";
         [Fact]
         public void CheckDataChannelVideoAndAudioAreWellManagedInAnswerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // In this SDP, the datachannel1's media identifier's tag is "application1"
             string remoteSdp =
@@ -414,8 +415,8 @@ a=ssrc:1091343449 label:5b06be39-0752-497f-80f5-6cf3db665f14";
         [Fact]
         public void CheckMediaIdentifierTagOrderRemainsForAnswerUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // In this SDP, the audio media identifier's tag is "zzz" and the video media identifier's tag is "aaa".
             // Such tag are meant to ensure that we do not sort sdp's media tracks by alphabetical order.
@@ -548,8 +549,8 @@ a=ssrc:4165955869 label:video0";
         [Fact]
         public void SendVideoRtcpFeedbackReportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCConfiguration pcConfiguration = new RTCConfiguration
             {
@@ -587,8 +588,8 @@ a=ssrc:4165955869 label:video0";
         [Fact]
         public void CheckMediaFormatNegotiationUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // By default offers made by us always put audio first. Create a remote SDP offer 
             // with the video first.
@@ -668,8 +669,8 @@ a=rtpmap:100 VP8/90000";
         [Fact]
         public void CheckNoAudioNegotiationUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // By default offers made by us always put audio first. Create a remote SDP offer 
             // with the video first.
@@ -743,8 +744,8 @@ a=rtpmap:100 VP8/90000";
         [Fact]
         public void Check_Inactive_Audio_Negotiation_Test()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // By default offers made by us always put audio first. Create a remote SDP offer 
             // with the video first.
@@ -845,8 +846,8 @@ a=rtpmap:126 telephone-event/8000";
         [Fact]
         public async Task CheckPeerConnectionEstablishment()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var aliceConnected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var bobConnected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -904,8 +905,8 @@ a=rtpmap:126 telephone-event/8000";
         [Fact]
         public async Task CheckDataChannelEstablishment()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var aliceDataConnected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var bobDataOpened = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -955,8 +956,8 @@ a=rtpmap:126 telephone-event/8000";
         [Fact]
         public void CheckAnswerForGStreamerOfferUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Remote offer from GStreamer, see https://github.com/sipsorcery-org/sipsorcery/issues/596.
             string remoteSdp =
@@ -1024,8 +1025,8 @@ a=fingerprint:sha-256 AE:1C:59:19:00:7B:C2:1C:85:95:0C:6C:8C:14:E8:67:A4:7D:D0:A
         [Fact]
         public void AnswerShouldNotContainAbsSendTimeIfOfferDidNot()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string offerSdp =
                 @"v=0

--- a/test/integration/sys/net/NetServicesUnitTest.cs
+++ b/test/integration/sys/net/NetServicesUnitTest.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.IntegrationTests
@@ -43,8 +44,8 @@ namespace SIPSorcery.Sys.IntegrationTests
         [Trait("Category", "IPv6")]
         public void GetLocalForInternetIPv6AdressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (Socket.OSSupportsIPv6)
             {

--- a/test/unit/Initialise.cs
+++ b/test/unit/Initialise.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
@@ -132,6 +133,11 @@ namespace SIPSorcery.UnitTests
                 return Task.FromResult<SIPEndPoint>(null);
             }
         }
+    }
+
+    public static class TestHelper
+    {
+        public static string GetCurrentMethodName([CallerMemberName] string methodName = default) => methodName;
     }
 
     public class MockMediaSession : IMediaSession

--- a/test/unit/app/SIPUserAgents/SIPClientUserAgentUnitTest.cs
+++ b/test/unit/app/SIPUserAgents/SIPClientUserAgentUnitTest.cs
@@ -19,8 +19,8 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void CallWithAdjustedInviteHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             MockSIPChannel channel = new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0));

--- a/test/unit/app/SIPUserAgents/SIPRegistrationUserAgentUnitTest.cs
+++ b/test/unit/app/SIPUserAgents/SIPRegistrationUserAgentUnitTest.cs
@@ -19,8 +19,8 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void RegisterStartWithCustomHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             MockSIPChannel channel = new MockSIPChannel(new IPEndPoint(IPAddress.Any, 0));
@@ -48,8 +48,8 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void RegisterWithAdjustedRegisterHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             MockSIPChannel channel = new MockSIPChannel(new System.Net.IPEndPoint(IPAddress.Any, 0));

--- a/test/unit/app/SIPUserAgents/SIPUserAgentAttendedTransferUnitTest.cs
+++ b/test/unit/app/SIPUserAgents/SIPUserAgentAttendedTransferUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: SIPUserAgentAttendedTransferUnitTest.cs
 //
 // Description: Unit tests for SIPUserAgent attended transfer handling, verifying
@@ -182,7 +182,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public async Task NonMatchingAgentIgnoresReplacesInvite()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var channelEndPoint = new IPEndPoint(IPAddress.Loopback, 6060);
             var channel = new RecordingMockSIPChannel(channelEndPoint);
@@ -257,7 +257,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public async Task MatchingAgentProcessesReplacesInvite()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var channelEndPoint = new IPEndPoint(IPAddress.Loopback, 6061);
             var channel = new RecordingMockSIPChannel(channelEndPoint);

--- a/test/unit/app/SIPUserAgents/SIPUserAgentUnitTest.cs
+++ b/test/unit/app/SIPUserAgents/SIPUserAgentUnitTest.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
 using Xunit;
@@ -21,7 +21,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void CreateSIPUserAgentTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             MockSIPChannel channel = new MockSIPChannel(new IPEndPoint(IPAddress.Any, 0));
@@ -40,7 +40,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void CreateReferRequestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             // Create a REFER request to test its structure
             var referRequest = SIPRequest.GetRequest(
@@ -67,7 +67,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void ReferWithoutReferToHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             // Create a REFER request without a Refer-To header
             var referRequest = SIPRequest.GetRequest(
@@ -92,7 +92,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void ReferRequiresEstablishedDialogTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             SIPTransport transport = new SIPTransport();
             MockSIPChannel channel = new MockSIPChannel(new IPEndPoint(IPAddress.Any, 0));
@@ -121,7 +121,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void ReferAuthenticationResponseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             // Create a REFER request
             var referRequest = SIPRequest.GetRequest(
@@ -163,7 +163,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void ReferAcceptedResponseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             // Create a REFER request
             var referRequest = SIPRequest.GetRequest(
@@ -194,7 +194,7 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void ReferWithAuthenticationTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             // Create a REFER request
             var referRequest = SIPRequest.GetRequest(

--- a/test/unit/app/media/VideoTestPatternSourceUnitTest.cs
+++ b/test/unit/app/media/VideoTestPatternSourceUnitTest.cs
@@ -16,6 +16,7 @@
 using Microsoft.Extensions.Logging;
 using Xunit;
 using SIPSorcery.Media;
+using SIPSorcery.UnitTests;
 
 namespace SIPSorcery.SIP.App.UnitTests
 {
@@ -36,8 +37,8 @@ namespace SIPSorcery.SIP.App.UnitTests
         [Fact]
         public void CanInstantiateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             VideoTestPatternSource testPatternSource = new VideoTestPatternSource();
 

--- a/test/unit/core/SIP/Channels/SIPUDPChannelUnitTest.cs
+++ b/test/unit/core/SIP/Channels/SIPUDPChannelUnitTest.cs
@@ -15,6 +15,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -35,8 +36,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CreateChannelUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var udpChan = new SIPUDPChannel(IPAddress.Any, 0);
 
@@ -53,8 +54,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public async Task InterChannelCommsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var udpChan1 = new SIPUDPChannel(IPAddress.Any, 0);
             logger.LogDebug("Listening end point {ListeningSIPEndPoint}.", udpChan1.ListeningSIPEndPoint);
@@ -115,8 +116,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GetDefaultContactURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var udpChan = new SIPUDPChannel(IPAddress.Any, 0);
 

--- a/test/unit/core/SIP/SIPAuthorisationDigestUnitTest.cs
+++ b/test/unit/core/SIP/SIPAuthorisationDigestUnitTest.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using SIPSorcery.SIP.App;
+using SIPSorcery.UnitTests;
 
 namespace SIPSorcery.SIP.UnitTests
 {
@@ -47,8 +48,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownDigestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "asterisk", "aaronxten2", "password", "sip:303@bluesipd", "17190028", "INVITE");
 
@@ -66,8 +67,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownDigestTestObscureChars()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "sip.blueface.ie", "aaronnetgear", "!\"$%^&*()_-+=}[{]~#@':;?><,.", "sip:sip.blueface.ie:5060", "1430352056", "REGISTER");
 
@@ -84,8 +85,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownDigestTestObscureChars2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "sip.blueface.ie", "aaronxten", "_*!$%^()\"", "sip:sip.blueface.ie", "1263192143", "REGISTER");
 
@@ -102,8 +103,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownDigestTest2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "asterisk", "aaronxten2", "password", "sip:303@213.168.225.133", "4a4ad124", "INVITE");
 
@@ -120,8 +121,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownRegisterDigestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "asterisk", "aaron", "password", "sip:blueface", "1c8192c9", "REGISTER");
 
@@ -138,8 +139,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownRegisterDigestTest2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "asterisk", "aaron", "password", "sip:blueface", "1c3c7a97", "REGISTER");
 
@@ -156,8 +157,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseWWWAuthenticateDigestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, @"Digest realm=""aol.com"",nonce=""48e7541d4339e27ee7b520a4bf8a8e3c4fffcb90"",qop=""auth"",opaque=""004533235332435434ffac663e"",algorithm=MD5");
 
@@ -172,8 +173,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownWWWAuthenticateDigestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, @"Digest realm=""aol.com"",nonce=""48e757f3b95250379d63fe29f777984a93831b80"",qop=""auth"",opaque=""004533235332435434ffac663e"",algorithm=MD5");
             authRequest.SetCredentials("user@aim.com", "password", "sip:01135312222222@sip.aol.com;transport=udp", "INVITE");
@@ -193,8 +194,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AuthenticateHeaderToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, @"Digest realm=""aol.com"",nonce=""48e7541d4339e27ee7b520a4bf8a8e3c4fffcb90"",qop=""auth"",opaque=""004533235332435434ffac663e"",algorithm=MD5");
             authRequest.SetCredentials("user@aim.com", "password", "sip:01135312222222@sip.aol.com;transport=udp", "INVITE");
@@ -214,8 +215,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownQOPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, "Digest realm=\"jnctn.net\", nonce=\"4a597e1c0000a1636739088e9151ef2f319af257c8f585f1\", qop=\"auth\"");
             authRequest.SetCredentials("user", "password", "sip:user.onsip.com", "REGISTER");
@@ -235,8 +236,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownOpaqueTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, @"digest realm=""Syndeo Corporation"", nonce=""1265068315059e3bbf3052cf13ea5ca22fb71669a7"", opaque=""09c0f23f71f89ce53baab5664c09cbfa"", algorithm=MD5");
             authRequest.SetCredentials("user", "pass", "sip:sip.ribbit.com", "REGISTER");
@@ -254,8 +255,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GenerateDigestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthorisationDigest authRequest = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, @"digest realm=""sipsorcery.com"", nonce=""1265068315059e3bbf3052cf13ea5ca22fb71669a7"", opaque=""09c0f23f71f89ce53baab5664c09cbfa"", algorithm=MD5");
             authRequest.SetCredentials("username", "password", "sip:sipsorcery.com", "REGISTER");
@@ -273,8 +274,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownHA1Digest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var digest = HTTPDigest.DigestCalcHA1("user", "sipsorcery.cloud", "password");
 
@@ -291,8 +292,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownMD5AndSHA256DigestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             {
                 SIPAuthorisationDigest authDigest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.ProxyAuthorization, "asterisk", "aaronxten2", "password", 
@@ -330,8 +331,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void HttpDigestMD5TestVector()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var md5DigestReq = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate, 
 @"Digest
@@ -361,8 +362,8 @@ opaque=""FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""");
         [Fact]
         public void HttpDigestSHA256TestVector()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var digestReq = SIPAuthorisationDigest.ParseAuthorisationDigest(SIPAuthorisationHeadersEnum.WWWAuthenticate,
 @"Digest

--- a/test/unit/core/SIP/SIPContactHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPContactHeaderUnitTest.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -28,8 +29,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseContactHeaderDomainForUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:sip.domain.com@sip.domain.com>";
 
@@ -42,8 +43,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseBadAastraContactHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:10001@127.0.0.1:5060\n";
 
@@ -53,8 +54,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoAngleQuotesContactHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "sip:10001@127.0.0.1:5060";
 
@@ -69,8 +70,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseCiscoContactHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:user@127.0.0.1:5060;user=phone;transport=udp>;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-0006d74b0e72>\";+u.sip!model.ccm.cisco.com=\"7\"";
 
@@ -91,8 +92,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoLineBreakContactHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:10001@127.0.0.1:5060\nAllow: OPTIONS";
 
@@ -104,8 +105,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseContactWithParamHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:user@127.0.0.1:5060;ftag=1233>";
 
@@ -122,8 +123,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseExpiresContactHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:user@127.0.0.1:5060>; expires=60";
 
@@ -141,8 +142,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseZeroExpiresContactHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "<sip:user@127.0.0.1:5060>; expires=0";
 
@@ -160,8 +161,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MultipleContactsHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "\"Mr. Watson\" <sip:watson@worcester.bell-telephone.com>;q=0.7; expires=3600, \"Mr. Watson\" <sip:watson@bell-telephone.com> ;q=0.1";
 
@@ -180,8 +181,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MultipleContactsWithURIParamsHeaderUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testContactHeader = "\"Mr. Watson\" <sip:watson@worcester.bell-telephone.com;ftag=1232>;q=0.7; expires=3600, \"Mr. Watson\" <sip:watson@bell-telephone.com?nonsense=yes> ;q=0.1";
 
@@ -202,8 +203,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SimpleAreEqualUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPContactHeader contactHeader1 = new SIPContactHeader(null, SIPURI.ParseSIPURI("sip:user@127.0.0.1:5060"));
             SIPContactHeader contactHeader2 = new SIPContactHeader(null, SIPURI.ParseSIPURI("sip:user@127.0.0.1:5060"));
@@ -214,8 +215,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SimpleNotEqualUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPContactHeader contactHeader1 = new SIPContactHeader(null, SIPURI.ParseSIPURI("sip:user@127.0.0.1:5060"));
             SIPContactHeader contactHeader2 = new SIPContactHeader(null, SIPURI.ParseSIPURI("sip:user@127.0.0.2:5060"));
@@ -226,8 +227,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void WithParametersAreEqualUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPContactHeader contactHeader1 = new SIPContactHeader(SIPUserField.ParseSIPUserField("<sip:user@127.0.0.1:5060>;param1=value1"));
             SIPContactHeader contactHeader2 = new SIPContactHeader(SIPUserField.ParseSIPUserField("<sip:user@127.0.0.1:5060>;param1=value1"));
@@ -238,8 +239,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void WithExpiresParametersAreEqualUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPContactHeader contactHeader1 = new SIPContactHeader(SIPUserField.ParseSIPUserField("<sip:user@127.0.0.1:5060> ;expires=0; param1=value1"));
             SIPContactHeader contactHeader2 = new SIPContactHeader(SIPUserField.ParseSIPUserField("<sip:user@127.0.0.1:5060>;expires=50;param1=value1"));
@@ -250,8 +251,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void WithDifferentNamesAreEqualUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPContactHeader contactHeader1 = new SIPContactHeader(SIPUserField.ParseSIPUserField("\"Joe Bloggs\" <sip:user@127.0.0.1:5060> ;expires=0; param1=value1"));
             SIPContactHeader contactHeader2 = new SIPContactHeader(SIPUserField.ParseSIPUserField("\"Jane Doe\" <sip:user@127.0.0.1:5060>;expires=50;param1=value1"));

--- a/test/unit/core/SIP/SIPDialogueUnitTest.cs
+++ b/test/unit/core/SIP/SIPDialogueUnitTest.cs
@@ -38,8 +38,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public async Task CreateDialogueFromUasTxUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -96,8 +96,8 @@ dummy";
         [Fact]
         public async Task CheckRemoteSocketProxyReceivedUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -154,8 +154,8 @@ dummy";
         [Fact]
         public async Task CreateDialogueFromUacTxUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -214,8 +214,8 @@ dummy";
         [Fact]
         public async Task UacTxCheckRemoteSocketProxyReceivedUnitTestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 

--- a/test/unit/core/SIP/SIPEndPointTest.cs
+++ b/test/unit/core/SIP/SIPEndPointTest.cs
@@ -11,6 +11,7 @@
 
 using System.Net;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -28,8 +29,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AllFieldsParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "sips:10.0.0.100:5060;lr;transport=tcp;";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -46,8 +47,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void HostOnlyParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "10.0.0.100";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -62,8 +63,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void HostAndSchemeParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "sip:10.0.0.100";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -80,8 +81,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void HostAndPortParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "10.0.0.100:5065";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -96,8 +97,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void HostAndTransportParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "10.0.0.100;transport=tcp";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -114,8 +115,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SchemeHostPortParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "sips:10.0.0.100:5063";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -130,8 +131,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SchemeHostTransportParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "sip:10.0.0.100:5063;lr;tag=123;transport=tcp;tag2=abcd";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -146,8 +147,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void EqualityTestNoPostHostTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint sipEP1 = SIPEndPoint.ParseSIPEndPoint("10.0.0.100");
             SIPEndPoint sipEP2 = SIPEndPoint.ParseSIPEndPoint("10.0.0.100:5060");
@@ -158,8 +159,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void EqualityTestTLSHostTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint sipEP1 = SIPEndPoint.ParseSIPEndPoint("sips:10.0.0.100");
             SIPEndPoint sipEP2 = SIPEndPoint.ParseSIPEndPoint("10.0.0.100:5061;transport=tls");
@@ -170,8 +171,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void EqualityTestRouteTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint sipEP1 = SIPEndPoint.ParseSIPEndPoint("sip:10.0.0.100;lr");
             SIPEndPoint sipEP2 = new SIPEndPoint(SIPProtocolsEnum.udp, new IPEndPoint(IPAddress.Parse("10.0.0.100"), 5060));
@@ -184,8 +185,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6LoopbackToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint sipEndPoint = new SIPEndPoint(SIPProtocolsEnum.udp, new IPEndPoint(IPAddress.IPv6Loopback, 0));
 
@@ -200,8 +201,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6LoopbackAndSchemeParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "udp:[::1]";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -219,8 +220,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6LoopbackAndPortParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "tcp:[::1]:6060";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -239,8 +240,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6LoopbackWithScehemeParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "sip:[::1]:6060";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -259,8 +260,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void WebSocketLoopbackAndPortParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "ws:[::1]:6060";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -279,8 +280,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SecureWebSocketLoopbackAndPortParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "wss:[fe80::54a9:d238:b2ee:ceb]:7060";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -299,8 +300,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6WithConnectionIDParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "udp:[::1];xid=1234567";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);
@@ -319,8 +320,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6WithConnectionAndChannelIDParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipEndPointStr = "udp:[::1];cid=123;xid=1234567";
             SIPEndPoint sipEndPoint = SIPEndPoint.ParseSIPEndPoint(sipEndPointStr);

--- a/test/unit/core/SIP/SIPHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPHeaderUnitTest.cs
@@ -11,6 +11,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -30,8 +31,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseXTenHeadersTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenInviteHeaders =
                 "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
@@ -78,8 +79,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAsteriskRecordRouteHeadersTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenInviteHeaders =
                 "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A=" + m_CRLF +
@@ -111,8 +112,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAMulitLineHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string mulitLineHeader =
                 "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A=" + m_CRLF +
@@ -155,8 +156,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAuthenticationRequiredHeadersTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string authReqdHeaders =
                 "SIP/2.0 407 Proxy Authentication Required" + m_CRLF +
@@ -185,8 +186,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoViaHeadersUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noViaHeaders =
                 "SIP/2.0 407 Proxy Authentication Required" + m_CRLF +
@@ -212,8 +213,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void LowerCaseExpiresUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "Via: SIP/2.0/UDP 192.168.1.32:10254;branch=z9hG4bK-d87543-eb7c9f44883c5955-1--d87543-;rport;received=89.100.104.191" + m_CRLF +
@@ -241,8 +242,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void HuaweiRegisterUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "From: <sip:10000579@200.170.136.196>;tag=0477183750" + m_CRLF +
@@ -273,8 +274,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MultipleContactHeadersUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "From: <sip:10000579@200.170.136.196>;tag=0477183750" + m_CRLF +
@@ -306,8 +307,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ExtractHeadersUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "From: <sip:10000579@200.170.136.196>;tag=0477183750" + m_CRLF +
@@ -338,8 +339,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "\"User\" <sip:user@domain.com>;tag=abcdef";
 
@@ -356,8 +357,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderNoTagTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "User <sip:user@domain.com>";
 
@@ -371,8 +372,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderSocketDomainTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "User <sip:user@127.0.0.1:5090>";
 
@@ -386,8 +387,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderSocketDomainAndTagTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "User <sip:user@127.0.0.1:5090>;tag=abcdef";
 
@@ -401,8 +402,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderNoNameTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "<sip:user@domaintest.com>";
 
@@ -416,8 +417,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderNoAngleBracketsTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "sip:user@domaintest.com";
 
@@ -431,8 +432,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderNoSpaceTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "UNAVAILABLE<sip:user@domaintest.com:5060>;tag=abcd";
 
@@ -446,8 +447,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromHeaderNoUserTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testFromHeader = "<sip:sip.domain.com>;tag=as6900b876";
 
@@ -461,8 +462,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseToHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testToHeader = "User <sip:user@domain.com>;tag=abcdef";
 
@@ -476,8 +477,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMSCToHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testToHeader = "sip:xxx@127.0.110.30;tag=AZHf2-ZMfDX0";
 
@@ -493,8 +494,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ToStringToHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testToHeader = "User <sip:user@domain.com>;tag=abcdef";
 
@@ -513,8 +514,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ChangeTagToHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testToHeader = "User <sip:user@domain.com>;tag=abcdef";
 
@@ -534,8 +535,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseByeToHeader()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testHeader = "\"Joe Bloggs\" <sip:joe@sip.blueface.ie>;tag=0013c339acec34652d988c7e-4fddcdef";
 
@@ -551,8 +552,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAuthHeaderUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPAuthenticationHeader authHeader = SIPAuthenticationHeader.ParseSIPAuthenticationHeader(SIPAuthorisationHeadersEnum.ProxyAuthorization, "Digest realm=\"o-fone.com\",nonce=\"mv1keFTRX4yYVsHb/E+rviOflIurIw\",algorithm=MD5,qop=\"auth\",username=\"joe.bloggs\", response=\"1234\",uri=\"sip:o-fone.com\"");
 
@@ -569,8 +570,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MissingBracketsRouteTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPRoute newRoute = new SIPRoute("sip:127.0.0.1:5060");
 
@@ -582,8 +583,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRouteTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPRoute route = SIPRoute.ParseSIPRoute("<sip:127.0.0.1:5060;lr>");
 
@@ -597,8 +598,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SetLooseRouteTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPRoute route = SIPRoute.ParseSIPRoute("<sip:127.0.0.1:5060>");
             route.IsStrictRouter = false;
@@ -613,8 +614,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void RemoveLooseRouterTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPRoute route = SIPRoute.ParseSIPRoute("<sip:127.0.0.1:5060;lr>");
             route.IsStrictRouter = true;
@@ -629,8 +630,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRouteWithDisplayNameTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPRoute route = SIPRoute.ParseSIPRoute("12345656 <sip:127.0.0.1:5060;lr>");
 
@@ -646,8 +647,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRouteWithDoubleQuotedDisplayNameTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPRoute route = SIPRoute.ParseSIPRoute("\"Joe Bloggs\" <sip:127.0.0.1:5060;lr>");
 
@@ -661,8 +662,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRouteWithUserPortionTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string routeStr = "<sip:0033820600000@127.0.0.1:5060;lr;transport=udp>";
             SIPRoute route = SIPRoute.ParseSIPRoute(routeStr);
@@ -681,8 +682,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseSIPRouteSetTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string routeSetString = "<sip:127.0.0.1:5434;lr>,<sip:10.0.0.1>,<sip:192.168.0.1;ftag=12345;lr=on>";
             SIPRouteSet routeSet = SIPRouteSet.ParseSIPRouteSet(routeSetString);
@@ -705,8 +706,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AdjustReceivedViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenViaHeader = "SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -734,8 +735,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AdjustReceivedCorrectAlreadyViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenViaHeader = "SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -762,8 +763,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRequireAndSupportedExtensionsTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteHeaders =
                 "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
@@ -795,8 +796,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRSeqHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string ringResponse =
                 "SIP/2.0 180 Ringing" + m_CRLF +
@@ -823,8 +824,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseRAckHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string prackRequest =
                 "PRACK sip:127.0.0.1 SIP/2.0" + m_CRLF +
@@ -850,8 +851,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseServerHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var expectedServerValue = "SomeServerValue";
 
             string inviteWithServerHeader =

--- a/test/unit/core/SIP/SIPMessageUnitTest.cs
+++ b/test/unit/core/SIP/SIPMessageUnitTest.cs
@@ -12,6 +12,7 @@
 using System.Net;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -31,8 +32,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseResponseUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 100 Trying" + CRLF +
@@ -57,8 +58,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseResponseWithBodyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + CRLF +
@@ -100,8 +101,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseResponseNoEndDoubleCRLFUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 100 Trying" + CRLF +
@@ -126,8 +127,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseCiscoOptionsResponseUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + CRLF +
@@ -168,8 +169,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ContentLengthParseFromSingleRequestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -200,8 +201,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ContentLengthParseFromSingleRequestExtraSpacingTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -232,8 +233,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ContentLengthCompactParseFromSingleRequestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -265,8 +266,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ContentLengthCompactParseFromSingleRequestExtraSpacingTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -295,8 +296,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseReceiveNoContentLengthHeaderRequestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -323,8 +324,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseReceiveSingleRequestTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -430,8 +431,8 @@ CRLF +
         [Fact]
         public void ParseMultiRequestAndResponseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
             "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -497,8 +498,8 @@ CRLF +
         [Fact]
         public void ParseRequestOneByteMissingTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
             "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -528,8 +529,8 @@ CRLF +
         [Fact]
         public void ParseRequestOneByteExtraTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
             "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -561,8 +562,8 @@ CRLF +
         [Fact]
         public void ParseRequestBytesReadShortTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
             "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -592,8 +593,8 @@ CRLF +
         [Fact]
         public void ParseRequestWithLeadingNATKeepAliveBytesTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
             "    SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -628,8 +629,8 @@ CRLF +
         [Fact]
         public void TestProcessRecevieWithBytesToSkipTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
 "            SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -660,8 +661,8 @@ CRLF +
         [Fact]
         public void IsPingUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = new byte[] { 0x0d, 0x0a };//"\r\n"
             Assert.True(SIPMessageBuffer.IsPing(buffer), "Buffer \\r\\n is not a Ping message.");
@@ -699,8 +700,8 @@ CRLF +
         [Fact]
         public void ParseWithDefaultEncodingPersistsEndPoints()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
     "SIP/2.0 100 Trying" + CRLF +

--- a/test/unit/core/SIP/SIPParametersUnitTest.cs
+++ b/test/unit/core/SIP/SIPParametersUnitTest.cs
@@ -11,6 +11,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -28,8 +29,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void RouteParamExtractTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string routeParam = ";lr;server=hippo";
             SIPParameters serverParam = new SIPParameters(routeParam, ';');
@@ -44,8 +45,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void QuotedStringParamExtractTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string methodsParam = ";methods=\"INVITE, MESSAGE, INFO, SUBSCRIBE, OPTIONS, BYE, CANCEL, NOTIFY, ACK, REFER\"";
             SIPParameters serverParam = new SIPParameters(methodsParam, ';');
@@ -60,8 +61,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UserFieldWithNamesExtractTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string userField = "\"Joe Bloggs\" <sip:joe@bloggs.com>;allow=\"options, invite, cancel\"";
             string[] keyValuePairs = SIPParameters.GetKeyValuePairsFromQuoted(userField, ',');
@@ -75,8 +76,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MultipleUserFieldWithNamesExtractTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string userField = "\"Joe Bloggs\" <sip:joe@bloggs.com>;allow=\"options, invite, cancel\" , \"Jane Doe\" <sip:jabe@doe.com>";
             string[] keyValuePairs = SIPParameters.GetKeyValuePairsFromQuoted(userField, ',');
@@ -91,8 +92,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MultipleUserFieldWithNamesExtraWhitespaceExtractTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string userField = "  \"Joe Bloggs\"   <sip:joe@bloggs.com>;allow=\"options, invite, cancel\" \t,   \"Jane Doe\" <sip:jabe@doe.com>";
             string[] keyValuePairs = SIPParameters.GetKeyValuePairsFromQuoted(userField, ',');
@@ -107,8 +108,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GetHashCodeDiffOrderEqualityUnittest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testParamStr1 = ";lr;server=hippo;ftag=12345";
             SIPParameters testParam1 = new SIPParameters(testParamStr1, ';');
@@ -122,8 +123,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GetHashCodeDiffOrderEqualityReorderedUnittest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testParamStr1 = ";lr;server=hippo;ftag=12345";
             SIPParameters testParam1 = new SIPParameters(testParamStr1, ';');
@@ -137,8 +138,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CheckEqualWithDiffCaseEqualityUnittest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testParamStr1 = ";LR;Server=hippo;FTag=12345";
             SIPParameters testParam1 = new SIPParameters(testParamStr1, ';');
@@ -154,8 +155,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GetHashCodeDiffValueCaseEqualityUnittest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testParamStr1 = ";LR;Server=hippo;FTag=12345";
             SIPParameters testParam1 = new SIPParameters(testParamStr1, ';');
@@ -171,8 +172,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void EmptyValueParametersUnittest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testParamStr1 = ";emptykey;Server=hippo;FTag=12345";
             SIPParameters testParam1 = new SIPParameters(testParamStr1, ';');

--- a/test/unit/core/SIP/SIPReplacesParameterUnitTest.cs
+++ b/test/unit/core/SIP/SIPReplacesParameterUnitTest.cs
@@ -10,6 +10,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -27,8 +28,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParamsInUserPortionURITest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var replaces = SIPReplacesParameter.Parse(SIPEscape.SIPURIParameterUnescape("a48484fb-ac6e00aa%4010.0.0.12%3Bfrom-tag%3D11e7a0c7ec2ab74eo0%3Bto-tag%3D1313732478"));
 

--- a/test/unit/core/SIP/SIPRequestUnitTest.cs
+++ b/test/unit/core/SIP/SIPRequestUnitTest.cs
@@ -37,8 +37,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseXtenINVITEUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -88,8 +88,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MalformedContactHeaderUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
             "REGISTER sip:sip.sipsorcery.com SIP/2.0" + m_CRLF +
@@ -112,8 +112,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAsteriskACKUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "ACK sip:303@213.168.225.133 SIP/2.0" + m_CRLF +
@@ -142,8 +142,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseCiscoACKUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "ACK sip:303@213.168.225.133:5061 SIP/2.0" + m_CRLF +
@@ -175,8 +175,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseXtenByeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "BYE sip:303@213.168.225.133 SIP/2.0" + m_CRLF +
@@ -205,8 +205,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAsteriskBYEUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0" + m_CRLF +
@@ -235,8 +235,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void TopRouteUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0" + m_CRLF +
@@ -262,8 +262,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SubscribeRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SUBSCRIBE sip:0123456@127.0.0.1 SIP/2.0" + m_CRLF +
@@ -293,8 +293,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SpaceInNamesRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:Blue Face SIP/2.0" + m_CRLF +
@@ -323,8 +323,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DodgyAastraRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -347,8 +347,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NetgearInviteRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:12345@sip.domain.com:5060;TCID-0 SIP/2.0" + m_CRLF +
@@ -393,8 +393,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void RTCRegisterRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -419,8 +419,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CiscoRegisterRequest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:194.213.29.11 SIP/2.0" + m_CRLF +
@@ -442,8 +442,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AuthenticatedRegisterRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:blueface.ie SIP/2.0" + m_CRLF +
@@ -477,8 +477,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MicrosoftMessengerRegisterRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:aaronmsn SIP/2.0" + m_CRLF +
@@ -503,8 +503,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CreateBranchIdUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -537,8 +537,8 @@ namespace SIPSorcery.SIP.UnitTests
         /*[Test]
         public void LoopDetectUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
                
             string sipMsg = 
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -570,8 +570,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void LooseRouteForProxyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -604,8 +604,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void LooseRouteForProxyMultipleContactsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -638,8 +638,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void LooseRouteNotForProxyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -670,8 +670,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void StrictRoutePriorToProxyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:82.195.148.216:5062;lr SIP/2.0" + m_CRLF +
@@ -707,8 +707,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void StrictRouteAfterProxyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -745,8 +745,8 @@ namespace SIPSorcery.SIP.UnitTests
         //[Ignore()]
         public void LooseRouteForProxyHostnameUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
@@ -778,8 +778,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SpuriousStartCharsInResponseUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // This is an example of a malformed response received in the wild. It matches the bnf format for a request,
             // if the format of the SIP URI is not taken into account.
@@ -805,8 +805,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void RegisterZeroExpiryUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:213.200.94.181 SIP/2.0" + m_CRLF +
@@ -831,8 +831,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AvayaInviteUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:194.213.29.100:5060 SIP/2.0" + m_CRLF +
@@ -892,8 +892,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void LocalphoneInviteUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:shebeen@sip.mysipswitch.com;switchtag=134308 SIP/2.0" + m_CRLF +
@@ -933,8 +933,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MultipleRouteHeadersUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0" + m_CRLF +
@@ -975,8 +975,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SinologicInvalidInviteUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "INVITE sip:0447507533@69.59.142.213 SIP/2.0" + m_CRLF +
@@ -1003,8 +1003,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseACKWithDomainNameInViaTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "ACK sip:67.222.131.147 SIP/2.0" + m_CRLF +
@@ -1032,8 +1032,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ToStringSerialisationTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = new SIPURI("dummy", "dummy", null, SIPSchemesEnum.sip, SIPProtocolsEnum.udp);
             SIPRequest registerRequest = SIPRequest.GetRequest(SIPMethodsEnum.REGISTER, uri);
@@ -1061,8 +1061,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CopyToStringSerialisationTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = new SIPURI("dummy", "dummy", null, SIPSchemesEnum.sip, SIPProtocolsEnum.udp);
             SIPRequest registerRequest = SIPRequest.GetRequest(SIPMethodsEnum.REGISTER, uri);
@@ -1092,8 +1092,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParsedToStringSerialisationTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipRequestStr = "REGISTER sip:dummy@dummy SIP/2.0" + m_CRLF +
 "Via: SIP/2.0/UDP 0.0.0.0;branch=z9hG4bKb4313133e5fe42da87034c2b22ac2aab;rport" + m_CRLF +
@@ -1128,8 +1128,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void BinarySerialisationRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = new SIPURI("dummy", "dummy", null, SIPSchemesEnum.sip, SIPProtocolsEnum.udp);
             SIPRequest req = SIPRequest.GetRequest(SIPMethodsEnum.MESSAGE, uri);
@@ -1167,8 +1167,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AuthenticateInviteRequestUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:100@sipsorcery.cloud SIP/2.0
 Via: SIP/2.0/UDP 192.168.0.50:50508;branch=z9hG4bK990378180248496197e9b88881ea227c;rport
@@ -1212,8 +1212,8 @@ a=ssrc:172341600 cname:ee6f407e-d848-44b3-a451-e8cf2d0e22d9
         [Fact]
         public void SupportMultiplePAIHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:+4199999999@10.0.0.1;user=phone SIP/2.0
 Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;X-DispMsg=1423
@@ -1249,8 +1249,8 @@ Content-Length: 0
         [Fact]
         public void SupportMultipleHistoryInfoHeaderWithCommaTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:+4199999999@10.0.0.1;user=phone SIP/2.0
 Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;X-DispMsg=1423
@@ -1284,8 +1284,8 @@ Content-Length: 0
         [Fact]
         public void SupportMultiplePAIHeaderWithCommaTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:+4199999999@10.0.0.1;user=phone SIP/2.0
 Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;X-DispMsg=1423
@@ -1320,8 +1320,8 @@ Content-Length: 0
         [Fact]
         public void GeneratePAIHeadersOnToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
 
 
@@ -1364,8 +1364,8 @@ Content-Length: 0
         [Fact]
         public void HistoryInfoHeaderSortedTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:+4199999999@10.0.0.1;user=phone SIP/2.0
 Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;X-DispMsg=1423
@@ -1401,8 +1401,8 @@ Content-Length: 0
         [Fact]
         public void GenerateHistoryInfoHeadersOnToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
 
 
@@ -1442,8 +1442,8 @@ Content-Length: 0
         [Fact]
         public void DiversionHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:+4199999999@10.0.0.1;user=phone SIP/2.0
 Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;X-DispMsg=1423
@@ -1479,8 +1479,8 @@ Content-Length: 0
         [Fact]
         public void DiversionHeaderInOneLineTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteReq = @"INVITE sip:+4199999999@10.0.0.1;user=phone SIP/2.0
 Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;X-DispMsg=1423
@@ -1515,8 +1515,8 @@ Content-Length: 0
         [Fact]
         public void GenerateDiversionHeadersOnToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
 
 
@@ -1560,8 +1560,8 @@ Content-Length: 0
         [Fact]
         public void ParseSERVICEUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SERVICE sip:user1@something.com SIP/2.0" + m_CRLF +

--- a/test/unit/core/SIP/SIPResponseUnitTest.cs
+++ b/test/unit/core/SIP/SIPResponseUnitTest.cs
@@ -18,6 +18,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Ocsp;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -40,8 +41,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAsteriskTRYINGUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 100 Trying" + m_CRLF +
@@ -67,8 +68,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseAsteriskOKUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + m_CRLF +
@@ -112,8 +113,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseOptionsBodyResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg = "SIP/2.0 200 OK" + m_CRLF +
                 "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK10a1fab0" + m_CRLF +
@@ -149,8 +150,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseForbiddenResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg = "SIP/2.0 403 Forbidden" + m_CRLF +
                 "Via: SIP/2.0/UDP 192.168.1.1;branch=z9hG4bKbcb78f72d221beec" + m_CRLF +
@@ -174,8 +175,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseOptionsResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
             "SIP/2.0 200 OK" + m_CRLF +
@@ -213,8 +214,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMissingCSeqOptionsResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + m_CRLF +
@@ -242,8 +243,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMSCOkResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + m_CRLF +
@@ -285,8 +286,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMultipleContactsResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + m_CRLF +
@@ -319,8 +320,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMultiLineRecordRouteResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + m_CRLF +
@@ -372,8 +373,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMultiLineViaResponse()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "SIP/2.0 200 OK" + m_CRLF +
@@ -419,8 +420,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void BinarySerialisationRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = new SIPURI("dummy", "dummy", null, SIPSchemesEnum.sip, SIPProtocolsEnum.udp);
             SIPRequest req = SIPRequest.GetRequest(SIPMethodsEnum.MESSAGE, uri);
@@ -555,8 +556,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ChineseCharactersParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipResponse =
                 "SIP/2.0 200 Ok" + m_CRLF +

--- a/test/unit/core/SIP/SIPStreamConnectionUnitTest.cs
+++ b/test/unit/core/SIP/SIPStreamConnectionUnitTest.cs
@@ -41,8 +41,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void TestSocketReadSingleMessageTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
 "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -77,8 +77,8 @@ CRLF +
         [Fact]
         public void TestSocketReadWithBytesToSkipTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
 "            SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -119,8 +119,8 @@ CRLF + CRLF +
         [Fact]
         public void TestSocketReadWithTwoMessagesAndBytesToSkipTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
 "            SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
@@ -175,8 +175,8 @@ CRLF +
         [Fact]
         public void ContentLengthParseWhenUpperCaseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
@@ -205,8 +205,8 @@ CRLF +
         [Fact]
         public void ContentLengthParseWhenMixedCaseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
 "NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +

--- a/test/unit/core/SIP/SIPTransportUnitTest.cs
+++ b/test/unit/core/SIP/SIPTransportUnitTest.cs
@@ -38,8 +38,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public async Task TestSetRequestContactHostUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -81,8 +81,8 @@ dummy";
         [Fact]
         public async Task TestSetRequestContactHostIPAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -123,8 +123,8 @@ dummy";
         [Fact]
         public async Task TestSetResponseContactHostUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -165,8 +165,8 @@ dummy";
         [Fact]
         public async Task TestSetResponseContactHostIPAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -206,8 +206,8 @@ dummy";
         [Fact]
         public async Task TestSetRequestCustomHeaderFuncUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 
@@ -254,8 +254,8 @@ dummy";
         [Fact]
         public async Task TestSetResponseCustomHeaderFuncUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEndPoint dummyEP = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 5060));
 

--- a/test/unit/core/SIP/SIPURIUnitTest.cs
+++ b/test/unit/core/SIP/SIPURIUnitTest.cs
@@ -12,6 +12,7 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -29,16 +30,16 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SampleTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             Assert.True(true, "True was false.");
         }
 
         [Fact]
         public void ParseHostOnlyURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:sip.domain.com");
 
@@ -51,8 +52,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseHostAndUserURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:user@sip.domain.com");
 
@@ -65,8 +66,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseWithParamURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:user@sip.domain.com;param=1234");
 
@@ -81,8 +82,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseWithParamAndPortURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:1234@sip.domain.com:5060;TCID-0");
 
@@ -99,8 +100,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseWithHeaderURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:user@sip.domain.com?header=1234");
 
@@ -114,8 +115,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SpaceInHostNameURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:Blue Face");
 
@@ -128,8 +129,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ContactAsteriskURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("*");
 
@@ -142,8 +143,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualNoParamsURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com");
@@ -156,8 +157,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualIPAddressNoParamsURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@192.168.1.101");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@192.168.1.101");
@@ -170,8 +171,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualWithParamsURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1;key2=value2");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key2=value2;key1=value1");
@@ -185,8 +186,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NotEqualWithParamsURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1;key2=value2");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key2=value2;key1=value2");
@@ -199,8 +200,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualWithHeadersURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1;key2=value2?header1=value1&header2=value2");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key2=value2;key1=value1?header2=value2&header1=value1");
@@ -213,8 +214,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NotEqualWithHeadersURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1;key2=value2?header1=value2&header2=value2");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key2=value2;key1=value1?header2=value2&header1=value1");
@@ -230,8 +231,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UriWithParameterEqualityURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1");
@@ -244,8 +245,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UriWithDifferentParamsEqualURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value2");
@@ -258,8 +259,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UriWithSameParamsInDifferentOrderURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key2=value2;key1=value1");
             SIPURI sipURI2 = SIPURI.ParseSIPURI("sip:abcd@adcb.com;key1=value1;key2=value2");
@@ -272,8 +273,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualNullURIsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = null;
             SIPURI sipURI2 = null;
@@ -286,8 +287,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NotEqualOneNullURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = SIPURI.ParseSIPURI("sip:abcd@adcb.com");
             SIPURI sipURI2 = null;
@@ -300,8 +301,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualNullEqualsOverloadUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = null;
 
@@ -313,8 +314,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AreEqualNullNotEqualsOverloadUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI1 = null;
 
@@ -326,8 +327,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UnknownSchemeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Assert.Throws<SIPValidationException>(() => SIPURI.ParseSIPURI("mailto:1234565"));
 
@@ -337,8 +338,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void KnownSchemesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             foreach (var value in System.Enum.GetValues(typeof(SIPSchemesEnum)))
             {
@@ -351,8 +352,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParamsInUserPortionURIWithUserPhoneTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:C=on;t=DLPAN@10.0.0.1:5060;lr;user=phone");
 
@@ -368,8 +369,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void OneParamInUserPortionURIWithUserPhoneTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:C=on@10.0.0.1:5060;lr;user=phone");
 
@@ -384,8 +385,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParamsInUserPortionURIPhoneNumWithParamsTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:+41999999999;cpc=ordinary@10.0.0.1:5060;transport=udp;user=phone");
 
@@ -400,8 +401,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParamsInUserPortionURITest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:C=on;t=DLPAN@10.0.0.1:5060;lr");
 
@@ -414,8 +415,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void SwitchTagParameterUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:joebloggs@sip.mysipswitch.com;switchtag=119651");
 
@@ -429,8 +430,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void LongUserUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:EhZgKgLM9CwGqYDAECqDpL5MNrM_sKN5NurN5q_pssAk4oxhjKEMT4@10.0.0.1:5060");
 
@@ -443,8 +444,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParsePartialURINoSchemeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURIRelaxed("sip.domain.com");
 
@@ -459,8 +460,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParsePartialURISIPSSchemeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURIRelaxed("sips:sip.domain.com:1234");
 
@@ -474,8 +475,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParsePartialURIWithUserUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURIRelaxed("sip:joe.bloggs@sip.domain.com:1234;transport=tcp");
 
@@ -493,8 +494,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseHoHostUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Assert.Throws<SIPValidationException>(() => SIPURI.ParseSIPURI("sip:;transport=UDP"));
 
@@ -504,8 +505,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UDPProtocolToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = new SIPURI(SIPSchemesEnum.sip, SIPEndPoint.ParseSIPEndPoint("127.0.0.1"));
             logger.LogDebug("{sipURI}", sipURI.ToString());
@@ -516,8 +517,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseUDPProtocolToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURIRelaxed("127.0.0.1");
             logger.LogDebug("{sipURI}", sipURI.ToString());
@@ -528,8 +529,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseBigURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURIRelaxed("TRUNKa1d2ce524d44cd54f39ac78bcdba85c7@65.98.14.50:5069");
             logger.LogDebug("{sipURI}", sipURI.ToString());
@@ -540,8 +541,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMalformedContactUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Assert.Throws<SIPValidationException>(() => SIPURI.ParseSIPURIRelaxed("sip:twolmsted@24.183.120.253, sip:5060"));
 
@@ -551,8 +552,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NoPortIPv4CanonicalAddressToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:127.0.0.1");
             logger.LogDebug("SIP URI {sipURI}", sipURI);
@@ -570,8 +571,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseIPv6UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:[::1]");
 
@@ -597,8 +598,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseIPv6WithExplicitPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURI = SIPURI.ParseSIPURI("sip:[::1]:6060");
 
@@ -617,8 +618,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void IPv6UriPortToNoPortCanonicalAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI sipURINoPort = SIPURI.ParseSIPURI("sip:[::1]");
             SIPURI sipURIWIthPort = SIPURI.ParseSIPURI("sip:[::1]:5060");
@@ -661,8 +662,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void UriConstructorWithIPv6AddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI ipv6Uri = new SIPURI(SIPSchemesEnum.sip, IPAddress.IPv6Loopback, 6060);
 
@@ -677,8 +678,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void InvalidIPv6UriThrowUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI ipv6Uri = new SIPURI(SIPSchemesEnum.sip, IPAddress.IPv6Loopback, 6060);
 
@@ -694,8 +695,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseIPv4MappedAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI ipv6Uri = new SIPURI(SIPSchemesEnum.sip, IPAddress.IPv6Loopback, 6060);
 
@@ -712,8 +713,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseReplacesHeaderUriUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI referToUri = SIPURI.ParseSIPURI("sip:1@127.0.0.1?Replaces=84929ZTg0Zjk1Y2UyM2Q1OWJjYWNlZmYyYTI0Njg1YjgwMzI%3Bto-tag%3D8787f9cc94bb4bb19c089af17e5a94f7%3Bfrom-tag%3Dc2b89404");
 
@@ -729,8 +730,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MangleUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@192.168.0.50:5060?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("67.222.131.147:5090"));
@@ -749,8 +750,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MangleNoPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@192.168.0.50?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("67.222.131.147:5090"));
@@ -770,8 +771,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MangleReceiveOnIPv6UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@192.168.0.50:5060?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("[2001:730:3ec2::10]:5090"));
@@ -791,8 +792,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NoMangleSameAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@192.168.0.50:5060?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("192.168.0.50:5060"));
@@ -808,8 +809,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NoManglePublicIPv4UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@67.222.131.149:5060?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("67.222.131.147:5060"));
@@ -825,8 +826,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NoMangleHostnameUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@sipsorcery.com:5060?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("67.222.131.147:5060"));
@@ -842,8 +843,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NoMangleIPv6UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]:5060?Replaces=xyz");
             SIPURI mangled = SIPURI.Mangle(uri, IPSocket.Parse("67.222.131.147:5060"));
@@ -859,8 +860,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DefaultUdpPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]:5060?Replaces=xyz");
 
@@ -877,8 +878,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DefaultUdpPortWhenNotSetUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]?Replaces=xyz");
 
@@ -894,8 +895,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void NonDefaultUdpPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]:5080?Replaces=xyz");
 
@@ -911,8 +912,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DefaultTcpPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]:5060;transport=tcp?Replaces=xyz");
 
@@ -928,8 +929,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DefaultTlsPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sips:user@[2001:730:3ec2::10]:5061?Replaces=xyz");
 
@@ -945,8 +946,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DefaultWebSocketPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]:80;transport=ws?Replaces=xyz");
 
@@ -962,8 +963,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void DefaultSecureWebSocketPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPURI uri = SIPURI.ParseSIPURI("sip:user@[2001:730:3ec2::10]:443;transport=wss?Replaces=xyz");
 
@@ -979,8 +980,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseTelSchemeURIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var telStr = "tel:+1-(201) 555 0123;phone-context=example.com";
             SIPURI sipURI = SIPURI.ParseSIPURI(telStr);

--- a/test/unit/core/SIP/SIPUserFieldUnitTest.cs
+++ b/test/unit/core/SIP/SIPUserFieldUnitTest.cs
@@ -10,6 +10,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -27,8 +28,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParamsInUserPortionURITest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPUserField userField = SIPUserField.ParseSIPUserField("<sip:C=on;t=DLPAN@10.0.0.1:5060;lr>");
 
@@ -44,8 +45,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseSIPUserFieldUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var userField = SIPUserField.ParseSIPUserField("\"Jane Doe\" <sip:jane@doe.com>");
 
@@ -61,8 +62,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseSIPUserFieldNoAnglesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var userField = SIPUserField.ParseSIPUserField("sip:jane@doe.com");
 
@@ -78,8 +79,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseWithHeaderParametersUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var userField = SIPUserField.ParseSIPUserField("\"Jane Doe\" <sip:jane@doe.com>p=1;q=2");
 
@@ -98,8 +99,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseWithHeaderAndURIParametersUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var userField = SIPUserField.ParseSIPUserField("\"Jane Doe\" <sip:jane@doe.com;a=x;b=y;c=z>p=1;q=2");
 

--- a/test/unit/core/SIP/SIPViaHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPViaHeaderUnitTest.cs
@@ -11,6 +11,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -28,8 +29,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseXTenViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenViaHeader = "SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -58,8 +59,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseReceivedFromIPViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenViaHeader = "SIP/2.0/UDP 192.168.1.2:5065;received=88.99.88.99;rport=10060;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -88,8 +89,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoPortViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noPortViaHeader = "SIP/2.0/UDP 192.168.1.1;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -107,8 +108,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoSemiColonViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noSemiColonViaHeader = "SIP/2.0/UDP 192.168.1.1:1234";
 
@@ -123,8 +124,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoContactViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noContactViaHeader = "SIP/2.0/UDP";
 
@@ -136,8 +137,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoSemiButHasBranchColonViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noSemiColonViaHeader = "SIP/2.0/UDP 192.168.1.1:1234branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -153,8 +154,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseNoBranchViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noSemiColonViaHeader = "SIP/2.0/UDP 192.168.1.1:1234;rport";
 
@@ -170,8 +171,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseBadAastraViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noSemiColonViaHeader = "SIP/2.0/UDP 192.168.1.1:1234port;branch=213123";
 
@@ -183,8 +184,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MaintainUnknownHeaderViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenViaHeader = "SIP/2.0/UDP 192.168.1.2:5065;received=88.99.88.99;unknown=12234;unknown2;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001;rport";
 
@@ -204,8 +205,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GetIPEndPointViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenViaHeader = "SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001";
 
@@ -219,8 +220,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CreateNewViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPViaHeader viaHeader = new SIPViaHeader("192.168.1.2", 5063, "abcdefgh");
 
@@ -234,8 +235,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMultiViaHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noPortViaHeader = "SIP/2.0/UDP 192.168.1.1:5060;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001, SIP/2.0/UDP 192.168.0.1:5061;branch=z9hG4bKFBB7EAC06";
 
@@ -252,8 +253,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseMultiViaHeaderTest2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noPortViaHeader = "SIP/2.0/UDP 194.213.29.100:5060;branch=z9hG4bK5feb18267ce40fb05969b4ba843681dbfc9ffcff, SIP/2.0/UDP 127.0.0.1:5061;branch=z9hG4bK52b6a8b7";
 

--- a/test/unit/core/SIP/TortureTests.cs
+++ b/test/unit/core/SIP/TortureTests.cs
@@ -15,6 +15,7 @@ using System.Net.Sockets;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Net;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -45,8 +46,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact(Skip = "Bit trickier to pass than anticipated.")]
         public void ShortTorturousInvite()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Assert.True(File.Exists("wsinv.dat"), "The wsinv.dat torture test input file was missing.");
 
@@ -76,8 +77,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_1()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "REGISTER sip:[2001:db8::10] SIP/2.0" + CRLF +
@@ -120,8 +121,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "REGISTER sip:2001:db8::10 SIP/2.0" + CRLF +
@@ -158,8 +159,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_3()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "REGISTER sip:[2001:db8::10:5070] SIP/2.0" + CRLF +
@@ -204,8 +205,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_4()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "REGISTER sip:[2001:db8::10]:5070 SIP/2.0" + CRLF +
@@ -250,8 +251,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_5_1()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "BYE sip:[2001:db8::10] SIP/2.0" + CRLF +
@@ -289,8 +290,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_5_2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "OPTIONS sip:[2001:db8::10] SIP/2.0" + CRLF +
@@ -332,8 +333,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_6()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "INVITE sip:user@[2001:db8::10] SIP/2.0" + CRLF +
@@ -392,8 +393,8 @@ CRLF +
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_7()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "BYE sip:user@host.example.net SIP/2.0" + CRLF +
@@ -443,8 +444,8 @@ CRLF +
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_8()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "INVITE sip:user@[2001:db8::10] SIP/2.0" + CRLF +
@@ -511,8 +512,8 @@ CRLF +
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_9()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "INVITE sip:user@example.com SIP/2.0" + CRLF +
@@ -578,8 +579,8 @@ CRLF +
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_10_1()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "OPTIONS sip:user@[2001:db8:::192.0.2.1] SIP/2.0" + CRLF +
@@ -615,8 +616,8 @@ CRLF +
         [Trait("Category", "IPv6Torture")]
         public void RFC5118_4_10_2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
 "OPTIONS sip:user@[2001:db8::192.0.2.1] SIP/2.0" + CRLF +

--- a/test/unit/core/SIPEvents/Dialog/SIPEventDialogInfoUnitTest.cs
+++ b/test/unit/core/SIPEvents/Dialog/SIPEventDialogInfoUnitTest.cs
@@ -13,6 +13,7 @@
 //using System.Xml.Linq;
 //using System.Xml.Schema;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -39,8 +40,8 @@ namespace SIPSorcery.SIP.UnitTests
         /// Commented out due to excluding xsd resources files that were breaking the WSL build. AC 14 Nov 2019
         //public void InvalidXMLUnitTest()
         //{
-        //    logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-        //    logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+        //    logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+        //    logger.BeginScope(TestHelper.GetCurrentMethodName());
 
         //    if (m_eventDialogSchema == null)
         //    {
@@ -82,8 +83,8 @@ namespace SIPSorcery.SIP.UnitTests
         //[Ignore("Use this method to validate dialog XML packages against the RFC schema. It takes a little bit of time to load the schema.")]
         //public void ValidXMLUnitTest()
         //{
-        //    logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-        //    logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+        //    logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+        //    logger.BeginScope(TestHelper.GetCurrentMethodName());
 
         //    if (m_eventDialogSchema == null)
         //    {
@@ -134,8 +135,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void GetAsXMLStringUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPEventDialogInfo dialogInfo = new SIPEventDialogInfo(0, SIPEventDialogInfoStateEnum.full, SIPURI.ParseSIPURI("sip:test@test.com"));
             dialogInfo.DialogItems.Add(new SIPEventDialog("abcde", "terminated", 487, SIPEventDialogStateEvent.Cancelled, 2));
@@ -150,8 +151,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromXMLStringUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string eventDialogInfoStr = "<?xml version='1.0' encoding='utf-16'?>" +
                  "<dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'>" +
@@ -186,8 +187,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromXMLStringMultiDialogsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string eventDialogInfoStr = "<?xml version='1.0' encoding='utf-16'?>" +
                  "<dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'>" +
@@ -219,8 +220,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void ParseFromXMLStringDialogWithParticipantsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string eventDialogInfoStr = "<?xml version='1.0' encoding='utf-16'?>" +
                  "<dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'>" +
@@ -260,8 +261,8 @@ namespace SIPSorcery.SIP.UnitTests
         /*[Fact]
         public void ParseSDPFromXMLStringDialogUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string CRLF = "\r\n";
             string sdp =

--- a/test/unit/core/SIPEvents/Presence/SIPEventPresenceUnitTest.cs
+++ b/test/unit/core/SIPEvents/Presence/SIPEventPresenceUnitTest.cs
@@ -31,8 +31,8 @@ namespace SIPSorcery.SIP.UnitTests
         //[ExpectedException(typeof(XmlSchemaValidationException))]
         //public void InvalidXMLUnitTest()
         //{
-        //    logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-        //    logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+        //    logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+        //    logger.BeginScope(TestHelper.GetCurrentMethodName());
 
         //    if (m_presenceSchema == null)
         //    {
@@ -70,8 +70,8 @@ namespace SIPSorcery.SIP.UnitTests
         ////[Ignore("Use this method to validate dialog XML packages against the RFC schema. It takes a little bit of time to load the schema.")]
         //public void ValidXMLUnitTest()
         //{
-        //    logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-        //    logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+        //    logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+        //    logger.BeginScope(TestHelper.GetCurrentMethodName());
 
         //    if (m_presenceSchema == null)
         //    {
@@ -113,8 +113,8 @@ namespace SIPSorcery.SIP.UnitTests
         //[Fact]
         //public void GetAsXMLStringUnitTest()
         //{
-        //    logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-        //    logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+        //    logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+        //    logger.BeginScope(TestHelper.GetCurrentMethodName());
 
         //    SIPEventPresence presence = new SIPEventPresence(SIPURI.ParseSIPURI("sip:me@somewhere.com"));
         //    presence.Tuples.Add(new SIPEventPresenceTuple("1234", SIPEventPresenceStateEnum.open, SIPURI.ParseSIPURIRelaxed("test@test.com"), 0.8M));
@@ -130,8 +130,8 @@ namespace SIPSorcery.SIP.UnitTests
         //[Fact]
         //public void ParseFromXMLStringUnitTest()
         //{
-        //    logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-        //    logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+        //    logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+        //    logger.BeginScope(TestHelper.GetCurrentMethodName());
 
         //    string presenceXMLStr = "<?xml version='1.0' encoding='utf-16'?>" +
         //         "<presence entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:pidf'>" +

--- a/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
@@ -17,6 +17,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -55,8 +56,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void MatchOnRequestAndResponseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport sipTransport = new SIPTransport();
             SIPTransactionEngine transactionEngine = sipTransport.m_transactionEngine;
@@ -98,8 +99,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Trait("Category", "txintegration")]
         public async Task AckRecognitionUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport clientTransport = null;
             SIPTransport serverTransport = null;
@@ -178,8 +179,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void AckRecognitionIIUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport sipTransport = new SIPTransport();
             SIPTransactionEngine engine = sipTransport.m_transactionEngine;     // Client side of the INVITE.
@@ -226,8 +227,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CancelledInviteWithoutCancelledAt_ExpiresUsingCreatedFallback()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport sipTransport = new SIPTransport();
             SIPTransactionEngine engine = sipTransport.m_transactionEngine;
@@ -252,8 +253,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CancelledInviteWithRecentCancelledAt_IsNotExpired()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SIPTransport sipTransport = new SIPTransport();
             SIPTransactionEngine engine = sipTransport.m_transactionEngine;

--- a/test/unit/core/SIPTransactions/SIPTransactionUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionUnitTest.cs
@@ -11,6 +11,7 @@
 
 using System.Net;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.SIP.UnitTests
@@ -29,8 +30,8 @@ namespace SIPSorcery.SIP.UnitTests
         [Fact]
         public void CreateTransactionUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipRequestStr =
                 "INVITE sip:023434211@213.200.94.182;switchtag=902888 SIP/2.0" + m_CRLF +

--- a/test/unit/net/ICE/RTCIceCandidateUnitTest.cs
+++ b/test/unit/net/ICE/RTCIceCandidateUnitTest.cs
@@ -12,6 +12,7 @@
 
 using System.Net;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -32,8 +33,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseHostCandidateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var candidate = RTCIceCandidate.Parse("1390596646 1 udp 1880747346 192.168.11.50 61680 typ host generation 0");
 
@@ -50,8 +51,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void Parse_IPv6_Host_Candidate_UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var candidate = RTCIceCandidate.Parse("1390596646 1 udp 1880747346 [::1] 61680 typ host generation 0");
 
@@ -69,8 +70,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void Parse_IPv6_Host_NoBrackets_Candidate_UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var candidate = RTCIceCandidate.Parse("1390596646 1 udp 1880747346 ::1 61680 typ host generation 0");
 
@@ -88,8 +89,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseSvrRflxCandidateUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var candidate = RTCIceCandidate.Parse("842163049 1 udp 1677729535 8.8.8.8 12767 typ srflx raddr 0.0.0.0 rport 0 generation 0 network-cost 999");
 
@@ -106,8 +107,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void EquivalentCandidateFoundationUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCIceCandidateInit initA = new RTCIceCandidateInit { usernameFragment = "abcd" };
             var candidateA = new RTCIceCandidate(initA);
@@ -130,8 +131,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void NonEquivalentCandidateFoundationUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCIceCandidateInit initA = new RTCIceCandidateInit { usernameFragment = "abcd" };
             var candidateA = new RTCIceCandidate(initA);
@@ -155,8 +156,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ToJsonUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var candidate = RTCIceCandidate.Parse("1390596646 1 udp 1880747346 192.168.11.50 61680 typ host generation 0");
 

--- a/test/unit/net/RTCP/RTCFeedbackUnitTest.cs
+++ b/test/unit/net/RTCP/RTCFeedbackUnitTest.cs
@@ -15,6 +15,7 @@
 
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -36,8 +37,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripPictureLossIndicationReportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint senderSsrc = 33;
             uint mediaSsrc = 44;
@@ -63,8 +64,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripREMBUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint senderSsrc = 33;
             uint mediaSsrc = 44;
@@ -102,8 +103,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripREMBUnitTestMultipleSsrcs()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint senderSsrc = 33;
             uint mediaSsrc = 44;

--- a/test/unit/net/RTCP/RTCPByeUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPByeUnitTest.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -35,8 +36,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPByeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 23;
 
@@ -56,8 +57,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripByeWithReasonUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 19;
             string reason = "x";
@@ -79,8 +80,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPByeOnBoundaryUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 123121231;
             string reason = "1234567";
@@ -102,8 +103,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripByeWithTimeoutReasonUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 19;
             string reason = RTCPSession.NO_ACTIVITY_TIMEOUT_REASON;

--- a/test/unit/net/RTCP/RTCPCompoundPacketUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPCompoundPacketUnitTest.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPCompoundPacketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 23;
             ulong ntpTs = 1;
@@ -89,8 +90,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseChromeRtcpPacketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("81C9000700000001384B9567000000000000D214000004C900000000000000008FCE0005000000010000000052454D42010A884A384B95678000000BF9CDAEFFBEF60160B98F");
 
@@ -102,8 +103,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseChromeRtcpPacket2UnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("81C90007FA17FA17761E74C8000000000000F19700000045000000000000000080000001FF6EBFCCFAFB3C6D6291");
 
@@ -115,8 +116,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseChromeRtcpPacketWith6SSRCsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("81C9000700000001497EB0250000000000009CA200000A0500000000000000008FCE000A000000010000000052454D42060B29711CAB48A626A3FADE2EE30A21497EB0255C6A292A604EEAC8");
 

--- a/test/unit/net/RTCP/RTCPHeaderUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPHeaderUnitTest.cs
@@ -15,6 +15,7 @@
 
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -32,8 +33,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetRTCPHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPHeader rtcpHeader = new RTCPHeader(RTCPReportTypesEnum.SR, 1);
             byte[] headerBuffer = rtcpHeader.GetHeader(0, 0);
@@ -49,8 +50,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RTCPHeaderRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPHeader src = new RTCPHeader(RTCPReportTypesEnum.SR, 1);
             byte[] headerBuffer = src.GetHeader(17, 54443);

--- a/test/unit/net/RTCP/RTCPReceiverReportUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPReceiverReportUnitTest.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPReceiverResportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 1;
 
@@ -89,8 +90,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseReceiverReportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("81C9000700000001679915EA000000000000212E000004B40000000000000000");
 
@@ -106,8 +107,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseReceiverReportChromeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("81C90007FA17FA1709CF4FFA000000000000496C00000021000000000000000080000003315A25AFFAF8545434C7");
 

--- a/test/unit/net/RTCP/RTCPSDesReportUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPSDesReportUnitTest.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -35,8 +36,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPSDesReportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 8;
             string cname = "abc";
@@ -58,8 +59,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPSDesReportNotOnBoundaryUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 8;
             string cname = "ab1234";
@@ -81,8 +82,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPSDesReportOnBoundaryUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 8;
             string cname = "ab123"; // 5 bytes + 1 byte for the item null termination.

--- a/test/unit/net/RTCP/RTCPSenderReportUnitTest.cs
+++ b/test/unit/net/RTCP/RTCPSenderReportUnitTest.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripRTCPSenderResportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             uint ssrc = 23;
             ulong ntpTs = 1;
@@ -84,8 +85,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseSenderReportUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("80C8000641446122E1D2B0EA004B650C0000D556000001310003BA5A");
 

--- a/test/unit/net/RTP/Ntp64TimestampUnitTest.cs
+++ b/test/unit/net/RTP/Ntp64TimestampUnitTest.cs
@@ -17,8 +17,8 @@ namespace SIPSorcery.UnitTests.net.RTP
 
         [Fact]
         public void InterpolatesNtpTimestampFromRtpTimestamp() {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var lastNtpTimestamp = 0x00000001_00000000ul;
             var lastRtpTimestamp = 1100u;

--- a/test/unit/net/RTP/RTPChannelUnitTest.cs
+++ b/test/unit/net/RTP/RTPChannelUnitTest.cs
@@ -20,6 +20,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -42,8 +43,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RtpChannelCreateManyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             List<RTPChannel> channels = new List<RTPChannel>();
 
@@ -67,8 +68,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task RtpChannelLoopbackUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPChannel channel1 = new RTPChannel(false, null);
 
@@ -115,8 +116,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task RtpChannelWithIPv4BindAddressLoopbackUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPChannel channel1 = new RTPChannel(false, IPAddress.Loopback);
             RTPChannel channel2 = new RTPChannel(false, IPAddress.Loopback);
@@ -167,8 +168,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task RtpChannelWithIPv6BindAddressLoopbackUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPChannel channel1 = new RTPChannel(false, IPAddress.IPv6Loopback);
 

--- a/test/unit/net/RTP/RTPHeaderExtensionUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderExtensionUnitTest.cs
@@ -23,8 +23,8 @@ namespace SIPSorcery.UnitTests.Net
             //  - the static method AbsSendTime() used by AbsSendTimeExtension.Marshal()
             //  - and a specific DateTimeOffset value
 
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             
             var extensionId = 2; // Id / Extmap of the extension
 
@@ -42,8 +42,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void RTPHeaderExtensionAudioLevel()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var extensionId = 2; // Id / Extmap of the extension
             var extension = new AudioLevelExtension(extensionId);
@@ -71,8 +71,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void RTPHeaderExtensionCVO()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var extensionId = 2; // Id / Extmap of the extension
             var extension = new CVOExtension(extensionId);

--- a/test/unit/net/RTP/RTPHeaderUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderUnitTest.cs
@@ -12,6 +12,7 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -30,8 +31,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetHeaderTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPHeader rtpHeader = new RTPHeader();
             byte[] headerBuffer = rtpHeader.GetHeader(1, 0, 1);
@@ -47,8 +48,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void HeaderRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPHeader src = new RTPHeader();
             byte[] headerBuffer = src.GetHeader(1, 0, 1);
@@ -80,8 +81,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void CustomisedHeaderRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPHeader src = new RTPHeader();
             src.Version = 3;
@@ -127,8 +128,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseRawRtpTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] rtpBytes = new byte[] {
                 0x80, 0x88, 0xe6, 0xfd, 0x00, 0x00, 0x00, 0xf0, 0xde, 0xe0, 0xee, 0x8f,
@@ -150,8 +151,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseRawRtpWithExtensionTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] rtpBytes = new byte[] {
                 0x90, 0x88, 0xe6, 0xfd,
@@ -188,8 +189,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseChromeRtpPacketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var buffer = TypeExtensions.ParseHexStr("800000099D5904B4838FCECF7F1E");
 
@@ -204,8 +205,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseHeaderExtensions()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var rtpHeaderBytes = new byte[] {
                 0x90, 0x60, 0x0c, 0xd5, 0x83, 0x0a, 0xcd, 0x97, 0x2e, 0xba, 0x23, 0x57, 0xbe, 0xde, 0x00, 0x05,

--- a/test/unit/net/RTP/RTPSessionRenegotiationUnitTest.cs
+++ b/test/unit/net/RTP/RTPSessionRenegotiationUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: RTPSessionRenegotiationUnitTest.cs
 //
 // Description: Unit tests for SDP renegotiation scenarios, specifically
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.SIP.App;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -43,8 +44,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void VideoRejectedByReInviteClosesRtcpSession()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // --- Local session with audio + video ---
             RTPSession rtpSession = new RTPSession(false, false, false);
@@ -127,8 +128,8 @@ a=rtpmap:96 VP8/90000";
         [Fact]
         public void BothStreamsActiveAfterReInviteKeepsRtcpRunning()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession rtpSession = new RTPSession(false, false, false);
 

--- a/test/unit/net/RTP/RTPSessionUnitTest.cs
+++ b/test/unit/net/RTP/RTPSessionUnitTest.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -43,8 +44,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void AudioOnlyOfferAnswerTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -92,8 +93,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void NoLocalTracksTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -127,8 +128,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void NoRemoteMediaTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession localSession = new RTPSession(false, false, false);
             MediaStreamTrack localAudioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) });
@@ -152,8 +153,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void NoMatchingMediaTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession localSession = new RTPSession(false, false, false);
             MediaStreamTrack localAudioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) });
@@ -181,8 +182,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void InvalidPortInRemoteOfferTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession localSession = new RTPSession(false, false, false);
             MediaStreamTrack localAudioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) });
@@ -218,8 +219,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void CheckCreateOfferWithIPv4BindAddressAnswerTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -245,8 +246,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void CheckCreateOfferWithIPv6BindAddressAnswerTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -272,8 +273,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void AudioVideoOfferNoLocalVideoUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -316,8 +317,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void AudioVideoOfferNoLocalAudioUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -359,8 +360,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void CheckDuplicateBindPortFailsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Create two RTP sessions. First one acts as the local session to generate the offer.
             // Second one acts as the remote session to generate the answer.
@@ -389,8 +390,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void MediaOrderMatchesRemoteOfferUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // By default offers made by us always put audio first. Create a remote SDP offer 
             // with the video first.
@@ -449,8 +450,8 @@ a=sendrecv";
         [Fact]
         public void SetRemoteSDPNoMediaStreamAttributeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string remoteSdp =
             @"v=0
@@ -495,8 +496,8 @@ a=rtpmap:111 OPUS/48000/2";
         [Fact]
         public void CheckSelectedAudioFormatAttributeUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string remoteSdp =
             @"v=0
@@ -567,8 +568,8 @@ a=fmtp:100 98/98";
         [Fact]
         public void ModifiedWellKnownFormatIDUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string remoteSdp =
             @"v=0
@@ -614,8 +615,8 @@ a=rtpmap:12 PCMA/8000";
         [Fact]
         public void OfferMLineOrderVideoFirstThenAudio()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession rtpSession = new RTPSession(false, false, false);
 
@@ -647,8 +648,8 @@ a=rtpmap:12 PCMA/8000";
         [Fact]
         public void OfferMLineOrderAudioFirstThenVideo()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession rtpSession = new RTPSession(false, false, false);
 

--- a/test/unit/net/RTP/ReorderBufferUnitTest.cs
+++ b/test/unit/net/RTP/ReorderBufferUnitTest.cs
@@ -23,8 +23,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldReorder()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300));
             var packets = new[] { CreatePacket(1), CreatePacket(3), CreatePacket(4), CreatePacket(2) };
 
@@ -42,8 +42,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldReorder2()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300));
             var packets = new[] { CreatePacket(1), CreatePacket(3), CreatePacket(2), CreatePacket(0) };
 
@@ -61,8 +61,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldReorderWithWrapAround()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300));
             var packets = new[] { CreatePacket(65534), CreatePacket(3), CreatePacket(2), CreatePacket(0), CreatePacket(65535) };
 
@@ -80,8 +80,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldReturnPacketsInOrder()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var provider = new DatetimeProvider();
             var baseTime = DateTime.Now;
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
@@ -103,8 +103,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldRemoveDuplicate()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var provider = new DatetimeProvider();
             var baseTime = DateTime.Now;
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
@@ -123,8 +123,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldWaitForMissingPacket()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var provider = new DatetimeProvider();
             var baseTime = DateTime.Now;
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
@@ -145,8 +145,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldSkipPacketAfterSpecifiedTimeout()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var provider = new DatetimeProvider();
             var baseTime = DateTime.Now;
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
@@ -166,8 +166,8 @@ namespace SIPSorcery.UnitTests.Net
         [Fact]
         public void ShouldSkipPacketAfterSpecifiedTimeoutWithWrapAround()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             var provider = new DatetimeProvider();
             var baseTime = DateTime.Now;
             var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);

--- a/test/unit/net/RTP/UdpReceiverConnectionResetUnitTest.cs
+++ b/test/unit/net/RTP/UdpReceiverConnectionResetUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: UdpReceiverConnectionResetUnitTest.cs
 //
 // Description: Unit tests verifying that a ConnectionReset (ICMP port
@@ -21,6 +21,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -110,8 +111,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task ReceiveLoopSurvivesConnectionReset()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var recvSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             recvSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));

--- a/test/unit/net/RTP/UdpReceiverUnitTest.cs
+++ b/test/unit/net/RTP/UdpReceiverUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: UdpReceiverUnitTest.cs
 //
 // Description: Unit tests for the UdpReceiver class, specifically verifying
@@ -22,6 +22,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -44,8 +45,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task CloseWhileReceivingDoesNotThrowUnobservedException()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             AggregateException capturedException = null;
 
@@ -107,8 +108,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void CloseFiresOnClosedEvent()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
@@ -133,8 +134,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void DoubleCloseDoesNotThrow()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));

--- a/test/unit/net/RTSP/RTSPConnectionUnitTest.cs
+++ b/test/unit/net/RTSP/RTSPConnectionUnitTest.cs
@@ -37,7 +37,7 @@ namespace SIPSorcery.Net.UnitTests
         public void RTSPMessageWithNoContentLengthHeaderAvailable()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTSPRequest setupRequest = new RTSPRequest(RTSPMethodsEnum.SETUP, RTSPURL.ParseRTSPURL("rtsp://localhost/sample"));
             byte[] rtspRequestBuffer = Encoding.UTF8.GetBytes(setupRequest.ToString());

--- a/test/unit/net/RTSP/RTSPMessageUnitTest.cs
+++ b/test/unit/net/RTSP/RTSPMessageUnitTest.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RTSPRequestWIthStandardHeadersParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int cseq = 23;
             string session = Guid.NewGuid().ToString();

--- a/test/unit/net/RTSP/RTSPRequestUnitTest.cs
+++ b/test/unit/net/RTSP/RTSPRequestUnitTest.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -36,8 +37,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RTSPRequestWIthStandardHeadersParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int cseq = 23;
             string session = Guid.NewGuid().ToString();

--- a/test/unit/net/RTSP/RTSPTransportHeaderUnitTest.cs
+++ b/test/unit/net/RTSP/RTSPTransportHeaderUnitTest.cs
@@ -13,6 +13,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -33,8 +34,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RTSPTransportHeaderParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string header = "RTP/AVP;unicast;destination=192.168.33.170;source=192.168.33.103;client_port=61132-61133;server_port=6970-6971";
 
@@ -54,8 +55,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RTSPTransportHeaderToStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var transportHeader = new RTSPTransportHeader() { Destination = "192.168.33.170", Source = "192.168.33.103", ClientRTPPortRange = "61132-61133", ServerRTPPortRange = "6970-6971" };
 

--- a/test/unit/net/SCTP/SctpAssociationUnitTest.cs
+++ b/test/unit/net/SCTP/SctpAssociationUnitTest.cs
@@ -20,6 +20,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -40,8 +41,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task ConnectAssociations()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             BlockingCollection<byte[]> _aOut = new BlockingCollection<byte[]>();
             BlockingCollection<byte[]> _bOut = new BlockingCollection<byte[]>();
@@ -98,8 +99,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task SendDataChunk()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             (var aAssoc, var bAssoc) = AssociationTestHelper.GetConnectedAssociations(logger, 1400);
             
@@ -126,8 +127,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task SendFragmentedDataChunk()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Setting a very small MTU to force the sending association to use fragmented data chunks.
             ushort dummyMTU = 4;
@@ -157,8 +158,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task SendLargeFragmentedDataChunk()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             // Setting a very small MTU to force the sending association to use fragmented data chunks.
             (var aAssoc, var bAssoc) = AssociationTestHelper.GetConnectedAssociations(logger, 1400);

--- a/test/unit/net/SCTP/SctpChunkUnitTest.cs
+++ b/test/unit/net/SCTP/SctpChunkUnitTest.cs
@@ -16,6 +16,7 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -35,8 +36,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripHeartBeatChunk()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SctpChunk heartbeatChunk = new SctpChunk(SctpChunkType.HEARTBEAT)
             {

--- a/test/unit/net/SCTP/SctpHeaderUnitTest.cs
+++ b/test/unit/net/SCTP/SctpHeaderUnitTest.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -33,8 +34,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundtripSctpHeader()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             ushort srcPort = 7;
             ushort dstPort = 8888;

--- a/test/unit/net/SCTP/SctpPacketUnitTest.cs
+++ b/test/unit/net/SCTP/SctpPacketUnitTest.cs
@@ -16,6 +16,7 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -395,8 +396,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseUsrSctpAbortPacket()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = {
                 0x00, 0x07, 0x11, 0x5c, 0x93, 0xc9, 0xd9, 0x8a, 0x19, 0x82, 0x31, 0xc1, 0x06, 0x00, 0x00, 0x3b,

--- a/test/unit/net/SCTP/SctpTransportUnitTest.cs
+++ b/test/unit/net/SCTP/SctpTransportUnitTest.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using TinyJson;
 using Xunit;
 
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetInitAckPacket()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var sctpTransport = new MockSctpTransport();
 

--- a/test/unit/net/SCTP/SctpUnitTest.cs
+++ b/test/unit/net/SCTP/SctpUnitTest.cs
@@ -12,6 +12,7 @@
 
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -32,8 +33,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundTripDataChannelOpenPacketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //var dataChanOpen = new DataChannelOpen("label");
             //byte[] pkt = dataChanOpen.getBytes();
@@ -53,8 +54,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundTripDataChannelOpenChunkNoPaddingUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DataChunk dcopen = DataChunk.mkDataChannelOpen("1234");
             //int chunkLength = dcopen.getLength();
@@ -83,8 +84,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundTripDataChannelOpenChunkOneBytePaddingUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DataChunk dcopen = DataChunk.mkDataChannelOpen("123");
             //int chunkLength = dcopen.getLength();
@@ -114,8 +115,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RoundTripDataChannelOpenChunkThreeBytesPaddingUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DataChunk dcopen = DataChunk.mkDataChannelOpen("12356");
             //int chunkLength = dcopen.getLength();

--- a/test/unit/net/SDP/KeyParameterUnitTest.cs
+++ b/test/unit/net/SDP/KeyParameterUnitTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -20,8 +21,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void KeySaltBase64Test()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.KeyParameter keyParameter = KeyParameterFactory.Create("ĀĀ\0\0\0\0\0\0\0\0\0\0\0\0\0\0", "ĀĀĀ\0\0\0\0\0\0\0\0\0\0\0");
             Assert.NotNull((object)keyParameter);
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void LifeTimeTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.KeyParameter keyParameter = KeyParameterFactory.Create("ĀĀ\0\0\0\0\0\0\0\0\0\0\0\0\0\0", "ĀĀĀ\0\0\0\0\0\0\0\0\0\0\0");
             Assert.Throws<ArgumentOutOfRangeException>(() => keyParameter.LifeTime = 0);
@@ -60,8 +61,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void LifeTimeStringTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.KeyParameter keyParameter = KeyParameterFactory.Create("ĀĀ\0\0\0\0\0\0\0\0\0\0\0\0\0\0", "ĀĀĀ\0\0\0\0\0\0\0\0\0\0\0");
             Assert.Throws<ArgumentException>(() => keyParameter.LifeTimeString = null);
@@ -92,8 +93,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.KeyParameter kp1 = SDPSecurityDescription.KeyParameter.Parse("inline:MTIzNDU2Nzg5QUJDREUwMTIzNDU2Nzg5QUJjZGVm|2^20|1:4");
             Assert.Equal("inline:MTIzNDU2Nzg5QUJDREUwMTIzNDU2Nzg5QUJjZGVm|2^20|1:4", kp1.ToString());

--- a/test/unit/net/SDP/SDPAudioVideoMediaFormatUnitTest.cs
+++ b/test/unit/net/SDP/SDPAudioVideoMediaFormatUnitTest.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -38,8 +39,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void MapWellKnownAudioFormatUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPAudioVideoMediaFormat pcmu = new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU);
 
@@ -57,8 +58,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void MapDynamicAv1VideoFormatUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var av1 = new VideoFormat(VideoCodecsEnum.AV1, 96);
             var sdpFormat = new SDPAudioVideoMediaFormat(av1);

--- a/test/unit/net/SDP/SDPMediaAnnouncementUnitTests.cs
+++ b/test/unit/net/SDP/SDPMediaAnnouncementUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -22,8 +23,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void InvalidPortInRemoteOfferTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var remoteOffer = new SDP();
 

--- a/test/unit/net/SDP/SDPSecurityDescriptionUnitTest.cs
+++ b/test/unit/net/SDP/SDPSecurityDescriptionUnitTest.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.SIP;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -21,8 +22,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription c1 = SDPSecurityDescription.Parse("a=crypto:1 AES_CM_128_HMAC_SHA1_80  inline:WVNfX19zZW1jdGwgKCkgewkyMjA7fQp9CnVubGVz|2^20|1:4    FEC_ORDER=FEC_SRTP");
             Assert.Equal("a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:WVNfX19zZW1jdGwgKCkgewkyMjA7fQp9CnVubGVz|2^20|1:4 FEC_ORDER=FEC_SRTP", c1.ToString());
@@ -160,8 +161,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseCryptoSIPMessage()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
             "INVITE sip:33@10.2.0.110:5061;transport=tls SIP/2.0" + CRLF +

--- a/test/unit/net/SDP/SDPUnitTests.cs
+++ b/test/unit/net/SDP/SDPUnitTests.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -36,8 +37,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -70,8 +71,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseBriaSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             string sdpStr = 
                 "v=0" + 
                 "o=- 5 2 IN IP4 10.1.1.2" + m_CRLF +
@@ -100,8 +101,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseTelephoneEventSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 " v=0" + m_CRLF +
@@ -135,8 +136,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseBadFormatBriaSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
             string sdpStr = " v=0\r\no=- 5 2 IN IP4 10.1.1.2\r\n s=CounterPath Bria\r\nc=IN IP4 144.137.16.240\r\nt=0 0\r\n m=audio 34640 RTP/AVP 0 8 101\r\na=sendrecv\r\na=rtpmap:101 telephone-event/8000\r\na=fmtp:101 0-15\r\na=alt:1 1 : STu/ZtOu 7hiLQmUp 10.1.1.2 34640\r\n";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
@@ -150,8 +151,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseICESessionAttributesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
               "v=0" + m_CRLF +
@@ -183,8 +184,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseMultipleMediaAnnouncementsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr = "v=0" + m_CRLF +
                 "o=- 13064410510996677 3 IN IP4 10.1.1.2" + m_CRLF +
@@ -221,8 +222,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseAudioAndVideoConnectionsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr = "v=0" + m_CRLF +
                 "o=Cisco-SIPUA 6396 0 IN IP4 101.180.234.134" + m_CRLF +
@@ -254,8 +255,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseMediaTypeImageUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr = "v=0" + m_CRLF +
                 "o=OfficeMasterDirectSIP 806542878 806542879 IN IP4 10.2.0.110" + m_CRLF +
@@ -283,8 +284,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseEdgeBrowserSdpUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr = "v=0" + m_CRLF +
                 "o=- 8028343537520473029 0 IN IP4 127.0.0.1" + m_CRLF +
@@ -330,8 +331,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseIPv6SDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr = "v=0" + m_CRLF +
                 "o=nasa1 971731711378798081 0 IN IP6 2201:056D::112E:144A:1E24" + m_CRLF +
@@ -358,8 +359,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetFirstMediaOfferRTPSocketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -387,8 +388,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetFirstMediaOfferIPv6RTPSocketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr = "v=0" + m_CRLF +
                 "o=nasa1 971731711378798081 0 IN IP6 2201:056D::112E:144A:1E24" + m_CRLF +
@@ -413,8 +414,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetFirstMediaSteamStatusUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -442,8 +443,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetFirstMediaSteamStatusNonDefaultUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -470,8 +471,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetSessionMediaSteamStatusUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -500,8 +501,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetAnnMediaSteamDiffToStreamStatusUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -531,8 +532,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GetAnnMediaSteamNotreamStatusAttributesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -559,8 +560,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void AnnouncementMediaSteamStatuRoundtripUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -591,8 +592,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void SessionMediaSteamStatusRoundTripUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -623,8 +624,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseWebRtcSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -686,8 +687,8 @@ a=rtpmap:100 VP8/90000";
         [Fact]
         public void ParseChromeOfferSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -878,8 +879,8 @@ a=sendrecv";
         [Fact]
         public void ParseDataChannelOnlyOfferSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -920,8 +921,8 @@ a=max-message-size:262144";
         [Fact]
         public void ParsePionDataChannelOnlyOfferSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -957,8 +958,8 @@ a=sctpmap:5000 webrtc-datachannel 1024";
         [Fact]
         public void ParseMediaFormatWithHyphenNameUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -992,8 +993,8 @@ a=sendrecv";
         [Fact]
         public void ParseMediaFormatWithFowardSlashUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -1023,8 +1024,8 @@ a=sendrecv";
         [Fact]
         public void ParseOfferWithFmtpPreceedingRtmapTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -1063,8 +1064,8 @@ a=ssrc:2404235415 cname:{7c06c5db-d3db-4891-b729-df4919014c3f}";
         [Fact]
         public void ParseMcpttTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -1097,8 +1098,8 @@ a=fmtp:MCPTT mc_queueing;mc_priority=4";
         [Fact]
         public void DescriptionAttributeRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -1139,8 +1140,8 @@ a=sendrecv
         [Fact]
         public void TIASBandwidthAttributeRoundTripTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -1177,8 +1178,8 @@ a=sendrecv
         [Fact]
         public void ParseFireFoxOfferSDPUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 @"v=0
@@ -1268,8 +1269,8 @@ a=ssrc-group:FID 3366495178 777490417";
         [Fact]
         public void AnnoucementMediaCheckTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +
@@ -1299,7 +1300,7 @@ a=ssrc-group:FID 3366495178 777490417";
         [Fact]
         public void Media_Formats_Order_Test()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var sdp = new SDP();
 
@@ -1331,7 +1332,7 @@ a=ssrc-group:FID 3366495178 777490417";
         public void Parse_Number_Of_Ports_Unit_Test()
         {
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
                 "v=0" + m_CRLF +

--- a/test/unit/net/SDP/SessionParameterUnitTest.cs
+++ b/test/unit/net/SDP/SessionParameterUnitTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -18,8 +19,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ConstructorTestEnumParams()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             foreach (var e in Enum.GetValues(typeof(SDPSecurityDescription.SessionParameter.SrtpSessionParams)))
             {
@@ -32,8 +33,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ConstructorTestFecKey()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.fec_key);
             Assert.StartsWith(SDPSecurityDescription.SessionParameter.FEC_KEY_PREFIX, sessionParameter.ToString());
@@ -41,8 +42,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ConstructorTestFecOrder()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.fec_order);
             Assert.StartsWith(SDPSecurityDescription.SessionParameter.FEC_ORDER_PREFIX, sessionParameter.ToString());
@@ -50,8 +51,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ConstructorTestWsh()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.wsh);
             Assert.StartsWith(SDPSecurityDescription.SessionParameter.WSH_PREFIX, sessionParameter.ToString());
@@ -59,8 +60,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ConstructorTestKdr()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.kdr);
             Assert.StartsWith(SDPSecurityDescription.SessionParameter.KDR_PREFIX, sessionParameter.ToString());
@@ -68,8 +69,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ConstructorTestUNEnums()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.UNAUTHENTICATED_SRTP);
             Assert.Equal(SDPSecurityDescription.SessionParameter.SrtpSessionParams.UNAUTHENTICATED_SRTP.ToString(), sessionParameter.ToString());
@@ -82,8 +83,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void WshTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.wsh);
             try
@@ -119,8 +120,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void KdrTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameter = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.kdr);
             try
@@ -143,8 +144,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             SDPSecurityDescription.SessionParameter sessionParameterKdr = SessionParameterFactory.Create(SDPSecurityDescription.SessionParameter.SrtpSessionParams.kdr, 4);
             string sKdr = sessionParameterKdr.ToString();

--- a/test/unit/net/STUN/STUNClientUnitTest.cs
+++ b/test/unit/net/STUN/STUNClientUnitTest.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -34,8 +35,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact(Skip = "STUN server isn't kept running all the time.")]
         public void GetPublicIPStunClientTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var publicIP = STUNClient.GetPublicIPAddress("stun.sipsorcery.com");
 

--- a/test/unit/net/STUN/STUNUnitTest.cs
+++ b/test/unit/net/STUN/STUNUnitTest.cs
@@ -15,6 +15,7 @@ using System.Net;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -35,8 +36,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseWebRTCSTUNRequestTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] stunReq = new byte[]{ 0x00, 0x01, 0x00, 0x60, 0x21, 0x12, 0xa4, 0x42, 0x66, 0x55, 0x55, 0x43, 0x4b, 0x48, 0x74, 0x73, 0x68, 0x4e, 0x71, 0x56,
                                          // Att1: 
@@ -68,8 +69,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void BindingRequestWithUsernameToBytesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNMessage initMessage = new STUNMessage(STUNMessageTypesEnum.BindingRequest);
             initMessage.AddUsernameAttribute("someusernamex");
@@ -86,8 +87,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseWebRTCSTUNResponseTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] stunResp = new byte[]{ 0x01, 0x01, 0x00, 0x2c, 0x21, 0x12, 0xa4, 0x42, 0x6a, 0x45, 0x38, 0x2b, 0x4e, 0x5a, 0x4b, 0x50,
                     0x64, 0x31, 0x70, 0x38, 0x00, 0x20, 0x00, 0x08, 0x00, 0x01, 0xe0, 0xda, 0xe1, 0xba, 0x85, 0x3f,
@@ -125,8 +126,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseXORMappedAddressAttributeTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] stunAttribute = new byte[] { 0x00, 0x01, 0xe0, 0xda, 0xe1, 0xba, 0x85, 0x3f };
 
@@ -142,8 +143,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void PutXORMappedAddressAttributeToBufferTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNXORAddressAttribute xorAddressAttribute = new STUNXORAddressAttribute(STUNAttributeTypesEnum.XORMappedAddress, 49608, IPAddress.Parse("192.168.33.125"), null);
 
@@ -170,8 +171,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void PutResponseToBufferTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNMessage stunResponse = new STUNMessage(STUNMessageTypesEnum.BindingSuccessResponse);
             stunResponse.Header.TransactionId = Guid.NewGuid().ToByteArray().Take(12).ToArray();
@@ -188,8 +189,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void TestMessageIntegrityAttributeForBindingRequest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] stunReq = new byte[]{
             0x00, 0x01, 0x00, 0x60, 0x21, 0x12, 0xa4, 0x42, 0x69, 0x64, 0x38, 0x2b, 0x4c, 0x45, 0x44, 0x57,
@@ -227,8 +228,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseCoturnSTUNResponseTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] stunResp = new byte[]{ 0x01, 0x01, 0x00, 0x44, 0x21, 0x12, 0xa4, 0x42, 0x6b, 0x4c, 0xf3, 0x18, 0xd0, 0xa7, 0xf5, 0x40,
                     0x97, 0x30, 0x3a, 0x27, 0x00, 0x20, 0x00, 0x08, 0x00, 0x01, 0x9e, 0x90, 0x1a, 0xb5, 0x08, 0xf3,
@@ -279,8 +280,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void GenerateHmacAndFingerprintTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string icePassword = "SKYKPPYLTZOAVCLTGHDUODANRKSPOVQVKXJULOGG";
 
@@ -331,8 +332,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void IntegrityCheckUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string icePassword = "SKYKPPYLTZOAVCLTGHDUODANRKSPOVQVKXJULOGG";
 
@@ -358,8 +359,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void KnownSTUNBindingRequestIntegrityCheckUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string icePassword = "DVJSBHBUIBFSZFKVECMPRISQ";
 
@@ -424,8 +425,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseStunMessageUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = TypeExtensions.ParseHexStr(
                 "000100542112a4424f585055434d4e54425a4f4a00060015435242617a4d64534248616a494774433a45544d5300000000240004ff200000802a000852c0aba195cf65190025000000080014b05baf6be589d5ab202e9153547457eb1a20244c8028000464f37f6c");

--- a/test/unit/net/STUN/STUNUriUnitTest.cs
+++ b/test/unit/net/STUN/STUNUriUnitTest.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -34,8 +35,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseNoSchemeNoPortTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             bool result = STUNUri.TryParse("stun.sipsorcery.com", out var stunUri);
 
@@ -52,8 +53,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseNoSchemeTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             bool result = STUNUri.TryParse("stun.sipsorcery.com:4478", out var stunUri);
 
@@ -70,8 +71,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseWithSchemeAndPortTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             bool result = STUNUri.TryParse("stuns:stun.sipsorcery.com:4478", out var stunUri);
 
@@ -88,8 +89,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseWithIPv4AddressTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             bool result = STUNUri.TryParse("stuns:192.168.0.100:4478", out var stunUri);
 
@@ -106,8 +107,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void ParseWithIPv6AddressTestMethod()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             bool result = STUNUri.TryParse("turn:[::1]:14478", out var stunUri);
 

--- a/test/unit/net/TURN/TurnServerUnitTest.cs
+++ b/test/unit/net/TURN/TurnServerUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: TurnServerUnitTest.cs
 //
 // Description: Unit tests for TurnServer (RFC 5766).
@@ -21,6 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Net.UnitTests
@@ -160,7 +161,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task AllocateReturns401WithoutCredentials()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -200,7 +201,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task AuthenticatedAllocateSucceeds()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -245,7 +246,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task WrongPasswordFails()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -277,7 +278,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task RefreshExtendsLifetime()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -312,7 +313,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task RefreshZeroDeletesAllocation()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -340,7 +341,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task CreatePermissionSucceeds()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -368,7 +369,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task ChannelBindSucceeds()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -405,7 +406,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task SendIndicationRelaysData()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -449,7 +450,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task ChannelDataRelaysViaBinding()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -500,7 +501,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task UdpRelayBackToClient()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -573,7 +574,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task BindingRequestReturnsAddress()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             var (server, port) = CreateTurnServer();
             using var client = await ConnectTcpClient(port);
@@ -598,7 +599,7 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public async Task ExpiredAllocationCleanedUp()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
 
             // Create server with very short lifetime
             int testPort;

--- a/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: RTCPeerConnectionRenegotiationUnitTest.cs
 //
 // Description: Unit tests for WebRTC SDP renegotiation — adding tracks after
@@ -15,6 +15,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
 
@@ -41,8 +42,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RenegotiationOfferPreservesVideoMLineAndAppendsAudio()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPeerConnection offerer = new RTCPeerConnection(null);
             var videoTrack = new MediaStreamTrack(
@@ -122,8 +123,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RenegotiationOfferPreservesAudioMLineAndAppendsVideo()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPeerConnection offerer = new RTCPeerConnection(null);
             offerer.addTrack(new MediaStreamTrack(
@@ -190,8 +191,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void RemoteDescriptionPreservedAfterAddTrack()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTCPeerConnection offerer = new RTCPeerConnection(null);
             offerer.addTrack(new MediaStreamTrack(
@@ -250,8 +251,8 @@ namespace SIPSorcery.Net.UnitTests
         [Fact]
         public void MultiplexedDestinationEndPointPreservedOnRenegotiation()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             RTPSession rtpSession = new RTPSession(new RtpSessionConfig
             {

--- a/test/unit/sys/BufferUtilsUnitTest.cs
+++ b/test/unit/sys/BufferUtilsUnitTest.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.UnitTests
@@ -29,8 +30,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void HasStringUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] sample = Encoding.ASCII.GetBytes("The quick brown fox jumped over...");
 
@@ -42,8 +43,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void NotBeforeEndUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] sample = Encoding.ASCII.GetBytes("The quick brown fox jumped over...");
 
@@ -55,8 +56,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetStringPositionWithEmptyFindUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:Blue Face SIP/2.0\r\n" +
@@ -81,8 +82,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetStringIndexUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:Blue Face SIP/2.0\r\n" +
@@ -107,8 +108,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetStringIndexSIPInviteUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                  "INVITE sip:12345@sip.domain.com:5060;TCID-0 SIP/2.0\r\n" +
@@ -152,8 +153,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetStringIndexNotFoundUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
                 "REGISTER sip:Blue Face SIP/2.0\r\n" +
@@ -178,8 +179,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void HexStrUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = new byte[] { 1, 2, 3 };
 
@@ -191,8 +192,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void HexStrWithSeparatorUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = new byte[] { 1, 2, 3 };
 

--- a/test/unit/sys/TypeExtensionsUnitTest.cs
+++ b/test/unit/sys/TypeExtensionsUnitTest.cs
@@ -17,6 +17,7 @@ using System;
 using System.Net;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.UnitTests
@@ -34,8 +35,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void TrimTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             String myString = null;
 
@@ -45,8 +46,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ZeroBytesTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             String myString = Encoding.UTF8.GetString(new byte[] { 0x00, 0x00, 0x00, 0x00 });
 
@@ -58,8 +59,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void HexStrTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = { 0x00, 0x01, 0x02, 0x03 };
 
@@ -71,8 +72,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ToUnixTimeTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var dateTime = new DateTime(2025, 2, 12, 23, 39, 0, DateTimeKind.Utc);
             var unixTime = dateTime.ToUnixTime();
@@ -85,8 +86,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ToUnixTimeAfter2038Test()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var dateTime = new DateTime(2060, 2, 13, 22, 54, 54, DateTimeKind.Utc);
             var unixTime = dateTime.ToUnixTime();
@@ -99,8 +100,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ParseHexStrTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] buffer = TypeExtensions.ParseHexStr("00010203");
 

--- a/test/unit/sys/crypto/CryptoUnitTest.cs
+++ b/test/unit/sys/crypto/CryptoUnitTest.cs
@@ -10,6 +10,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.UnitTests
@@ -27,8 +28,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void SampleTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int initRandomNumber = Crypto.GetRandomInt();
             logger.LogDebug("Random int = {initRandomNumber}.", initRandomNumber);
@@ -38,8 +39,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CallRandomNumberWebServiceUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             logger.LogDebug("Random number = {RandomNumber}", Crypto.GetRandomInt());
 
@@ -49,8 +50,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetRandomNumberTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             logger.LogDebug("Random number = {RandomNumber}", Crypto.GetRandomInt());
 
@@ -60,8 +61,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetOneHundredRandomNumbersTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             for (int index = 0; index < 100; index++)
             {

--- a/test/unit/sys/net/IPSocketUnitTest.cs
+++ b/test/unit/sys/net/IPSocketUnitTest.cs
@@ -11,6 +11,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.UnitTests
@@ -28,8 +29,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ParsePortFromSocketTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             int port = IPSocket.ParsePortFromSocket("localhost:5060");
             logger.LogDebug("port={Port}", port);
@@ -39,8 +40,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ParseHostFromSocketTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string host = IPSocket.ParseHostFromSocket("localhost:5060");
             logger.LogDebug("host={Host}", host);
@@ -50,8 +51,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void Test172IPRangeIsPrivate()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Assert.False(IPSocket.IsPrivateAddress("172.15.1.1"), "Public IP address was mistakenly identified as private.");
             Assert.True(IPSocket.IsPrivateAddress("172.16.1.1"), "Private IP address was not correctly identified.");
@@ -62,8 +63,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ParseTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string host = null;
             int port = 0;
@@ -159,8 +160,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void ParseEndpointTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             System.Net.IPEndPoint ep = null;
 

--- a/test/unit/sys/net/NetServicesUnitTest.cs
+++ b/test/unit/sys/net/NetServicesUnitTest.cs
@@ -22,6 +22,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.UnitTests
@@ -45,8 +46,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetLocalIPAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localAddress = NetServices.GetLocalAddressForRemote(IPAddress.Parse("192.168.11.48"));
             Assert.NotNull(localAddress);
@@ -60,8 +61,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetLocalForLoopbackAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localAddress = NetServices.GetLocalAddressForRemote(IPAddress.Loopback);
             Assert.Equal(IPAddress.Loopback, localAddress);
@@ -75,8 +76,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetLocalForInternetAdressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localAddress = NetServices.GetLocalAddressForRemote(IPAddress.Parse("67.222.131.147"));
             Assert.NotNull(localAddress);
@@ -91,8 +92,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Trait("Category", "IPv6")]
         public void GetLocalForIPv6LoopbackAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (Socket.OSSupportsIPv6)
             {
@@ -114,8 +115,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Trait("Category", "IPv6")]
         public void GetLocalIPv6AddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (Socket.OSSupportsIPv6)
             {
@@ -149,8 +150,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetAllLocalIPAddressesUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localAddresses = NetServices.LocalIPAddresses;
             Assert.NotEmpty(localAddresses);
@@ -167,8 +168,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetInternetAddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localInternetAddresses = NetServices.InternetDefaultAddress;
             Assert.NotNull(localInternetAddresses);
@@ -182,8 +183,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetInternetIPv6AddressUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (Socket.OSSupportsIPv6)
             {
@@ -206,8 +207,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CreateRtpAndControlSocketsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Socket rtpSocket = null;
             Socket controlSocket = null;
@@ -228,8 +229,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CreateRtpAndControlSocketsOnIP4AnyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             Socket rtpSocket = null;
             Socket controlSocket = null;
@@ -250,8 +251,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CreateRtpAndControlSocketsOnIP6AnyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (Socket.OSSupportsIPv6)
             {
@@ -275,8 +276,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CreateRtpAndControlMultipleSocketsUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             List<Socket> sockets = new List<Socket>();
 
@@ -310,8 +311,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CheckSupportsDualModeIPv4PacketInfoUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -341,8 +342,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CheckCreateSocketFailsForInUseSocketUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (!Socket.OSSupportsIPv6)
             {
@@ -396,8 +397,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CheckFailsOnDuplicateForIP4AnyThenIPv6AnyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -435,8 +436,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void CheckFailsOnDuplicateForIP6AnyThenIPv4AnyUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -469,8 +470,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void GetIPAddressesForInterfaceUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var localAddresses = NetServices.GetLocalAddressesOnInterface(null);
             Assert.NotEmpty(localAddresses);

--- a/test/unit/sys/net/PortRangeUnitTest.cs
+++ b/test/unit/sys/net/PortRangeUnitTest.cs
@@ -43,8 +43,8 @@ namespace SIPSorcery.UnitTests.sys.net
         [Fact]
         public void GetSequentialPortUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var portRange = new PortRange(6000, 6005);
             Assert.Equal(6000, portRange.GetNextPort());
@@ -60,8 +60,8 @@ namespace SIPSorcery.UnitTests.sys.net
         [Fact]
         public void GetShuffledPortsEvenlyDistributedUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             var portRange = new PortRange(6000, 6011, shuffle: true);
             var portCount = new Dictionary<int, int>();

--- a/test/unit/sys/net/RawSocketUnitTest.cs
+++ b/test/unit/sys/net/RawSocketUnitTest.cs
@@ -12,6 +12,7 @@
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
 using Xunit;
 
 namespace SIPSorcery.Sys.UnitTests
@@ -29,8 +30,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact]
         public void IPHeaderConstructionUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             IPv4Header header = new IPv4Header(ProtocolType.Udp, 4567, IPAddress.Parse("127.0.0.1"), IPAddress.Parse("127.0.0.1"));
             byte[] headerData = header.GetBytes();
@@ -54,8 +55,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact(Skip = "Will only work on Win10 or where raw socket privileges have been explicitly granted.")]
         public void PreconstructedIPPacketSendUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] ipPacket = new byte[] {
                      // IP Header.
@@ -90,8 +91,8 @@ namespace SIPSorcery.Sys.UnitTests
         [Fact(Skip = "Will only work on Win10 or where raw socket privileges have been explicitly granted.")]
         public void IPEmptyPacketSendUnitTest()
         {
-            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             UDPPacket udpPacket = new UDPPacket(4001, 4001, new byte[] { 0x1, 0x2, 0x3, 0x4 });
             IPv4Header header = new IPv4Header(ProtocolType.Udp, 7890, IPAddress.Parse("127.0.0.1"), IPAddress.Parse("127.0.0.1"));


### PR DESCRIPTION
## Summary

This updates test logging to remove reflection-based method name lookup and replaces the Serilog-based xUnit logging setup with `MartinCostello.Logging.XUnit`.

Part of #1434

## Why

Using `[CallerMemberName]` is a better fit for test log messages and scopes than `System.Reflection.MethodBase.GetCurrentMethod()` because the compiler supplies the caller name directly. That avoids reflection overhead, removes nullable/reflection-specific handling, and keeps the code simpler while still producing the same method names in test output.

`MartinCostello.Logging.XUnit` is also a lighter-weight option for test logging. It plugs directly into `Microsoft.Extensions.Logging` and `ITestOutputHelper`, so the tests no longer need a full Serilog logger configuration plus xUnit and console sinks just to write test output. This reduces test-only dependencies and keeps logging setup focused on the xUnit test scenario.

## Changes

- Added caller-member-name helpers for test method logging.
- Replaced reflection calls in test log messages and scopes.
- Switched affected test logger factories from Serilog to `MartinCostello.Logging.XUnit`.
- Updated test project package references to remove Serilog test logging packages.