### PR TITLE
Use explicit string comparisons in tests and examples

### DIFF
--- a/examples/AzureExamples/TextToPcm/Program.cs
+++ b/examples/AzureExamples/TextToPcm/Program.cs
@@ -70,7 +70,7 @@ class Program
                     Console.WriteLine($"Speech synthesized to speaker for text [{text}]");
 
                     var buffer = ttsOutStream.GetPcmBuffer();
-                    string saveFilename = DateTime.Now.Ticks.ToString() + ".pcm16k";
+                    string saveFilename = $"{DateTime.Now.Ticks}.pcm16k";
 
                     using (StreamWriter sw = new StreamWriter(saveFilename))
                     {

--- a/examples/OpenAIExamples/AliceAndBob/AudioScope/AudioScopeOpenGL.cs
+++ b/examples/OpenAIExamples/AliceAndBob/AudioScope/AudioScopeOpenGL.cs
@@ -93,7 +93,7 @@ namespace AudioScope
             //  going to throw an exception.
             if (_prog.GetLinkStatus(gl) == false)
             {
-                throw new SharpGL.Shaders.ShaderCompilationException(string.Format("Failed to link shader program with ID {0}.", _prog.ShaderProgramObject), _prog.GetInfoLog(gl));
+                throw new SharpGL.Shaders.ShaderCompilationException($"Failed to link shader program with ID {_prog.ShaderProgramObject}.", _prog.GetInfoLog(gl));
             }
 
             // Load clear program.
@@ -119,7 +119,7 @@ namespace AudioScope
             // going to throw an exception.
             if (_clearProg.GetLinkStatus(gl) == false)
             {
-                throw new SharpGL.Shaders.ShaderCompilationException(string.Format("Failed to link the clear shader program with ID {0}.", _clearProg.ShaderProgramObject), _clearProg.GetInfoLog(gl));
+                throw new SharpGL.Shaders.ShaderCompilationException($"Failed to link the clear shader program with ID {_clearProg.ShaderProgramObject}.", _clearProg.GetInfoLog(gl));
             }
 
             _clearRectangle = new float[] { -1.0f, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f };

--- a/examples/SIPExamples/SIPProxy/Program.cs
+++ b/examples/SIPExamples/SIPProxy/Program.cs
@@ -129,7 +129,7 @@ namespace SIPSorcery.SIPProxy
             }
             catch (Exception excp)
             {
-                Console.WriteLine("Exception Main. " + excp);
+                Console.WriteLine($"Exception Main. {excp}");
             }
         }
 

--- a/examples/Softphone/Signalling/SIPClient.cs
+++ b/examples/Softphone/Signalling/SIPClient.cs
@@ -117,7 +117,7 @@ namespace SIPSorcery.SoftPhone
             else
             {
                 // This call will use the pre-configured SIP account.
-                callURI = SIPURI.ParseSIPURIRelaxed(destination + "@" + m_sipServer);
+                callURI = SIPURI.ParseSIPURIRelaxed($"{destination}@{m_sipServer}");
                 sipUsername = m_sipUsername;
                 sipPassword = m_sipPassword;
                 fromHeader = (new SIPFromHeader(m_sipFromName, new SIPURI(m_sipUsername, m_sipServer, null), null)).ToString();
@@ -151,7 +151,7 @@ namespace SIPSorcery.SoftPhone
         /// </summary>
         public void Cancel()
         {
-            StatusMessage(this, "Cancelling SIP call to " + m_userAgent.CallDescriptor?.Uri + ".");
+            StatusMessage(this, $"Cancelling SIP call to {m_userAgent.CallDescriptor?.Uri}.");
             m_userAgent.Cancel();
         }
 
@@ -215,7 +215,7 @@ namespace SIPSorcery.SoftPhone
         /// Puts the remote call party on hold.
         /// </summary>
         public async Task PutOnHold()
-        { 
+        {
             await MediaSession.PutOnHold();
             m_userAgent.PutOnHold();
             StatusMessage(this, "Local party put on hold");
@@ -319,7 +319,7 @@ namespace SIPSorcery.SoftPhone
         /// </summary>
         private void CallTrying(ISIPClientUserAgent uac, SIPResponse sipResponse)
         {
-            StatusMessage(this, "Call trying: " + sipResponse.StatusCode + " " + sipResponse.ReasonPhrase + ".");
+            StatusMessage(this, $"Call trying: {sipResponse.StatusCode} {sipResponse.ReasonPhrase}.");
         }
 
         /// <summary>
@@ -327,7 +327,7 @@ namespace SIPSorcery.SoftPhone
         /// </summary>
         private void CallRinging(ISIPClientUserAgent uac, SIPResponse sipResponse)
         {
-            StatusMessage(this, "Call ringing: " + sipResponse.StatusCode + " " + sipResponse.ReasonPhrase + ".");
+            StatusMessage(this, $"Call ringing: {sipResponse.StatusCode} {sipResponse.ReasonPhrase}.");
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace SIPSorcery.SoftPhone
         /// </summary>
         private void CallFailed(ISIPClientUserAgent uac, string errorMessage, SIPResponse failureResponse)
         {
-            StatusMessage(this, "Call failed: " + errorMessage + ".");
+            StatusMessage(this, $"Call failed: {errorMessage}.");
             CallFinished(null);
         }
 
@@ -346,7 +346,7 @@ namespace SIPSorcery.SoftPhone
         /// <param name="sipResponse">The SIP answer response received from the remote party.</param>
         private void CallAnswered(ISIPClientUserAgent uac, SIPResponse sipResponse)
         {
-            StatusMessage(this, "Call answered: " + sipResponse.StatusCode + " " + sipResponse.ReasonPhrase + ".");
+            StatusMessage(this, $"Call answered: {sipResponse.StatusCode} {sipResponse.ReasonPhrase}.");
             CallAnswer?.Invoke(this);
         }
 

--- a/examples/WebRTCExamples/FfmpegToWebRTC/Program.cs
+++ b/examples/WebRTCExamples/FfmpegToWebRTC/Program.cs
@@ -6,11 +6,11 @@
 //
 // Author(s):
 // Aaron Clauson (aaron@sipsorcery.com)
-// 
+//
 // History:
 // 08 Jul 2020	Aaron Clauson	Created, Dublin, Ireland.
 //
-// License: 
+// License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
@@ -89,18 +89,16 @@ namespace SIPSorcery.Examples
 
             if (args?.Length > 0)
             {
-                switch(args[0].ToLower())
+                if (string.Equals(args[0], FFMPEG_VP8_CODEC, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(args[0], FFMPEG_VP9_CODEC, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(args[0], FFMPEG_H264_CODEC, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(args[0], FFMPEG_H265_CODEC, StringComparison.OrdinalIgnoreCase))
                 {
-                    case FFMPEG_VP8_CODEC:
-                    case FFMPEG_VP9_CODEC:
-                    case FFMPEG_H264_CODEC:
-                    case FFMPEG_H265_CODEC:
-                        videoCodec = args[0].ToLower();
-                        break;
-
-                    default:
-                        Console.WriteLine($"Video codec option not recognised. Valid values are {FFMPEG_VP8_CODEC}, {FFMPEG_VP9_CODEC} and {FFMPEG_H264_CODEC}. Using {videoCodec}.");
-                        break;
+                    videoCodec = args[0].ToLower();
+                }
+                else
+                {
+                    Console.WriteLine($"Video codec option not recognised. Valid values are {FFMPEG_VP8_CODEC}, {FFMPEG_VP9_CODEC} and {FFMPEG_H264_CODEC}. Using {videoCodec}.");
                 }
             }
 
@@ -108,7 +106,7 @@ namespace SIPSorcery.Examples
 
             logger = AddConsoleLogger();
 
-            string ffmpegCommand = String.Format(FFMPEG_DEFAULT_COMMAND, videoCodec, FFMPEG_DEFAULT_RTP_PORT, SSRC_REMOTE_VIDEO, FFMPEG_SDP_FILE);
+            string ffmpegCommand = $"ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=10 {videoCodec} -pix_fmt yuv420p -strict experimental -g 1 -ssrc {SSRC_REMOTE_VIDEO} -f rtp rtp://127.0.0.1:{FFMPEG_DEFAULT_RTP_PORT} -sdp_file {FFMPEG_SDP_FILE}";
 
             // Start web socket.
             Console.WriteLine("Starting web socket server...");
@@ -294,7 +292,7 @@ namespace SIPSorcery.Examples
                 {
                     logger.LogDebug("ICE Candidate: " + message);
 
-                    if (string.IsNullOrWhiteSpace(message) || message.Trim().ToLower() == SDP.END_ICE_CANDIDATES_ATTRIBUTE)
+                    if (string.IsNullOrWhiteSpace(message) || message.AsSpan().Trim().Equals(SDP.END_ICE_CANDIDATES_ATTRIBUTE, StringComparison.OrdinalIgnoreCase))
                     {
                         logger.LogDebug("End of candidates message received.");
                     }

--- a/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/DemuxerConfig.cs
+++ b/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/DemuxerConfig.cs
@@ -47,52 +47,18 @@ namespace RtspToWebRtcRestreamer
                 switch (outputStream)
                 {
                     case StreamsEnum.videoAndAudio:
-                        return String.Format(commandTemplateDic[StreamsEnum.videoAndAudio],
-                            rtspUrl,
-                            vcodec,
-                            videoSsrc,
-                            serverIP,
-                            videoPort,
-                            acodec,
-                            audioSsrc,
-                            audioPort,
-                            sdpPath
-                            );
+                        return $"-use_wallclock_as_timestamps 1 -i {rtspUrl} -map 0:v -c:v {vcodec} -ssrc {videoSsrc} -f rtp rtp://{serverIP}:{videoPort} -map 0:a -c:a {acodec} -ssrc {audioSsrc} -f rtp rtp://{serverIP}:{audioPort}  -sdp_file {sdpPath} -y";
                     case StreamsEnum.videoAndAudioUdp:
-                        return String.Format(commandTemplateDic[StreamsEnum.videoAndAudioUdp],
-                            rtspUrl,
-                            vcodec,
-                            videoSsrc,
-                            serverIP,
-                            videoPort,
-                            acodec,
-                            audioSsrc,
-                            audioPort,
-                            sdpPath
-                            );
+                        return $"-use_wallclock_as_timestamps 1 -rtsp_transport udp -i {rtspUrl} -map 0:v -c:v {vcodec} -ssrc {videoSsrc} -f rtp rtp://{serverIP}:{videoPort} -map 0:a -c:a {acodec} -ssrc {audioSsrc} -f rtp rtp://{serverIP}:{audioPort} -sdp_file {sdpPath} -y";
                     case StreamsEnum.audio:
-                        return String.Format(commandTemplateDic[StreamsEnum.audio],
-                            rtspUrl,                            
-                            acodec,
-                            audioSsrc,
-                            serverIP,
-                            audioPort,
-                            sdpPath
-                            );
+                        return $"-re -i {rtspUrl} -vn -acodec {acodec} -ssrc {audioSsrc} -f rtp rtp://{serverIP}:{audioPort} -sdp_file {sdpPath}";
                     case StreamsEnum.video:
-                        return String.Format(commandTemplateDic[StreamsEnum.video],
-                            rtspUrl,
-                            vcodec,
-                            videoSsrc,
-                            serverIP,
-                            videoPort,
-                            sdpPath
-                            );
+                        return $"-re -i {rtspUrl} -an -vcodec {vcodec} -ssrc {videoSsrc} -f rtp rtp://{serverIP}:{videoPort} -sdp_file {sdpPath}";
                     default:
                         return "";
                 }
-                    
-                
+
+
             }
         }
     }

--- a/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/WebSocketSignalingServer.cs
+++ b/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/WebSocketSignalingServer.cs
@@ -158,7 +158,7 @@ namespace RtspToWebRtcRestreamer
                 {
                     _logger.LogInformation("ICE Candidate: " + message);
 
-                    if (string.IsNullOrWhiteSpace(message) || message.Trim().ToLower() == SDP.END_ICE_CANDIDATES_ATTRIBUTE)
+                    if (string.IsNullOrWhiteSpace(message) || message.AsSpan().Trim().Equals(SDP.END_ICE_CANDIDATES_ATTRIBUTE, StringComparison.OrdinalIgnoreCase))
                     {
                         _logger.LogDebug("End of candidates message received.");
                     }

--- a/examples/WebRTCExamples/UnityVideoSink/Assets/Scripts/PlayerController.cs
+++ b/examples/WebRTCExamples/UnityVideoSink/Assets/Scripts/PlayerController.cs
@@ -47,7 +47,7 @@ public class PlayerController : MonoBehaviour
 
     void SetCountText()
     {
-        countText.text = "Count: " + count.ToString();
+        countText.text = $"Count: {count.ToString()}";
 
         if (count >= 10)
         {

--- a/examples/WebRTCExamples/UnityVideoSink/Assets/Scripts/WebRTCStream.cs
+++ b/examples/WebRTCExamples/UnityVideoSink/Assets/Scripts/WebRTCStream.cs
@@ -261,7 +261,7 @@ public class UnityLogger : IDisposable, Microsoft.Extensions.Logging.ILogger
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
-        Debug.Log("[" + eventId + "] " + formatter(state, exception));
+        Debug.Log($"[{eventId}] {formatter(state, exception)}");
         System.Diagnostics.Debug.WriteLine("[" + eventId + "] " + formatter(state, exception));
     }
 }

--- a/examples/WebRTCExamples/UnityVideoSource/Assets/Scripts/PlayerController.cs
+++ b/examples/WebRTCExamples/UnityVideoSource/Assets/Scripts/PlayerController.cs
@@ -250,8 +250,7 @@ public class UnityLogger : IDisposable, Microsoft.Extensions.Logging.ILogger
 
     public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
-        Debug.Log("[" + eventId + "] " + formatter(state, exception));
+        Debug.Log($"[{eventId}] {formatter(state, exception)}");
         System.Diagnostics.Debug.WriteLine("[" + eventId + "] " + formatter(state, exception));
     }
 }
-

--- a/examples/WebRTCExamples/WebRTCOpenGL/AudioScope/AudioScopeOpenGL.cs
+++ b/examples/WebRTCExamples/WebRTCOpenGL/AudioScope/AudioScopeOpenGL.cs
@@ -92,7 +92,7 @@ namespace AudioScope
             //  going to throw an exception.
             if (_prog.GetLinkStatus(gl) == false)
             {
-                throw new SharpGL.Shaders.ShaderCompilationException(string.Format("Failed to link shader program with ID {0}.", _prog.ShaderProgramObject), _prog.GetInfoLog(gl));
+                throw new SharpGL.Shaders.ShaderCompilationException($"Failed to link shader program with ID {_prog.ShaderProgramObject}.", _prog.GetInfoLog(gl));
             }
 
             // Load clear program.
@@ -118,7 +118,7 @@ namespace AudioScope
             // going to throw an exception.
             if (_clearProg.GetLinkStatus(gl) == false)
             {
-                throw new SharpGL.Shaders.ShaderCompilationException(string.Format("Failed to link the clear shader program with ID {0}.", _clearProg.ShaderProgramObject), _clearProg.GetInfoLog(gl));
+                throw new SharpGL.Shaders.ShaderCompilationException($"Failed to link the clear shader program with ID {_clearProg.ShaderProgramObject}.", _clearProg.GetInfoLog(gl));
             }
 
             _clearRectangle = new float[] { -1.0f, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f };

--- a/examples/WebRTCExamples/WebRTCOpenGLSource/AudioScope/AudioScopeOpenGL.cs
+++ b/examples/WebRTCExamples/WebRTCOpenGLSource/AudioScope/AudioScopeOpenGL.cs
@@ -92,7 +92,7 @@ namespace AudioScope
             //  going to throw an exception.
             if (_prog.GetLinkStatus(gl) == false)
             {
-                throw new SharpGL.Shaders.ShaderCompilationException(string.Format("Failed to link shader program with ID {0}.", _prog.ShaderProgramObject), _prog.GetInfoLog(gl));
+                throw new SharpGL.Shaders.ShaderCompilationException($"Failed to link shader program with ID {_prog.ShaderProgramObject}.", _prog.GetInfoLog(gl));
             }
 
             // Load clear program.
@@ -118,7 +118,7 @@ namespace AudioScope
             // going to throw an exception.
             if (_clearProg.GetLinkStatus(gl) == false)
             {
-                throw new SharpGL.Shaders.ShaderCompilationException(string.Format("Failed to link the clear shader program with ID {0}.", _clearProg.ShaderProgramObject), _clearProg.GetInfoLog(gl));
+                throw new SharpGL.Shaders.ShaderCompilationException($"Failed to link the clear shader program with ID {_clearProg.ShaderProgramObject}.", _clearProg.GetInfoLog(gl));
             }
 
             _clearRectangle = new float[] { -1.0f, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f };

--- a/examples/WebRTCExamples/WebRTCtoFfplay/Program.cs
+++ b/examples/WebRTCExamples/WebRTCtoFfplay/Program.cs
@@ -259,7 +259,7 @@ namespace SIPSorcery.Examples
                 sw.Write(sdpOffer);
             }
 
-            string ffplayCommand = String.Format(FFPLAY_DEFAULT_COMMAND, FFPLAY_DEFAULT_SDP_PATH);
+            string ffplayCommand = $"ffplay -probesize 32 -protocol_whitelist \"file,rtp,udp\" -i {FFPLAY_DEFAULT_SDP_PATH}";
             Console.WriteLine($"Start ffplay using the command below:");
             Console.WriteLine(ffplayCommand);
             Console.WriteLine($"To request the remote peer to send a video key frame press 'k'");
@@ -312,7 +312,7 @@ namespace SIPSorcery.Examples
                 {
                     logger.LogDebug("ICE Candidate: " + message);
 
-                    if (string.IsNullOrWhiteSpace(message) || message.Trim().ToLower() == SDP.END_ICE_CANDIDATES_ATTRIBUTE)
+                    if (string.IsNullOrWhiteSpace(message) || message.AsSpan().Trim().Equals(SDP.END_ICE_CANDIDATES_ATTRIBUTE, StringComparison.OrdinalIgnoreCase))
                     {
                         logger.LogDebug("End of candidates message received.");
                     }

--- a/examples/WebRTCScenarios/DataChannelStressTest/Program.cs
+++ b/examples/WebRTCScenarios/DataChannelStressTest/Program.cs
@@ -124,8 +124,7 @@ namespace SIPSorcery.Demo
             Console.WriteLine($"Data channel open tasks completed in {connectSW.ElapsedMilliseconds:0.##}ms.");
             foreach (var pair in connectionPairs)
             {
-                Console.WriteLine($"PC pair {pair.Name} src datachannel {pair.DC.readyState} streamid {pair.DC.id}, " +
-                    $"dst datachannel {pair.PCDst.DataChannels.Single().readyState} streamid {pair.PCDst.DataChannels.Single().id}.");
+                Console.WriteLine($"PC pair {pair.Name} src datachannel {pair.DC.readyState} streamid {pair.DC.id}, dst datachannel {pair.PCDst.DataChannels.Single().readyState} streamid {pair.PCDst.DataChannels.Single().id}.");
 
                 char a = 'a';
                 for (int j = 1; j < TEST_DATACHANNELS_PER_PEER_CONNECTION; j++)
@@ -143,8 +142,7 @@ namespace SIPSorcery.Demo
                 {
                     var dstdc = pair.PCDst.DataChannels.SingleOrDefault(x => x.id == srcdc.id);
 
-                    Console.WriteLine($" {srcdc.label}: src status {srcdc.readyState} streamid {srcdc.id} <-> " +
-                        $"dst status {dstdc.readyState} streamid {dstdc.id}.");
+                    Console.WriteLine($" {srcdc.label}: src status {srcdc.readyState} streamid {srcdc.id} <-> dst status {dstdc.readyState} streamid {dstdc.id}.");
 
                     srcdc.onmessage += OnData;
                     dstdc.onmessage += OnData;

--- a/examples/webrtccmdline/Program.cs
+++ b/examples/webrtccmdline/Program.cs
@@ -471,9 +471,9 @@ namespace SIPSorcery.Examples
                     else
                     {
                         // Attempt to execute the current command.
-                        switch (command.ToLower())
+                        switch (command)
                         {
-                            case "c":
+                            case var _ when string.Equals(command, "c", StringComparison.OrdinalIgnoreCase):
                                 // Close active peer connection.
                                 if (_peerConnection != null)
                                 {
@@ -483,7 +483,7 @@ namespace SIPSorcery.Examples
                                 }
                                 break;
 
-                            case var x when x.StartsWith("cdc"):
+                            case var x when x.StartsWith("cdc", StringComparison.OrdinalIgnoreCase):
                                 // Attempt to create a new data channel.
                                 if (_peerConnection != null)
                                 {
@@ -503,7 +503,7 @@ namespace SIPSorcery.Examples
                                 }
                                 break;
 
-                            case var x when x.StartsWith("ldc"):
+                            case var _ when command.StartsWith("ldc", StringComparison.OrdinalIgnoreCase):
                                 // List data channels.
                                 if (_peerConnection != null)
                                 {
@@ -523,7 +523,7 @@ namespace SIPSorcery.Examples
                                 }
                                 break;
 
-                            case var x when x.StartsWith("sdc"):
+                            case var x when x.StartsWith("sdc", StringComparison.OrdinalIgnoreCase):
                                 // Send data channel message.
                                 if (_peerConnection != null)
                                 {
@@ -551,7 +551,7 @@ namespace SIPSorcery.Examples
                                 }
                                 break;
 
-                            case var x when x.StartsWith("dtmf"):
+                            case var x when x.StartsWith("dtmf", StringComparison.OrdinalIgnoreCase):
                                 if (_peerConnection != null)
                                 {
                                     if (_peerConnection.HasAudio)
@@ -577,14 +577,14 @@ namespace SIPSorcery.Examples
                                 }
                                 break;
 
-                            case "q":
+                            case var _ when string.Equals(command, "q", StringComparison.OrdinalIgnoreCase):
                                 // Quit.
                                 Console.WriteLine();
                                 Console.WriteLine("Quitting...");
                                 cts.Cancel();
                                 break;
 
-                            case "isalive":
+                            case var _ when string.Equals(command, "isalive", StringComparison.OrdinalIgnoreCase):
                                 // Check responsiveness.
                                 Console.WriteLine();
                                 Console.WriteLine("yep");

--- a/test/FFmpegConsoleApp/Program.cs
+++ b/test/FFmpegConsoleApp/Program.cs
@@ -10,10 +10,10 @@ namespace FFmpegConsoleApp
     {
         // A valid to a video file - usefull if you want to test streaming of a video file
         // It's alo possible to set a remote file
-        const String VIDEO_FILE_PATH = @"https://upload.wikimedia.org/wikipedia/commons/3/36/Cosmos_Laundromat_-_First_Cycle_-_Official_Blender_Foundation_release.webm"; 
+        const String VIDEO_FILE_PATH = @"https://upload.wikimedia.org/wikipedia/commons/3/36/Cosmos_Laundromat_-_First_Cycle_-_Official_Blender_Foundation_release.webm";
         //const String VIDEO_FILE_PATH = @"C:\media\big_buck_bunny.mp4";
         //const String VIDEO_FILE_PATH = @"C:\media\Armello_Trailer.webm";
-        
+
         static private AsciiFrame? asciiFrame = null;
 
         static void Main(string[] args)
@@ -58,7 +58,7 @@ namespace FFmpegConsoleApp
 
                 var keyConsole = Console.ReadKey();
                 if ( ( (keyConsole.KeyChar == 'c') && (cameras?.Count > 0) )
-                    || ( (keyConsole.KeyChar == 'm') && (monitors?.Count > 0)) 
+                    || ( (keyConsole.KeyChar == 'm') && (monitors?.Count > 0))
                     || (keyConsole.KeyChar == 'f'))
                 {
                     keyChar = keyConsole.KeyChar;
@@ -85,7 +85,7 @@ namespace FFmpegConsoleApp
                         Console.Out.Flush();
 
                         var keyConsole = Console.ReadKey();
-                        if (int.TryParse("" + keyConsole.KeyChar, out int keyValue) && keyValue < index && keyValue >= 0)
+                        if (int.TryParse($"{keyConsole.KeyChar}", out int keyValue) && keyValue < index && keyValue >= 0)
                         {
                             cameraIndex = keyValue;
                             break;
@@ -119,7 +119,7 @@ namespace FFmpegConsoleApp
                         Console.Out.Flush();
 
                         var keyConsole = Console.ReadKey();
-                        if (int.TryParse("" + keyConsole.KeyChar, out int keyValue) && keyValue < index && keyValue >= 0)
+                        if (int.TryParse($"{keyConsole.KeyChar}", out int keyValue) && keyValue < index && keyValue >= 0)
                         {
                             monitorIndex = keyValue;
                             break;

--- a/test/FFmpegManagedTranscodeTest/Program.cs
+++ b/test/FFmpegManagedTranscodeTest/Program.cs
@@ -105,7 +105,7 @@ class Program
 
                     if(bytes != null)
                     {
-                        Console.WriteLine($"VP8 encoded packet size {bytes.Length}, sha256: " + Convert.ToBase64String(SHA256.HashData(bytes)));
+                        Console.WriteLine($"VP8 encoded packet size {bytes.Length}, sha256: {Convert.ToBase64String(SHA256.HashData(bytes))}");
                     }
 
                     int sleep = (int)(dpts * 1000 - DateTime.Now.Subtract(startTime).TotalMilliseconds);

--- a/test/FFmpegMp4Test/FFmpegInit.cs
+++ b/test/FFmpegMp4Test/FFmpegInit.cs
@@ -110,7 +110,7 @@ namespace FFmpegMp4Test
                 string ffmpegExecutable = "ffmpeg";
                 string? path = Environment.GetEnvironmentVariable("PATH")?
                     .Split(';')
-                    .Where(s => File.Exists(Path.Combine(s, ffmpegExecutable)) || File.Exists(Path.Combine(s, ffmpegExecutable  + ".exe")))
+                    .Where(s => File.Exists(Path.Combine(s, ffmpegExecutable)) || File.Exists(Path.Combine(s, $"{ffmpegExecutable}.exe")))
                     .FirstOrDefault();
 
                 if (path != null)

--- a/test/FFmpegTranscodeTest/Program.cs
+++ b/test/FFmpegTranscodeTest/Program.cs
@@ -128,7 +128,7 @@ class Program
                     {
                         byte[] arr = new byte[pPacket->size];
                         Marshal.Copy((IntPtr)pPacket->data, arr, 0, pPacket->size);
-                        Console.WriteLine($"VP8 encoded packet size {arr.Length}, sha256: " + Convert.ToBase64String(SHA256.HashData(arr)));
+                        Console.WriteLine($"VP8 encoded packet size {arr.Length}, sha256: {Convert.ToBase64String(SHA256.HashData(arr))}");
                     }
                     else if (error == ffmpeg.AVERROR(ffmpeg.EAGAIN))
                     {

--- a/test/SIPSorcery.VP8.UnitTest/bitstream_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/bitstream_unittest.cs
@@ -213,7 +213,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.True(expected[i] == buf[i],
-                    "byte " + i + " mismatch: expected=0x" + expected[i].ToString("x2") + " actual=0x" + buf[i].ToString("x2"));
+                    $"byte {i} mismatch: expected=0x{expected[i].ToString("x2")} actual=0x{buf[i].ToString("x2")}");
             }
         }
     }

--- a/test/SIPSorcery.VP8.UnitTest/encode_inter_frame_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/encode_inter_frame_unittest.cs
@@ -72,7 +72,7 @@ namespace Vpx.Net.UnitTest
                 // mode tree bits -- no token coefficients at all. It
                 // must be no larger than the corresponding keyframe.
                 Assert.True(interFrame.Length <= kf.Length + 4,
-                    "static inter frame (" + interFrame.Length + ") should not exceed keyframe size (" + kf.Length + ")");
+                    $"static inter frame ({interFrame.Length}) should not exceed keyframe size ({kf.Length})");
 
                 byte[] decoded = DecodeOne(ctx, interFrame, width, height);
                 AssertExact(keyDecoded, decoded);
@@ -118,8 +118,7 @@ namespace Vpx.Net.UnitTest
             double psnrInterVsInterSrc = ComputePSNR(interYuv, decInter);
             double psnrKeyVsInterSrc   = ComputePSNR(interYuv, decKey);
             Assert.True(psnrInterVsInterSrc > psnrKeyVsInterSrc + 5.0,
-                "inter encoding should bring the decoded frame substantially closer to the inter source than the reference. psnrInter=" +
-                psnrInterVsInterSrc.ToString("F2") + " psnrKey=" + psnrKeyVsInterSrc.ToString("F2"));
+                $"inter encoding should bring the decoded frame substantially closer to the inter source than the reference. psnrInter={psnrInterVsInterSrc.ToString("F2")} psnrKey={psnrKeyVsInterSrc.ToString("F2")}");
         }
 
         [Fact]
@@ -346,7 +345,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.True(expected[i] == actual[i],
-                    "byte " + i + " differs: expected=" + expected[i] + " actual=" + actual[i]);
+                    $"byte {i} differs: expected={expected[i]} actual={actual[i]}");
             }
         }
 
@@ -367,7 +366,7 @@ namespace Vpx.Net.UnitTest
         {
             double psnr = ComputePSNR(expected, actual);
             Assert.True(psnr >= minPsnrDb,
-                "PSNR " + psnr.ToString("F2") + " dB below required " + minPsnrDb.ToString("F2") + " dB");
+                $"PSNR {psnr.ToString("F2")} dB below required {minPsnrDb.ToString("F2")} dB");
         }
     }
 }

--- a/test/SIPSorcery.VP8.UnitTest/frame_encoder_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/frame_encoder_unittest.cs
@@ -324,7 +324,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.True(expected[i] == actual[i],
-                    "Pixel " + i + " differs: src=" + expected[i] + " decoded=" + actual[i]);
+                    $"Pixel {i} differs: src={expected[i]} decoded={actual[i]}");
             }
         }
 
@@ -335,8 +335,7 @@ namespace Vpx.Net.UnitTest
             {
                 int d = actual[i] - expected[i];
                 Assert.True(d >= -tol && d <= tol,
-                    "Pixel " + i + " err " + d + " exceeds tolerance " + tol +
-                    " (src=" + expected[i] + " decoded=" + actual[i] + ")");
+                    $"Pixel {i} err {d} exceeds tolerance {tol} (src={expected[i]} decoded={actual[i]})");
             }
         }
     }

--- a/test/SIPSorcery.VP8.UnitTest/inter_mb_mode_bits_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/inter_mb_mode_bits_unittest.cs
@@ -245,7 +245,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < outA.Length; i++)
             {
                 Assert.True(outA[i] == outB[i],
-                    "byte " + i + " mismatch: A=0x" + outA[i].ToString("x2") + " B=0x" + outB[i].ToString("x2"));
+                    $"byte {i} mismatch: A=0x{outA[i].ToString("x2")} B=0x{outB[i].ToString("x2")}");
             }
         }
 
@@ -274,7 +274,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < outA.Length; i++)
             {
                 Assert.True(outA[i] == outB[i],
-                    "byte " + i + " mismatch: A=0x" + outA[i].ToString("x2") + " B=0x" + outB[i].ToString("x2"));
+                    $"byte {i} mismatch: A=0x{outA[i].ToString("x2")} B=0x{outB[i].ToString("x2")}");
             }
         }
     }

--- a/test/SIPSorcery.VP8.UnitTest/mb_encoder_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/mb_encoder_unittest.cs
@@ -166,14 +166,14 @@ namespace Vpx.Net.UnitTest
             {
                 int diff = r.ReconY[i] - srcY[i];
                 Assert.True(diff >= -kTol && diff <= kTol,
-                    "Y[" + i + "] recon err " + diff + " exceeds tolerance " + kTol);
+                    $"Y[{i}] recon err {diff} exceeds tolerance {kTol}");
             }
             for (int i = 0; i < 64; i++)
             {
                 int dU = r.ReconU[i] - srcU[i];
                 int dV = r.ReconV[i] - srcV[i];
-                Assert.True(dU >= -kTol && dU <= kTol, "U[" + i + "] recon err " + dU);
-                Assert.True(dV >= -kTol && dV <= kTol, "V[" + i + "] recon err " + dV);
+                Assert.True(dU >= -kTol && dU <= kTol, $"U[{i}] recon err {dU}");
+                Assert.True(dV >= -kTol && dV <= kTol, $"V[{i}] recon err {dV}");
             }
         }
 

--- a/test/SIPSorcery.VP8.UnitTest/mb_encoder_zeromv_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/mb_encoder_zeromv_unittest.cs
@@ -103,11 +103,11 @@ namespace Vpx.Net.UnitTest
             // step on Y is ~7-8; tolerance of 16 is comfortably above
             // that so we don't get false negatives from rounding noise.
             for (int i = 0; i < 256; i++)
-                AssertWithinTolerance(110, r.ReconY[i], 16, "Y[" + i + "]");
+                AssertWithinTolerance(110, r.ReconY[i], 16, $"Y[{i}]");
             for (int i = 0; i < 64;  i++)
-                AssertWithinTolerance(130, r.ReconU[i], 16, "U[" + i + "]");
+                AssertWithinTolerance(130, r.ReconU[i], 16, $"U[{i}]");
             for (int i = 0; i < 64;  i++)
-                AssertWithinTolerance(90,  r.ReconV[i], 16, "V[" + i + "]");
+                AssertWithinTolerance(90,  r.ReconV[i], 16, $"V[{i}]");
         }
 
         // ---------- Test 3: random source over flat prediction -> exercises coef path ----------
@@ -164,8 +164,7 @@ namespace Vpx.Net.UnitTest
                 if (err > maxErrY) maxErrY = err;
             }
             Assert.True(maxErrY < 100,
-                "Random-input Y plane recon max error " + maxErrY
-                + " is suspiciously large (> 100). The pipeline may have a sign/clip bug.");
+                $"Random-input Y plane recon max error {maxErrY} is suspiciously large (> 100). The pipeline may have a sign/clip bug.");
         }
 
         // ---------- helpers ----------
@@ -182,8 +181,7 @@ namespace Vpx.Net.UnitTest
             int err = actual - expected;
             if (err < 0) err = -err;
             Assert.True(err <= tol,
-                label + ": expected=" + expected + " actual=" + actual + " err=" + err
-                + " > tol=" + tol);
+                $"{label}: expected={expected} actual={actual} err={err} > tol={tol}");
         }
     }
 }

--- a/test/SIPSorcery.VP8.UnitTest/pack_tokens_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/pack_tokens_unittest.cs
@@ -187,7 +187,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.True(expected[i] == got[i],
-                    "byte " + i + " mismatch: expected=0x" + expected[i].ToString("x2") + " actual=0x" + got[i].ToString("x2"));
+                    $"byte {i} mismatch: expected=0x{expected[i].ToString("x2")} actual=0x{got[i].ToString("x2")}");
             }
         }
 

--- a/test/SIPSorcery.VP8.UnitTest/quantizer_init_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/quantizer_init_unittest.cs
@@ -175,12 +175,12 @@ namespace Vpx.Net.UnitTest
         private static void AssertTablesMatch(string label, QuantizerTables t,
             short[] zbin, short[] round, short[] quant, short[] qshift, short[] dequant, short[] zrun)
         {
-            AssertArr(label + ".zbin", zbin, t.zbin);
-            AssertArr(label + ".round", round, t.round);
-            AssertArr(label + ".quant", quant, t.quant);
-            AssertArr(label + ".quant_shift", qshift, t.quant_shift);
-            AssertArr(label + ".dequant", dequant, t.dequant);
-            AssertArr(label + ".zrun_zbin_boost", zrun, t.zrun_zbin_boost);
+            AssertArr($"{label}.zbin", zbin, t.zbin);
+            AssertArr($"{label}.round", round, t.round);
+            AssertArr($"{label}.quant", quant, t.quant);
+            AssertArr($"{label}.quant_shift", qshift, t.quant_shift);
+            AssertArr($"{label}.dequant", dequant, t.dequant);
+            AssertArr($"{label}.zrun_zbin_boost", zrun, t.zrun_zbin_boost);
         }
 
         private static void AssertArr(string name, short[] expected, short[] actual)
@@ -189,7 +189,7 @@ namespace Vpx.Net.UnitTest
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.True(expected[i] == actual[i],
-                    name + "[" + i + "]: expected " + expected[i] + " got " + actual[i]);
+                    $"{name}[{i}]: expected {expected[i]} got {actual[i]}");
             }
         }
     }

--- a/test/SIPSorcery.VP8.UnitTest/tokenize_unittest.cs
+++ b/test/SIPSorcery.VP8.UnitTest/tokenize_unittest.cs
@@ -247,11 +247,11 @@ namespace Vpx.Net.UnitTest
             {
                 var e = expected[i];
                 Assert.True(e.token == got[i].Token,
-                    "[" + i + "] Token: expected " + e.token + " got " + got[i].Token);
+                    $"[{i}] Token: expected {e.token} got {got[i].Token}");
                 Assert.True(e.extra == got[i].Extra,
-                    "[" + i + "] Extra: expected " + e.extra + " got " + got[i].Extra);
+                    $"[{i}] Extra: expected {e.extra} got {got[i].Extra}");
                 Assert.True(e.skipEob == got[i].skip_eob_node,
-                    "[" + i + "] skip_eob_node: expected " + e.skipEob + " got " + got[i].skip_eob_node);
+                    $"[{i}] skip_eob_node: expected {e.skipEob} got {got[i].skip_eob_node}");
             }
         }
     }

--- a/test/integration/SIPSorcery.IntegrationTests.csproj
+++ b/test/integration/SIPSorcery.IntegrationTests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Polyfill" Version="10.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />

--- a/test/integration/app/SIPUserAgentUnitTest.cs
+++ b/test/integration/app/SIPUserAgentUnitTest.cs
@@ -23,6 +23,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Polyfills;
 using SIPSorcery.Media;
 using SIPSorcery.Net;
 using SIPSorcery.SIP.App;
@@ -44,6 +45,36 @@ namespace SIPSorcery.SIP.IntegrationTests
 
         private string m_CRLF = SIPConstants.CRLF;
 
+        private string CreateInviteRequestWithSdp() =>
+            """
+            INVITE sip:192.168.11.50:5060 SIP/2.0
+            Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3691
+            To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ
+            From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938
+            Call-ID: 17324d6df8744d978008c8997bfd208d
+            CSeq: 3532 INVITE
+            Contact: <sip:aaron@192.168.11.50:60163;ob>
+            Max-Forwards: 70
+            User-Agent: MicroSIP/3.19.22
+            Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS
+            Supported: replaces, 100rel, timer, norefersub
+            Content-Length: 343
+            Content-Type: application/sdp
+            Session-Expires: 1800
+            Min-SE: 90
+
+            v=0
+            o=- 3785527268 3785527269 IN IP4 192.168.11.50
+            s=pjmedia
+            t=0 0
+            m=audio 4032 RTP/AVP 0 101
+            c=IN IP4 192.168.11.50
+            a=rtpmap:0 PCMU/8000
+            a=rtpmap:101 telephone-event/8000
+            a=fmtp:101 0-16
+            a=sendrecv
+            """.ReplaceLineEndings(m_CRLF);
+
         /// <summary>
         /// Tests that the Blind Transfer function doesn't do anything unexpected. The transfer
         /// request should return false since the Accepted response never arrives.
@@ -59,32 +90,7 @@ namespace SIPSorcery.SIP.IntegrationTests
 
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
 
-            string inviteReqStr = "INVITE sip:192.168.11.50:5060 SIP/2.0" + m_CRLF +
-"Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3691" + m_CRLF +
-"To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ" + m_CRLF +
-"From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938" + m_CRLF +
-"Call-ID: 17324d6df8744d978008c8997bfd208d" + m_CRLF +
-"CSeq: 3532 INVITE" + m_CRLF +
-"Contact: <sip:aaron@192.168.11.50:60163;ob>" + m_CRLF +
-"Max-Forwards: 70" + m_CRLF +
-"User-Agent: MicroSIP/3.19.22" + m_CRLF +
-"Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS" + m_CRLF +
-"Supported: replaces, 100rel, timer, norefersub" + m_CRLF +
-"Content-Length: 343" + m_CRLF +
-"Content-Type: application/sdp" + m_CRLF +
-"Session-Expires: 1800" + m_CRLF +
-"Min-SE: 90" + m_CRLF +
-"" + m_CRLF +
-"v=0" + m_CRLF +
-"o=- 3785527268 3785527269 IN IP4 192.168.11.50" + m_CRLF +
-"s=pjmedia" + m_CRLF +
-"t=0 0" + m_CRLF +
-"m=audio 4032 RTP/AVP 0 101" + m_CRLF +
-"c=IN IP4 192.168.11.50" + m_CRLF +
-"a=rtpmap:0 PCMU/8000" + m_CRLF +
-"a=rtpmap:101 telephone-event/8000" + m_CRLF +
-"a=fmtp:101 0-16" + m_CRLF +
-"a=sendrecv";
+            var inviteReqStr = CreateInviteRequestWithSdp();
 
             SIPEndPoint dummySipEndPoint = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 0));
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(inviteReqStr, dummySipEndPoint, dummySipEndPoint);
@@ -114,32 +120,7 @@ namespace SIPSorcery.SIP.IntegrationTests
 
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
 
-            string inviteReqStr = "INVITE sip:192.168.11.50:5060 SIP/2.0" + m_CRLF +
-"Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3691" + m_CRLF +
-"To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ" + m_CRLF +
-"From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938" + m_CRLF +
-"Call-ID: 17324d6df8744d978008c8997bfd208d" + m_CRLF +
-"CSeq: 3532 INVITE" + m_CRLF +
-"Contact: <sip:aaron@192.168.11.50:60163;ob>" + m_CRLF +
-"Max-Forwards: 70" + m_CRLF +
-"User-Agent: MicroSIP/3.19.22" + m_CRLF +
-"Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS" + m_CRLF +
-"Supported: replaces, 100rel, timer, norefersub" + m_CRLF +
-"Content-Length: 343" + m_CRLF +
-"Content-Type: application/sdp" + m_CRLF +
-"Session-Expires: 1800" + m_CRLF +
-"Min-SE: 90" + m_CRLF +
-"" + m_CRLF +
-"v=0" + m_CRLF +
-"o=- 3785527268 3785527269 IN IP4 192.168.11.50" + m_CRLF +
-"s=pjmedia" + m_CRLF +
-"t=0 0" + m_CRLF +
-"m=audio 4032 RTP/AVP 0 101" + m_CRLF +
-"c=IN IP4 192.168.11.50" + m_CRLF +
-"a=rtpmap:0 PCMU/8000" + m_CRLF +
-"a=rtpmap:101 telephone-event/8000" + m_CRLF +
-"a=fmtp:101 0-16" + m_CRLF +
-"a=sendrecv";
+            var inviteReqStr = CreateInviteRequestWithSdp();
 
             SIPEndPoint dummySipEndPoint = new SIPEndPoint(new IPEndPoint(IPAddress.Any, 0));
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(inviteReqStr, dummySipEndPoint, dummySipEndPoint);
@@ -174,32 +155,7 @@ namespace SIPSorcery.SIP.IntegrationTests
 
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
 
-            string inviteReqStr = "INVITE sip:192.168.11.50:5060 SIP/2.0" + m_CRLF +
-"Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3691" + m_CRLF +
-"To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ" + m_CRLF +
-"From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938" + m_CRLF +
-"Call-ID: 17324d6df8744d978008c8997bfd208d" + m_CRLF +
-"CSeq: 3532 INVITE" + m_CRLF +
-"Contact: <sip:aaron@192.168.11.50:60163;ob>" + m_CRLF +
-"Max-Forwards: 70" + m_CRLF +
-"User-Agent: MicroSIP/3.19.22" + m_CRLF +
-"Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS" + m_CRLF +
-"Supported: replaces, 100rel, timer, norefersub" + m_CRLF +
-"Content-Length: 343" + m_CRLF +
-"Content-Type: application/sdp" + m_CRLF +
-"Session-Expires: 1800" + m_CRLF +
-"Min-SE: 90" + m_CRLF +
-"" + m_CRLF +
-"v=0" + m_CRLF +
-"o=- 3785527268 3785527269 IN IP4 192.168.11.50" + m_CRLF +
-"s=pjmedia" + m_CRLF +
-"t=0 0" + m_CRLF +
-"m=audio 4032 RTP/AVP 0 101" + m_CRLF +
-"c=IN IP4 192.168.11.50" + m_CRLF +
-"a=rtpmap:0 PCMU/8000" + m_CRLF +
-"a=rtpmap:101 telephone-event/8000" + m_CRLF +
-"a=fmtp:101 0-16" + m_CRLF +
-"a=sendrecv";
+            var inviteReqStr = CreateInviteRequestWithSdp();
 
             SIPEndPoint dummySipEndPoint = new SIPEndPoint(new IPEndPoint(IPAddress.Loopback, 0));
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(inviteReqStr, dummySipEndPoint, dummySipEndPoint);
@@ -210,18 +166,21 @@ namespace SIPSorcery.SIP.IntegrationTests
             await userAgent.Answer(mockUas, CreateMediaSession());
 
             // Incremented Cseq and modified Via header from original request. Means the request is the same dialog but different tx.
-            string inviteReqStr2 = "BYE sip:192.168.11.50:5060 SIP/2.0" + m_CRLF +
-"Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3700" + m_CRLF +
-"To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ" + m_CRLF +
-"From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938" + m_CRLF +
-"Call-ID: 17324d6df8744d978008c8997bfd208d" + m_CRLF +
-"CSeq: 3533 BYE" + m_CRLF +
-"Contact: <sip:aaron@192.168.11.50:60163;ob>" + m_CRLF +
-"Max-Forwards: 70" + m_CRLF +
-"User-Agent: MicroSIP/3.19.22" + m_CRLF +
-"Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS" + m_CRLF +
-"Supported: replaces, 100rel, timer, norefersub" + m_CRLF +
-"";
+            var inviteReqStr2 =
+                """
+                BYE sip:192.168.11.50:5060 SIP/2.0
+                Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3700
+                To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ
+                From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938
+                Call-ID: 17324d6df8744d978008c8997bfd208d
+                CSeq: 3533 BYE
+                Contact: <sip:aaron@192.168.11.50:60163;ob>
+                Max-Forwards: 70
+                User-Agent: MicroSIP/3.19.22
+                Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS
+                Supported: replaces, 100rel, timer, norefersub
+
+                """.ReplaceLineEndings(m_CRLF);
 
             mockChannel.FireMessageReceived(dummySipEndPoint, dummySipEndPoint, Encoding.UTF8.GetBytes(inviteReqStr2));
         }
@@ -240,19 +199,24 @@ namespace SIPSorcery.SIP.IntegrationTests
 
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
 
-            string inviteReqStr = "INVITE sip:192.168.11.50:5060 SIP/2.0" + m_CRLF +
-"Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3691" + m_CRLF +
-"To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ" + m_CRLF +
-"From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938" + m_CRLF +
-"Call-ID: 17324d6df8744d978008c8997bfd208d" + m_CRLF +
-"CSeq: 3532 INVITE" + m_CRLF +
-"Contact: <sip:aaron@192.168.11.50:60163;ob>" + m_CRLF +
-"Max-Forwards: 70" + m_CRLF +
-"Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS" + m_CRLF +
-"Supported: replaces, 100rel, timer, norefersub" + m_CRLF +
-"Content-Length: 0" + m_CRLF +
-"Content-Type: application/sdp" + m_CRLF +
-"Session-Expires: 1800" + m_CRLF + m_CRLF;
+            var inviteReqStr =
+                """
+                INVITE sip:192.168.11.50:5060 SIP/2.0
+                Via: SIP/2.0/UDP 192.168.11.50:60163;rport;branch=z9hG4bKPj869f70960bdd4204b1352eaf242a3691
+                To: <sip:2@192.168.11.50>;tag=ZUJSXRRGXQ
+                From: <sip:aaron@192.168.11.50>;tag=4a60ce364b774258873ff199e5e39938
+                Call-ID: 17324d6df8744d978008c8997bfd208d
+                CSeq: 3532 INVITE
+                Contact: <sip:aaron@192.168.11.50:60163;ob>
+                Max-Forwards: 70
+                Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS
+                Supported: replaces, 100rel, timer, norefersub
+                Content-Length: 0
+                Content-Type: application/sdp
+                Session-Expires: 1800
+
+
+                """.ReplaceLineEndings(m_CRLF);
 
             SIPEndPoint dummySipEndPoint = new SIPEndPoint(new IPEndPoint(IPAddress.Loopback, 0));
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(inviteReqStr, dummySipEndPoint, dummySipEndPoint);
@@ -281,17 +245,22 @@ namespace SIPSorcery.SIP.IntegrationTests
 
             SIPUserAgent userAgent = new SIPUserAgent(transport, null);
 
-            string inviteReqStr = @"INVITE sip:1@127.0.0.1 SIP/2.0
-Via: SIP/2.0/UDP 127.0.0.1:51200;branch=z9hG4bKbeed9b0cde8d43cc8a2aae91526b6a1d;rport
-To: <sip:1@127.0.0.1>
-From: <sip:thisis@anonymous.invalid>;tag=GCLNRILCDU
-Call-ID: 7265e19f53a146a1bacdf4f4f8ea70b2
-CSeq: 1 INVITE
-Contact: <sip:127.0.0.1:51200>
-Max-Forwards: 70
-User-Agent: www.sipsorcery.com
-Content-Length: 0
-Content-Type: application/sdp" + m_CRLF + m_CRLF;
+            var inviteReqStr =
+                """
+                INVITE sip:1@127.0.0.1 SIP/2.0
+                Via: SIP/2.0/UDP 127.0.0.1:51200;branch=z9hG4bKbeed9b0cde8d43cc8a2aae91526b6a1d;rport
+                To: <sip:1@127.0.0.1>
+                From: <sip:thisis@anonymous.invalid>;tag=GCLNRILCDU
+                Call-ID: 7265e19f53a146a1bacdf4f4f8ea70b2
+                CSeq: 1 INVITE
+                Contact: <sip:127.0.0.1:51200>
+                Max-Forwards: 70
+                User-Agent: www.sipsorcery.com
+                Content-Length: 0
+                Content-Type: application/sdp
+
+
+                """.ReplaceLineEndings(m_CRLF);
 
             SIPEndPoint dummySipEndPoint = new SIPEndPoint(new IPEndPoint(IPAddress.Loopback, 0));
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(inviteReqStr, dummySipEndPoint, dummySipEndPoint);
@@ -304,24 +273,29 @@ Content-Type: application/sdp" + m_CRLF + m_CRLF;
             {
                 await Task.Delay(2000);
 
-                string ackReqStr = @"ACK sip:127.0.0.1:5060 SIP/2.0
-Via: SIP/2.0/UDP 127.0.0.1:51200;branch=z9hG4bK76dfb1480ea14f778bd24afed1c8ded0;rport
-To: <sip:1@127.0.0.1>;tag=YWPNZPMLPB
-From: <sip:thisis@anonymous.invalid>;tag=GCLNRILCDU
-Call-ID: 7265e19f53a146a1bacdf4f4f8ea70b2
-CSeq: 1 ACK
-Max-Forwards: 70
-Content-Length: 160
+                var ackReqStr =
+                    """
+                    ACK sip:127.0.0.1:5060 SIP/2.0
+                    Via: SIP/2.0/UDP 127.0.0.1:51200;branch=z9hG4bK76dfb1480ea14f778bd24afed1c8ded0;rport
+                    To: <sip:1@127.0.0.1>;tag=YWPNZPMLPB
+                    From: <sip:thisis@anonymous.invalid>;tag=GCLNRILCDU
+                    Call-ID: 7265e19f53a146a1bacdf4f4f8ea70b2
+                    CSeq: 1 ACK
+                    Max-Forwards: 70
+                    Content-Length: 160
 
-v=0
-o=- 67424 0 IN IP4 127.0.0.1
-s=-
-c=IN IP4 127.0.0.1
-t=0 0
-m=audio 16976 RTP/AVP 8 101
-a=rtpmap:101 telephone-event/8000
-a=fmtp:101 0-16
-a=sendrecv" + m_CRLF + m_CRLF;
+                    v=0
+                    o=- 67424 0 IN IP4 127.0.0.1
+                    s=-
+                    c=IN IP4 127.0.0.1
+                    t=0 0
+                    m=audio 16976 RTP/AVP 8 101
+                    a=rtpmap:101 telephone-event/8000
+                    a=fmtp:101 0-16
+                    a=sendrecv
+
+
+                    """.ReplaceLineEndings(m_CRLF);
 
                 uas.ClientTransaction.ACKReceived(dummySep, dummySep, SIPRequest.ParseSIPRequest(ackReqStr));
             });

--- a/test/integration/net/DNS/DNSUnitTest.cs
+++ b/test/integration/net/DNS/DNSUnitTest.cs
@@ -176,7 +176,7 @@ namespace SIPSorcery.Net.IntegrationTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             //DNSResponse result = DNSManager.Lookup(SIPDNSConstants.SRV_SIP_UDP_QUERY_PREFIX + "sipsorcery.com", QType.SRV, 10, null, false, false);
-            var result = await SIPDns.LookupClient.QueryAsync(SIPDNSConstants.SRV_SIP_UDP_QUERY_PREFIX + "sipsorcery.com", QueryType.SRV);
+            var result = await SIPDns.LookupClient.QueryAsync($"{SIPDNSConstants.SRV_SIP_UDP_QUERY_PREFIX}sipsorcery.com", QueryType.SRV);
 
             foreach (var srvResult in result.Answers?.SrvRecords())
             {

--- a/test/unit/SIPSorcery.UnitTests.csproj
+++ b/test/unit/SIPSorcery.UnitTests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Polyfill" Version="10.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />

--- a/test/unit/app/SIPUserAgents/SIPUserAgentAttendedTransferUnitTest.cs
+++ b/test/unit/app/SIPUserAgents/SIPUserAgentAttendedTransferUnitTest.cs
@@ -113,13 +113,7 @@ namespace SIPSorcery.SIP.App.UnitTests
 
             // Minimal SDP body so Answer() can process the offer.
             string sdpBody =
-                "v=0\r\n" +
-                $"o=- 0 0 IN IP4 {channelEndPoint.Address}\r\n" +
-                "s=-\r\n" +
-                $"c=IN IP4 {channelEndPoint.Address}\r\n" +
-                "t=0 0\r\n" +
-                "m=audio 49170 RTP/AVP 0\r\n" +
-                "a=rtpmap:0 PCMU/8000\r\n";
+                $"v=0\r\no=- 0 0 IN IP4 {channelEndPoint.Address}\r\ns=-\r\nc=IN IP4 {channelEndPoint.Address}\r\nt=0 0\r\nm=audio 49170 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
 
             request.Body = sdpBody;
 

--- a/test/unit/core/SIP/SIPContactHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPContactHeaderUnitTest.cs
@@ -116,7 +116,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Contact Header ContactParams = {ContactParams}", sipContactHeaderList[0].ContactParameters.ToString());
 
             Assert.True(sipContactHeaderList[0].ContactName == null, "The Contact header name was not parsed correctly.");
-            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:user@127.0.0.1:5060;ftag=1233", "The Contact header URI was not parsed correctly, parsed valued = " + sipContactHeaderList[0].ContactURI.ToString() + ".");
+            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:user@127.0.0.1:5060;ftag=1233", $"The Contact header URI was not parsed correctly, parsed valued = {sipContactHeaderList[0].ContactURI.ToString()}.");
             Assert.True(sipContactHeaderList[0].ContactURI.Parameters.Get("ftag") == "1233", "The Contact header ftag URI parameter was not parsed correctly.");
         }
 
@@ -135,7 +135,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Contact = {Contact}", sipContactHeaderList[0].ToString());
 
             Assert.True(sipContactHeaderList[0].ContactName == null, "The Contact header name was not parsed correctly.");
-            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:user@127.0.0.1:5060", "The Contact header URI was not parsed correctly, parsed valued = " + sipContactHeaderList[0].ContactURI.ToString() + ".");
+            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:user@127.0.0.1:5060", $"The Contact header URI was not parsed correctly, parsed valued = {sipContactHeaderList[0].ContactURI.ToString()}.");
             Assert.True(sipContactHeaderList[0].Expires == 60, "The Contact header Expires parameter was not parsed correctly.");
         }
 
@@ -154,7 +154,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Contact = {Contact}", sipContactHeaderList[0].ToString());
 
             Assert.True(sipContactHeaderList[0].ContactName == null, "The Contact header name was not parsed correctly.");
-            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:user@127.0.0.1:5060", "The Contact header URI was not parsed correctly, parsed valued = " + sipContactHeaderList[0].ContactURI.ToString() + ".");
+            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:user@127.0.0.1:5060", $"The Contact header URI was not parsed correctly, parsed valued = {sipContactHeaderList[0].ContactURI.ToString()}.");
             Assert.True(sipContactHeaderList[0].Expires == 0, "The Contact header Expires parameter was not parsed correctly.");
         }
 
@@ -173,7 +173,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Contact Header ContactParams = {ContactParams}", sipContactHeaderList[0].ContactParameters.ToString());
 
             Assert.True(sipContactHeaderList[0].ContactName == "Mr. Watson", "The Contact header name was not parsed correctly.");
-            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:watson@worcester.bell-telephone.com", "The Contact header URI was not parsed correctly, parsed valued = " + sipContactHeaderList[0].ContactURI.ToString() + ".");
+            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:watson@worcester.bell-telephone.com", $"The Contact header URI was not parsed correctly, parsed valued = {sipContactHeaderList[0].ContactURI.ToString()}.");
             Assert.True(sipContactHeaderList[0].Expires == 3600, "The Contact header Expires parameter was not parsed correctly.");
             Assert.True(sipContactHeaderList[0].Q == "0.7", "The Contact header Q parameter was not parsed correctly.");
         }
@@ -193,7 +193,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Contact Header ContactParams = {ContactParams}", sipContactHeaderList[0].ContactParameters.ToString());
 
             Assert.True(sipContactHeaderList[0].ContactName == "Mr. Watson", "The Contact header name was not parsed correctly.");
-            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:watson@worcester.bell-telephone.com;ftag=1232", "The Contact header URI was not parsed correctly, parsed valued = " + sipContactHeaderList[0].ContactURI.ToString() + ".");
+            Assert.True(sipContactHeaderList[0].ContactURI.ToString() == "sip:watson@worcester.bell-telephone.com;ftag=1232", $"The Contact header URI was not parsed correctly, parsed valued = {sipContactHeaderList[0].ContactURI.ToString()}.");
             Assert.True(sipContactHeaderList[0].Expires == 3600, "The Contact header Expires parameter was not parsed correctly.");
             Assert.True(sipContactHeaderList[0].Q == "0.7", "The Contact header Q parameter was not parsed correctly.");
             Assert.True(sipContactHeaderList[0].ContactURI.Parameters.Get("ftag") == "1232", "The Contact header URI ftag parameter was not parsed correctly.");

--- a/test/unit/core/SIP/SIPHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPHeaderUnitTest.cs
@@ -35,16 +35,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenInviteHeaders =
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                "Content-Length: 271" + m_CRLF;
+                $"Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}Content-Length: 271{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", xtenInviteHeaders);
 
@@ -59,19 +50,19 @@ namespace SIPSorcery.SIP.UnitTests
             Assert.True(sipHeader.Vias.TopViaHeader.Transport == SIPProtocolsEnum.udp, "The Via transport was not parsed correctly.");
             Assert.True(sipHeader.Vias.TopViaHeader.Branch == "z9hG4bKFBB7EAC06934405182D13950BD51F001", "The Via branch was not parsed correctly.");
             Assert.True(sipHeader.Vias.TopViaHeader.ViaParameters.Has("rport"), "The Via rport parameter was not parsed correctly.");
-            Assert.True("SER Test X" == sipHeader.From.FromName, "The From Name value was not parsed correctly, " + sipHeader.From.FromName + ".");
-            Assert.True("sip:aaronxten@sip.blueface.ie:5065" == sipHeader.From.FromURI.ToString(), "The From URI value was not parsed correctly, " + sipHeader.From.FromURI + ".");
-            Assert.True("196468136" == sipHeader.From.FromTag, "The From tag value was not parsed correctly, " + sipHeader.From.FromTag + ".");
-            Assert.True(null == sipHeader.To.ToName, "The To Name value was not parsed correctly, " + sipHeader.To.ToName + ".");
-            Assert.True("sip:303@sip.blueface.ie" == sipHeader.To.ToURI.ToString(), "The To URI value was not parsed correctly, " + sipHeader.To.ToURI + ".");
-            Assert.True(null == sipHeader.To.ToTag, "The To tag value was not parsed correctly, " + sipHeader.To.ToTag + ".");
-            Assert.True("A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" == sipHeader.CallId, "The Call ID values was not parsed correctly, " + sipHeader.CallId + ".");
-            Assert.True(49429 == sipHeader.CSeq, "The CSeq value was not parsed correctly, " + sipHeader.CSeq + ".");
-            Assert.True(SIPMethodsEnum.INVITE == sipHeader.CSeqMethod, "The CSeq Method value was not parsed correctly, " + sipHeader.CSeqMethod + ".");
-            Assert.True(70 == sipHeader.MaxForwards, "The MaxForwards value was not parsed correctly, " + sipHeader.MaxForwards + ".");
-            Assert.True("X-PRO release 1103v" == sipHeader.UserAgent, "The UserAgent value was not parsed correctly, " + sipHeader.UserAgent + ".");
-            Assert.True("application/sdp" == sipHeader.ContentType, "The ContentType value was not parsed correctly, " + sipHeader.ContentType + ".");
-            Assert.True(271 == sipHeader.ContentLength, "The ContentLength value was not parsed correctly, " + sipHeader.ContentLength + ".");
+            Assert.True("SER Test X" == sipHeader.From.FromName, $"The From Name value was not parsed correctly, {sipHeader.From.FromName}.");
+            Assert.True("sip:aaronxten@sip.blueface.ie:5065" == sipHeader.From.FromURI.ToString(), $"The From URI value was not parsed correctly, {sipHeader.From.FromURI}.");
+            Assert.True("196468136" == sipHeader.From.FromTag, $"The From tag value was not parsed correctly, {sipHeader.From.FromTag}.");
+            Assert.True(null == sipHeader.To.ToName, $"The To Name value was not parsed correctly, {sipHeader.To.ToName}.");
+            Assert.True("sip:303@sip.blueface.ie" == sipHeader.To.ToURI.ToString(), $"The To URI value was not parsed correctly, {sipHeader.To.ToURI}.");
+            Assert.True(null == sipHeader.To.ToTag, $"The To tag value was not parsed correctly, {sipHeader.To.ToTag}.");
+            Assert.True("A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" == sipHeader.CallId, $"The Call ID values was not parsed correctly, {sipHeader.CallId}.");
+            Assert.True(49429 == sipHeader.CSeq, $"The CSeq value was not parsed correctly, {sipHeader.CSeq}.");
+            Assert.True(SIPMethodsEnum.INVITE == sipHeader.CSeqMethod, $"The CSeq Method value was not parsed correctly, {sipHeader.CSeqMethod}.");
+            Assert.True(70 == sipHeader.MaxForwards, $"The MaxForwards value was not parsed correctly, {sipHeader.MaxForwards}.");
+            Assert.True("X-PRO release 1103v" == sipHeader.UserAgent, $"The UserAgent value was not parsed correctly, {sipHeader.UserAgent}.");
+            Assert.True("application/sdp" == sipHeader.ContentType, $"The ContentType value was not parsed correctly, {sipHeader.ContentType}.");
+            Assert.True(271 == sipHeader.ContentLength, $"The ContentLength value was not parsed correctly, {sipHeader.ContentLength}.");
 
             logger.LogDebug("---------------------------------------------------");
         }
@@ -83,18 +74,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string xtenInviteHeaders =
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A=" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64091;branch=z9hG4bK4E0728C26A0640E7830D7C9179D08D67" + m_CRLF +
-                "Record-Route: <sip:213.168.225.133:5060;lr>,<sip:220.240.255.198:64091;lr>" + m_CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=457825353" + m_CRLF +
-                "To: <sip:303@bluesipd>;tag=as02a64a42" + m_CRLF +
-                "Call-ID: 8A702FA2-18F0-4DFC-AED5-C1A883EADB84@192.168.1.2" + m_CRLF +
-                "CSeq: 38002 INVITE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 350" + m_CRLF;
+                $"Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A={m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64091;branch=z9hG4bK4E0728C26A0640E7830D7C9179D08D67{m_CRLF}Record-Route: <sip:213.168.225.133:5060;lr>,<sip:220.240.255.198:64091;lr>{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=457825353{m_CRLF}To: <sip:303@bluesipd>;tag=as02a64a42{m_CRLF}Call-ID: 8A702FA2-18F0-4DFC-AED5-C1A883EADB84@192.168.1.2{m_CRLF}CSeq: 38002 INVITE{m_CRLF}User-Agent: asterisk{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 350{m_CRLF}";
             logger.LogDebug("Original SIP Headers:\n{Headers}", xtenInviteHeaders);
 
             string[] headersCollection = Regex.Split(xtenInviteHeaders, "\r\n");
@@ -116,18 +96,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string mulitLineHeader =
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A=" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64091;branch=z9hG4bK4E0728C26A0640E7830D7C9179D08D67" + m_CRLF +
-                "Record-Route: <sip:213.168.225.133:5060;lr>," + m_CRLF +
-                " <sip:220.240.255.198:64091;lr>" + m_CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=457825353" + m_CRLF +
-                "To: <sip:303@bluesipd>;tag=as02a64a42" + m_CRLF +
-                "Call-ID: 8A702FA2-18F0-4DFC-AED5-C1A883EADB84@192.168.1.2" + m_CRLF +
-                "CSeq: 38002 INVITE" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 350" + m_CRLF;
+                $"Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A={m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64091;branch=z9hG4bK4E0728C26A0640E7830D7C9179D08D67{m_CRLF}Record-Route: <sip:213.168.225.133:5060;lr>,{m_CRLF} <sip:220.240.255.198:64091;lr>{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=457825353{m_CRLF}To: <sip:303@bluesipd>;tag=as02a64a42{m_CRLF}Call-ID: 8A702FA2-18F0-4DFC-AED5-C1A883EADB84@192.168.1.2{m_CRLF}CSeq: 38002 INVITE{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 350{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", mulitLineHeader);
 
@@ -145,7 +114,7 @@ namespace SIPSorcery.SIP.UnitTests
 
             logger.LogDebug("Parsed SIP Headers:\n{Headers}", sipHeader.ToString());
 
-            Assert.True(sipHeader.RecordRoutes.Length == 2, "An incorrect number of record route entries was extracted, number was " + sipHeader.RecordRoutes.Length + ".");
+            Assert.True(sipHeader.RecordRoutes.Length == 2, $"An incorrect number of record route entries was extracted, number was {sipHeader.RecordRoutes.Length}.");
 
             SIPRoute topRoute = sipHeader.RecordRoutes.PopRoute();
             Assert.True(topRoute.Host == "213.168.225.133:5060", "The top record route was not parsed correctly.");
@@ -160,18 +129,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string authReqdHeaders =
-                "SIP/2.0 407 Proxy Authentication Required" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5066;received=220.240.255.198:64066;branch=65cacee9-25b6-405c-8f82-e40427438af7" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>;tag=as67b6416e" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Call-ID: 5bcb927f-9571-47d0-a2a1-36226bcf7665@192.168.1.2" + m_CRLF +
-                "CSeq: 908 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Proxy-Authenticate: Digest realm=\"asterisk\", nonce=\"15aeff81\"" + m_CRLF +
-                "Record-Route: <sip:213.168.225.135:5060;lr>" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + m_CRLF + m_CRLF;
+                $"SIP/2.0 407 Proxy Authentication Required{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5066;received=220.240.255.198:64066;branch=65cacee9-25b6-405c-8f82-e40427438af7{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>;tag=as67b6416e{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Call-ID: 5bcb927f-9571-47d0-a2a1-36226bcf7665@192.168.1.2{m_CRLF}CSeq: 908 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: asterisk{m_CRLF}Proxy-Authenticate: Digest realm=\"asterisk\", nonce=\"15aeff81\"{m_CRLF}Record-Route: <sip:213.168.225.135:5060;lr>{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}{m_CRLF}";
             logger.LogDebug("Original SIP Headers:\n{Headers}", authReqdHeaders);
 
             string[] headersCollection = Regex.Split(authReqdHeaders, "\r\n");
@@ -190,16 +148,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string noViaHeaders =
-                "SIP/2.0 407 Proxy Authentication Required" + m_CRLF +
-                "From: dev <sip:aarondev@84.203.144.70>;tag=0013c339acec050c0635cf7b-48c41caf" + m_CRLF +
-                "To: <sip:303@84.203.144.70>;tag=as019f14fe" + m_CRLF +
-                "Call-ID: 0013c339-acec0011-7181eff5-7cfa0e24@89.100.92.186" + m_CRLF +
-                "CSeq: 101 INVITE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133:5061>" + m_CRLF +
-                "Proxy-Authenticate: Digest algorithm=MD5, realm=\"sip.blueface.ie\", nonce=\"789f00ab\"" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"SIP/2.0 407 Proxy Authentication Required{m_CRLF}From: dev <sip:aarondev@84.203.144.70>;tag=0013c339acec050c0635cf7b-48c41caf{m_CRLF}To: <sip:303@84.203.144.70>;tag=as019f14fe{m_CRLF}Call-ID: 0013c339-acec0011-7181eff5-7cfa0e24@89.100.92.186{m_CRLF}CSeq: 101 INVITE{m_CRLF}User-Agent: asterisk{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY{m_CRLF}Contact: <sip:303@213.168.225.133:5061>{m_CRLF}Proxy-Authenticate: Digest algorithm=MD5, realm=\"sip.blueface.ie\", nonce=\"789f00ab\"{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", noViaHeaders);
 
@@ -217,16 +166,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "Via: SIP/2.0/UDP 192.168.1.32:10254;branch=z9hG4bK-d87543-eb7c9f44883c5955-1--d87543-;rport;received=89.100.104.191" + m_CRLF +
-                "To: aaronxten <sip:aaronxten@213.200.94.181>" + m_CRLF +
-                "From: aaronxten <sip:aaronxten@213.200.94.181>;tag=774d2561" + m_CRLF +
-                "Call-ID: MTBhNGZjZmQ2OTc3MWU5MTZjNWUxMDYxOTk1MjdmYzk." + m_CRLF +
-                "CSeq: 2 REGISTER" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.32:10254;rinstance=6d2bbd8014ca7a76>;expires=0" + m_CRLF +
-                "Max-Forwards: 69" + m_CRLF +
-                "expires: 60" + m_CRLF +
-                "User-Agent: X-Lite release 1006e stamp 34025" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO" + m_CRLF + m_CRLF;
+                $"Via: SIP/2.0/UDP 192.168.1.32:10254;branch=z9hG4bK-d87543-eb7c9f44883c5955-1--d87543-;rport;received=89.100.104.191{m_CRLF}To: aaronxten <sip:aaronxten@213.200.94.181>{m_CRLF}From: aaronxten <sip:aaronxten@213.200.94.181>;tag=774d2561{m_CRLF}Call-ID: MTBhNGZjZmQ2OTc3MWU5MTZjNWUxMDYxOTk1MjdmYzk.{m_CRLF}CSeq: 2 REGISTER{m_CRLF}Contact: <sip:aaronxten@192.168.1.32:10254;rinstance=6d2bbd8014ca7a76>;expires=0{m_CRLF}Max-Forwards: 69{m_CRLF}expires: 60{m_CRLF}User-Agent: X-Lite release 1006e stamp 34025{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO{m_CRLF}{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", sipMsg);
 
@@ -246,16 +186,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "From: <sip:10000579@200.170.136.196>;tag=0477183750" + m_CRLF +
-                "To: <sip:10000579@200.170.136.196>;tag=414dedfe" + m_CRLF +
-                "CSeq: 1 REGISTER" + m_CRLF +
-                "Call-ID: 438676792abe47328fc557da2d84d0ee" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.102:7246;branch=z9hG4bK92460620adf84edab2341899a3453f79;received=124.168.235.200;rport=10552" + m_CRLF +
-                "Server: Huawei SoftX3000 R006B03D" + m_CRLF +
-                "WWW-Authenticate: Digest realm=\"huawei\"," + m_CRLF +
-                " nonce=\"248e4b4457f252ae53c859bfe03c4f93\",domain=\"sip:huawei.com\"," + m_CRLF +
-                " stale=false,algorithm=MD5" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"From: <sip:10000579@200.170.136.196>;tag=0477183750{m_CRLF}To: <sip:10000579@200.170.136.196>;tag=414dedfe{m_CRLF}CSeq: 1 REGISTER{m_CRLF}Call-ID: 438676792abe47328fc557da2d84d0ee{m_CRLF}Via: SIP/2.0/UDP 192.168.1.102:7246;branch=z9hG4bK92460620adf84edab2341899a3453f79;received=124.168.235.200;rport=10552{m_CRLF}Server: Huawei SoftX3000 R006B03D{m_CRLF}WWW-Authenticate: Digest realm=\"huawei\",{m_CRLF} nonce=\"248e4b4457f252ae53c859bfe03c4f93\",domain=\"sip:huawei.com\",{m_CRLF} stale=false,algorithm=MD5{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", sipMsg);
 
@@ -278,18 +209,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "From: <sip:10000579@200.170.136.196>;tag=0477183750" + m_CRLF +
-                "To: <sip:10000579@200.170.136.196>;tag=414dedfe" + m_CRLF +
-                "CSeq: 1 REGISTER" + m_CRLF +
-                "Contact: \"Joe Bloggs\" <sip:joe@bloggs.com>;expires=0" + m_CRLF +
-                "Call-ID: 438676792abe47328fc557da2d84d0ee" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.102:7246;branch=z9hG4bK92460620adf84edab2341899a3453f79;received=124.168.235.200;rport=10552" + m_CRLF +
-                "Server: Huawei SoftX3000 R006B03D" + m_CRLF +
-                "WWW-Authenticate: Digest realm=\"huawei\"," + m_CRLF +
-                " nonce=\"248e4b4457f252ae53c859bfe03c4f93\",domain=\"sip:huawei.com\"," + m_CRLF +
-                " stale=false,algorithm=MD5" + m_CRLF +
-                "Contact: \"Jane Doe\" <sip:jane@doe.com>" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"From: <sip:10000579@200.170.136.196>;tag=0477183750{m_CRLF}To: <sip:10000579@200.170.136.196>;tag=414dedfe{m_CRLF}CSeq: 1 REGISTER{m_CRLF}Contact: \"Joe Bloggs\" <sip:joe@bloggs.com>;expires=0{m_CRLF}Call-ID: 438676792abe47328fc557da2d84d0ee{m_CRLF}Via: SIP/2.0/UDP 192.168.1.102:7246;branch=z9hG4bK92460620adf84edab2341899a3453f79;received=124.168.235.200;rport=10552{m_CRLF}Server: Huawei SoftX3000 R006B03D{m_CRLF}WWW-Authenticate: Digest realm=\"huawei\",{m_CRLF} nonce=\"248e4b4457f252ae53c859bfe03c4f93\",domain=\"sip:huawei.com\",{m_CRLF} stale=false,algorithm=MD5{m_CRLF}Contact: \"Jane Doe\" <sip:jane@doe.com>{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", sipMsg);
 
@@ -311,18 +231,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "From: <sip:10000579@200.170.136.196>;tag=0477183750" + m_CRLF +
-                "To: <sip:10000579@200.170.136.196>;tag=414dedfe" + m_CRLF +
-                "CSeq: 1 REGISTER" + m_CRLF +
-                "Call-ID: 438676792abe47328fc557da2d84d0ee" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.102:7246;branch=z9hG4bK92460620adf84edab2341899a3453f79;received=124.168.235.200;rport=10552" + m_CRLF +
-                "Server: Huawei SoftX3000 R006B03D" + m_CRLF +
-                "Refer-To: Test Refer-To" + m_CRLF +
-                "Authentication-Info: Test Authentication-Info" + m_CRLF +
-                "WWW-Authenticate: Digest realm=\"huawei\"," + m_CRLF +
-                " nonce=\"248e4b4457f252ae53c859bfe03c4f93\",domain=\"sip:huawei.com\"," + m_CRLF +
-                " stale=false,algorithm=MD5" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"From: <sip:10000579@200.170.136.196>;tag=0477183750{m_CRLF}To: <sip:10000579@200.170.136.196>;tag=414dedfe{m_CRLF}CSeq: 1 REGISTER{m_CRLF}Call-ID: 438676792abe47328fc557da2d84d0ee{m_CRLF}Via: SIP/2.0/UDP 192.168.1.102:7246;branch=z9hG4bK92460620adf84edab2341899a3453f79;received=124.168.235.200;rport=10552{m_CRLF}Server: Huawei SoftX3000 R006B03D{m_CRLF}Refer-To: Test Refer-To{m_CRLF}Authentication-Info: Test Authentication-Info{m_CRLF}WWW-Authenticate: Digest realm=\"huawei\",{m_CRLF} nonce=\"248e4b4457f252ae53c859bfe03c4f93\",domain=\"sip:huawei.com\",{m_CRLF} stale=false,algorithm=MD5{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", sipMsg);
 
@@ -439,7 +348,7 @@ namespace SIPSorcery.SIP.UnitTests
 
             SIPFromHeader sipFromHeader = SIPFromHeader.ParseFromHeader(testFromHeader);
 
-            Assert.True(sipFromHeader.FromName == "UNAVAILABLE", "The From header name was not parsed correctly, name=" + sipFromHeader.FromName + ".");
+            Assert.True(sipFromHeader.FromName == "UNAVAILABLE", $"The From header name was not parsed correctly, name={sipFromHeader.FromName}.");
             Assert.True(sipFromHeader.FromURI.ToString() == "sip:user@domaintest.com:5060", "The From header URI was not parsed correctly.");
             Assert.True(sipFromHeader.FromTag == "abcd", "The From header Tag was not parsed correctly.");
         }
@@ -767,18 +676,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string inviteHeaders =
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                "Content-Length: 271" + m_CRLF +
-                "Require: abcd, 100rel, xyz" + m_CRLF +
-                "Supported: 100rel, other" + m_CRLF;
+                $"Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}Content-Length: 271{m_CRLF}Require: abcd, 100rel, xyz{m_CRLF}Supported: 100rel, other{m_CRLF}";
 
             string[] headersCollection = Regex.Split(inviteHeaders, "\r\n");
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
@@ -800,16 +698,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string ringResponse =
-                "SIP/2.0 180 Ringing" + m_CRLF +
-                "Via: SIP/2.0/UDP 0.0.0.0:6060;branch=z9hG4bK299925765f7c4defb20cef3fde520172;rport=6060;received=127.0.0.1" + m_CRLF +
-                "To: <sip:127.0.0.1>" + m_CRLF +
-                "From: <sip:thisis@anonymous.invalid>;tag=NEEBBCYYZR" + m_CRLF +
-                "Call-ID: 9add71138b794dadbd709a2b8c0cfc89" + m_CRLF +
-                "CSeq: 1 INVITE" + m_CRLF +
-                "Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, REFER, REGISTER, SUBSCRIBE" + m_CRLF +
-                "Supported: 100rel" + m_CRLF +
-                "Content-Length: 0" + m_CRLF +
-                "RSeq: 266163001" + m_CRLF + m_CRLF;
+                $"SIP/2.0 180 Ringing{m_CRLF}Via: SIP/2.0/UDP 0.0.0.0:6060;branch=z9hG4bK299925765f7c4defb20cef3fde520172;rport=6060;received=127.0.0.1{m_CRLF}To: <sip:127.0.0.1>{m_CRLF}From: <sip:thisis@anonymous.invalid>;tag=NEEBBCYYZR{m_CRLF}Call-ID: 9add71138b794dadbd709a2b8c0cfc89{m_CRLF}CSeq: 1 INVITE{m_CRLF}Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, REFER, REGISTER, SUBSCRIBE{m_CRLF}Supported: 100rel{m_CRLF}Content-Length: 0{m_CRLF}RSeq: 266163001{m_CRLF}{m_CRLF}";
 
             var sipResponse = SIPResponse.ParseSIPResponse(ringResponse);
 
@@ -828,15 +717,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string prackRequest =
-                "PRACK sip:127.0.0.1 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 0.0.0.0:6060;branch=z9hG4bKed0553cb6e4b476990a34d7c98f58a14;rport" + m_CRLF +
-                "To: <sip:127.0.0.1>" + m_CRLF +
-                "From: <sip:thisis@anonymous.invalid>;tag=YPACUCOFBG" + m_CRLF +
-                "Call-ID: c22e9dc218a1423695b1f5ef33020b84" + m_CRLF +
-                "CSeq: 1 ACK" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Length: 0" + m_CRLF +
-                "RAck: 423501656 1 INVITE" + m_CRLF + m_CRLF;
+                $"PRACK sip:127.0.0.1 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 0.0.0.0:6060;branch=z9hG4bKed0553cb6e4b476990a34d7c98f58a14;rport{m_CRLF}To: <sip:127.0.0.1>{m_CRLF}From: <sip:thisis@anonymous.invalid>;tag=YPACUCOFBG{m_CRLF}Call-ID: c22e9dc218a1423695b1f5ef33020b84{m_CRLF}CSeq: 1 ACK{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Length: 0{m_CRLF}RAck: 423501656 1 INVITE{m_CRLF}{m_CRLF}";
 
             var sipRequest = SIPRequest.ParseSIPRequest(prackRequest);
 
@@ -856,16 +737,7 @@ namespace SIPSorcery.SIP.UnitTests
             var expectedServerValue = "SomeServerValue";
 
             string inviteWithServerHeader =
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 271" + m_CRLF +
-                "Server: " + expectedServerValue + m_CRLF;
+                $"Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 271{m_CRLF}Server: {expectedServerValue}{m_CRLF}";
 
             string[] headersCollection = Regex.Split(inviteWithServerHeader, "\r\n");
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);

--- a/test/unit/core/SIP/SIPMessageUnitTest.cs
+++ b/test/unit/core/SIP/SIPMessageUnitTest.cs
@@ -36,17 +36,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 100 Trying" + CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag=" + CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8" + CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142" + CRLF +
-                "To: <sip:303@bluesipd>" + CRLF +
-                "Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2" + CRLF +
-                "CSeq: 45560 INVITE" + CRLF +
-                "User-Agent: asterisk" + CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + CRLF +
-                "Contact: <sip:303@213.168.225.133>" + CRLF +
-                "Content-Length: 0" + CRLF + CRLF;
+                $"SIP/2.0 100 Trying{CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag={CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8{CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142{CRLF}To: <sip:303@bluesipd>{CRLF}Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2{CRLF}CSeq: 45560 INVITE{CRLF}User-Agent: asterisk{CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{CRLF}Contact: <sip:303@213.168.225.133>{CRLF}Content-Length: 0{CRLF}{CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
 
@@ -62,34 +52,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKT36BdhXPlT5cqPFQQr81yMmZ37U=" + CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64216;branch=z9hG4bK7D8B6549580844AEA104BD4A837049DD" + CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=630217013" + CRLF +
-                "To: <sip:303@bluesipd>;tag=as46f418e9" + CRLF +
-                "Call-ID: 9AA41C8F-D691-49F3-B346-2538B5FD962F@192.168.1.2" + CRLF +
-                "CSeq: 27481 INVITE" + CRLF +
-                "User-Agent: asterisk" + CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + CRLF +
-                "Contact: <sip:303@213.168.225.133>" + CRLF +
-                "Content-Type: application/sdp" + CRLF +
-                "Content-Length: 352" + CRLF +
-                CRLF +
-                "v=0" + CRLF +
-                "o=root 24710 24712 IN IP4 213.168.225.133" + CRLF +
-                "s=session" + CRLF +
-                "c=IN IP4 213.168.225.133" + CRLF +
-                "t=0 0" + CRLF +
-                "m=audio 18656 RTP/AVP 0 8 18 3 97 111 101" + CRLF +
-                "a=rtpmap:0 PCMU/8000" + CRLF +
-                "a=rtpmap:8 PCMA/8000" + CRLF +
-                "a=rtpmap:18 G729/8000" + CRLF +
-                "a=rtpmap:3 GSM/8000" + CRLF +
-                "a=rtpmap:97 iLBC/8000" + CRLF +
-                "a=rtpmap:111 G726-32/8000" + CRLF +
-                "a=rtpmap:101 telephone-event/8000" + CRLF +
-                "a=fmtp:101 0-16" + CRLF +
-                "a=silenceSupp:off - - - -" + CRLF;
+                $"SIP/2.0 200 OK{CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKT36BdhXPlT5cqPFQQr81yMmZ37U={CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64216;branch=z9hG4bK7D8B6549580844AEA104BD4A837049DD{CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=630217013{CRLF}To: <sip:303@bluesipd>;tag=as46f418e9{CRLF}Call-ID: 9AA41C8F-D691-49F3-B346-2538B5FD962F@192.168.1.2{CRLF}CSeq: 27481 INVITE{CRLF}User-Agent: asterisk{CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{CRLF}Contact: <sip:303@213.168.225.133>{CRLF}Content-Type: application/sdp{CRLF}Content-Length: 352{CRLF}{CRLF}v=0{CRLF}o=root 24710 24712 IN IP4 213.168.225.133{CRLF}s=session{CRLF}c=IN IP4 213.168.225.133{CRLF}t=0 0{CRLF}m=audio 18656 RTP/AVP 0 8 18 3 97 111 101{CRLF}a=rtpmap:0 PCMU/8000{CRLF}a=rtpmap:8 PCMA/8000{CRLF}a=rtpmap:18 G729/8000{CRLF}a=rtpmap:3 GSM/8000{CRLF}a=rtpmap:97 iLBC/8000{CRLF}a=rtpmap:111 G726-32/8000{CRLF}a=rtpmap:101 telephone-event/8000{CRLF}a=fmtp:101 0-16{CRLF}a=silenceSupp:off - - - -{CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
 
@@ -105,17 +68,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 100 Trying" + CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag=" + CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8" + CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142" + CRLF +
-                "To: <sip:303@bluesipd>" + CRLF +
-                "Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2" + CRLF +
-                "CSeq: 45560 INVITE" + CRLF +
-                "User-Agent: asterisk" + CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + CRLF +
-                "Contact: <sip:303@213.168.225.133>" + CRLF +
-                "Content-Length: 0" + CRLF;
+                $"SIP/2.0 100 Trying{CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag={CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8{CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142{CRLF}To: <sip:303@bluesipd>{CRLF}Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2{CRLF}CSeq: 45560 INVITE{CRLF}User-Agent: asterisk{CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{CRLF}Contact: <sip:303@213.168.225.133>{CRLF}Content-Length: 0{CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
 
@@ -131,28 +84,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK7ae332e73550dbdf2f159061651e7ed5bb88ac52, SIP/2.0/UDP 194.213.29.52:5064;branch=z9hG4bK1121681627" + CRLF +
-                "From: <sip:natkeepalive@194.213.29.52:5064>;tag=8341482660" + CRLF +
-                "To: <sip:user@1.2.3.4:5060>;tag=000e38e46c60ef28651381fe-201e6ab1" + CRLF +
-                "Call-ID: 1125158248@194.213.29.52" + CRLF +
-                "Date: Wed, 29 Nov 2006 22:31:58 GMT" + CRLF +
-                "CSeq: 148 OPTIONS" + CRLF +
-                "Server: CSCO/7" + CRLF +
-                "Content-Type: application/sdp" + CRLF +
-                "Allow: OPTIONS,INVITE,BYE,CANCEL,REGISTER,ACK,NOTIFY,REFER" + CRLF +
-                "Content-Length: 193" + CRLF +
-                CRLF +
-                "v=0" + CRLF +
-                "o=Cisco-SIPUA (null) (null) IN IP4 87.198.196.121" + CRLF +
-                "s=SIP Call" + CRLF +
-                "c=IN IP4 87.198.196.121" + CRLF +
-                "t=0 0" + CRLF +
-                "m=audio 1 RTP/AVP 18 0 8" + CRLF +
-                "a=rtpmap:18 G729/8000" + CRLF +
-                "a=rtpmap:0 PCMU/8000" + CRLF +
-                "a=rtpmap:8 PCMA/8000" + CRLF +
-                CRLF;
+                $"SIP/2.0 200 OK{CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK7ae332e73550dbdf2f159061651e7ed5bb88ac52, SIP/2.0/UDP 194.213.29.52:5064;branch=z9hG4bK1121681627{CRLF}From: <sip:natkeepalive@194.213.29.52:5064>;tag=8341482660{CRLF}To: <sip:user@1.2.3.4:5060>;tag=000e38e46c60ef28651381fe-201e6ab1{CRLF}Call-ID: 1125158248@194.213.29.52{CRLF}Date: Wed, 29 Nov 2006 22:31:58 GMT{CRLF}CSeq: 148 OPTIONS{CRLF}Server: CSCO/7{CRLF}Content-Type: application/sdp{CRLF}Allow: OPTIONS,INVITE,BYE,CANCEL,REGISTER,ACK,NOTIFY,REFER{CRLF}Content-Length: 193{CRLF}{CRLF}v=0{CRLF}o=Cisco-SIPUA (null) (null) IN IP4 87.198.196.121{CRLF}s=SIP Call{CRLF}c=IN IP4 87.198.196.121{CRLF}t=0 0{CRLF}m=audio 1 RTP/AVP 18 0 8{CRLF}a=rtpmap:18 G729/8000{CRLF}a=rtpmap:0 PCMU/8000{CRLF}a=rtpmap:8 PCMA/8000{CRLF}{CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse sipResponse = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -173,18 +105,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
-"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1" + CRLF +
-"To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968" + CRLF +
-"From: <sip:127.0.0.1:5003>;tag=1555449860" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 4 NOTIFY" + CRLF +
-"Content-Length: 2393" + CRLF +
-"Contact: <sip:127.0.0.1:5003>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Event: dialog" + CRLF + CRLF;
+$"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1{CRLF}To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968{CRLF}From: <sip:127.0.0.1:5003>;tag=1555449860{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 4 NOTIFY{CRLF}Content-Length: 2393{CRLF}Contact: <sip:127.0.0.1:5003>{CRLF}Max-Forwards: 69{CRLF}Event: dialog{CRLF}{CRLF}";
 
             byte[] notifyRequestBytes = UTF8Encoding.UTF8.GetBytes(notifyRequest);
 
@@ -205,18 +126,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
-"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1" + CRLF +
-"To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968" + CRLF +
-"From: <sip:127.0.0.1:5003>;tag=1555449860" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 4 NOTIFY" + CRLF +
-"Content-Length      :   2393  " + CRLF +
-"Contact: <sip:127.0.0.1:5003>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Event: dialog" + CRLF + CRLF;
+$"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1{CRLF}To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968{CRLF}From: <sip:127.0.0.1:5003>;tag=1555449860{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 4 NOTIFY{CRLF}Content-Length      :   2393  {CRLF}Contact: <sip:127.0.0.1:5003>{CRLF}Max-Forwards: 69{CRLF}Event: dialog{CRLF}{CRLF}";
 
             byte[] notifyRequestBytes = UTF8Encoding.UTF8.GetBytes(notifyRequest);
 
@@ -237,18 +147,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
-"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1" + CRLF +
-"To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968" + CRLF +
-"From: <sip:127.0.0.1:5003>;tag=1555449860" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 4 NOTIFY" + CRLF +
-"l: 2393" + CRLF +
-"Contact: <sip:127.0.0.1:5003>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Event: dialog" + CRLF + CRLF;
+$"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1{CRLF}To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968{CRLF}From: <sip:127.0.0.1:5003>;tag=1555449860{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 4 NOTIFY{CRLF}l: 2393{CRLF}Contact: <sip:127.0.0.1:5003>{CRLF}Max-Forwards: 69{CRLF}Event: dialog{CRLF}{CRLF}";
 
             byte[] notifyRequestBytes = UTF8Encoding.UTF8.GetBytes(notifyRequest);
 
@@ -270,18 +169,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
-"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1" + CRLF +
-"To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968" + CRLF +
-"From: <sip:127.0.0.1:5003>;tag=1555449860" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 4 NOTIFY" + CRLF +
-"l   :       2393" + CRLF +
-"Contact: <sip:127.0.0.1:5003>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Event: dialog" + CRLF + CRLF;
+$"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1{CRLF}To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968{CRLF}From: <sip:127.0.0.1:5003>;tag=1555449860{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 4 NOTIFY{CRLF}l   :       2393{CRLF}Contact: <sip:127.0.0.1:5003>{CRLF}Max-Forwards: 69{CRLF}Event: dialog{CRLF}{CRLF}";
 
             byte[] notifyRequestBytes = UTF8Encoding.UTF8.GetBytes(notifyRequest);
 
@@ -300,17 +188,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
-"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1" + CRLF +
-"To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968" + CRLF +
-"From: <sip:127.0.0.1:5003>;tag=1555449860" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 4 NOTIFY" + CRLF +
-"Contact: <sip:127.0.0.1:5003>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Event: dialog" + CRLF + CRLF;
+$"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1{CRLF}To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968{CRLF}From: <sip:127.0.0.1:5003>;tag=1555449860{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 4 NOTIFY{CRLF}Contact: <sip:127.0.0.1:5003>{CRLF}Max-Forwards: 69{CRLF}Event: dialog{CRLF}{CRLF}";
 
             byte[] notifyRequestBytes = UTF8Encoding.UTF8.GetBytes(notifyRequest);
             byte[] parsedNotifyBytes = SIPMessageBuffer.ParseSIPMessageFromStream(notifyRequestBytes, 0, notifyRequestBytes.Length, out _);
@@ -328,96 +206,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string notifyRequest =
-"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1" + CRLF +
-"To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968" + CRLF +
-"From: <sip:127.0.0.1:5003>;tag=1555449860" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 4 NOTIFY" + CRLF +
-"Contact: <sip:127.0.0.1:5003>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Content-Length: 2393" + CRLF +
-"Event: dialog" + CRLF +
-CRLF +
-"<?xml version='1.0' encoding='utf-16'?>" + CRLF +
-"<dialog-info xmlns:ss='sipsorcery:dialog-info' version='0' state='full' entity='sip:aaron@10.1.1.5' xmlns='urn:ietf:params:xml:ns:dialog-info'>" + CRLF +
-"  <dialog id='6eab270b-b981-4734-bb6f-a4d33f77c331' call-id='c0a6182504cd4501afb8339f4218704e' local-tag='1047197926' remote-tag='56F30C5C-4B96DF700001F3A1-B67FABB0' direction='initiator'>" + CRLF +
-"    <state>confirmed</state>" + CRLF +
-"    <duration>1676</duration>" + CRLF +
-"    <ss:bridgeid>1c47e24b-4c1b-4dae-af93-567f26a7c215</ss:bridgeid>" + CRLF +
-"    <local>" + CRLF +
-"      <identity>sip:switchboard@10.1.1.5</identity>" + CRLF +
-"      <cseq>1</cseq>" + CRLF +
-"      <ss:sdp>v=0" + CRLF +
-"o=- 1268178554 1268178554 IN IP4 10.1.1.7" + CRLF +
-"s=Polycom IP Phone" + CRLF +
-"c=IN IP4 10.1.1.7" + CRLF +
-"t=0 0" + CRLF +
-"a=sendrecv" + CRLF +
-"m=audio 2262 RTP/AVP 18 0 8 101" + CRLF +
-"a=rtpmap:18 G729/8000" + CRLF +
-"a=rtpmap:0 PCMU/8000" + CRLF +
-"a=rtpmap:8 PCMA/8000" + CRLF +
-"a=rtpmap:101 telephone-event/8000" + CRLF +
-"</ss:sdp>" + CRLF +
-"    </local>" + CRLF +
-"    <remote>" + CRLF +
-"      <identity>sip:music@iptel.org</identity>" + CRLF +
-"      <target uri='sip:music@213.192.59.78:5080' />" + CRLF +
-"      <cseq>1</cseq>" + CRLF +
-"      <ss:sdp>v=0" + CRLF +
-"o=sems 2134578198 1169488647 IN IP4 213.192.59.78" + CRLF +
-"s=session" + CRLF +
-"c=IN IP4 213.192.59.91" + CRLF +
-"t=0 0" + CRLF +
-"m=audio 27712 RTP/AVP 0 8 101" + CRLF +
-"a=rtpmap:0 PCMU/8000" + CRLF +
-"a=rtpmap:8 PCMA/8000" + CRLF +
-"a=rtpmap:101 telephone-event/8000" + CRLF +
-"a=fmtp:101 0-15" + CRLF +
-"</ss:sdp>" + CRLF +
-"    </remote>" + CRLF +
-"  </dialog>" + CRLF +
-"  <dialog id='b5f20497-c482-4b88-99d1-51b13f9d9167' call-id='4b20b31441064c599e63a3a1320322ae' local-tag='1468371802' remote-tag='1048320465' direction='recipient'>" + CRLF +
-"    <state>confirmed</state>" + CRLF +
-"    <duration>1676</duration>" + CRLF +
-"    <ss:bridgeid>1c47e24b-4c1b-4dae-af93-567f26a7c215</ss:bridgeid>" + CRLF +
-"    <local>" + CRLF +
-"      <identity>sip:hold@10.1.1.5@10.1.1.5</identity>" + CRLF +
-"      <cseq>2</cseq>" + CRLF +
-"      <ss:sdp>v=0" + CRLF +
-"o=sems 2134578198 1169488647 IN IP4 213.192.59.78" + CRLF +
-"s=session" + CRLF +
-"c=IN IP4 213.192.59.91" + CRLF +
-"t=0 0" + CRLF +
-"m=audio 27712 RTP/AVP 0 8 101" + CRLF +
-"a=rtpmap:0 PCMU/8000" + CRLF +
-"a=rtpmap:8 PCMA/8000" + CRLF +
-"a=rtpmap:101 telephone-event/8000" + CRLF +
-"a=fmtp:101 0-15" + CRLF +
-"</ss:sdp>" + CRLF +
-"    </local>" + CRLF +
-"    <remote>" + CRLF +
-"      <identity>sip:switchboard@10.1.1.5</identity>" + CRLF +
-"      <target uri='sip:10.1.1.5:62442;transport=tcp' />" + CRLF +
-"      <cseq>2</cseq>" + CRLF +
-"      <ss:sdp>v=0" + CRLF +
-"o=- 1268178554 1268178554 IN IP4 10.1.1.7" + CRLF +
-"s=Polycom IP Phone" + CRLF +
-"c=IN IP4 10.1.1.7" + CRLF +
-"t=0 0" + CRLF +
-"a=sendrecv" + CRLF +
-"m=audio 2262 RTP/AVP 18 0 8 101" + CRLF +
-"a=rtpmap:18 G729/8000" + CRLF +
-"a=rtpmap:0 PCMU/8000" + CRLF +
-"a=rtpmap:8 PCMA/8000" + CRLF +
-"a=rtpmap:101 telephone-event/8000" + CRLF +
-"</ss:sdp>" + CRLF +
-"    </remote>" + CRLF +
-"  </dialog>" + CRLF +
-"</dialog-info>";
+$"NOTIFY sip:10.1.1.5:62647;transport=tcp SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKa4d17f991015b1d8b788f2ac54d66ec66811226a;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKc2224b79f5af4c4a9b1cd649890c6497;rport{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5003;branch=z9hG4bK0495dc29b7eb40008779a75c3734c4c5;rport=5003;received=127.0.0.1{CRLF}To: <sip:10.1.1.5:62647;transport=tcp>;tag=1892981968{CRLF}From: <sip:127.0.0.1:5003>;tag=1555449860{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 4 NOTIFY{CRLF}Contact: <sip:127.0.0.1:5003>{CRLF}Max-Forwards: 69{CRLF}Content-Length: 2393{CRLF}Event: dialog{CRLF}{CRLF}<?xml version='1.0' encoding='utf-16'?>{CRLF}<dialog-info xmlns:ss='sipsorcery:dialog-info' version='0' state='full' entity='sip:aaron@10.1.1.5' xmlns='urn:ietf:params:xml:ns:dialog-info'>{CRLF}  <dialog id='6eab270b-b981-4734-bb6f-a4d33f77c331' call-id='c0a6182504cd4501afb8339f4218704e' local-tag='1047197926' remote-tag='56F30C5C-4B96DF700001F3A1-B67FABB0' direction='initiator'>{CRLF}    <state>confirmed</state>{CRLF}    <duration>1676</duration>{CRLF}    <ss:bridgeid>1c47e24b-4c1b-4dae-af93-567f26a7c215</ss:bridgeid>{CRLF}    <local>{CRLF}      <identity>sip:switchboard@10.1.1.5</identity>{CRLF}      <cseq>1</cseq>{CRLF}      <ss:sdp>v=0{CRLF}o=- 1268178554 1268178554 IN IP4 10.1.1.7{CRLF}s=Polycom IP Phone{CRLF}c=IN IP4 10.1.1.7{CRLF}t=0 0{CRLF}a=sendrecv{CRLF}m=audio 2262 RTP/AVP 18 0 8 101{CRLF}a=rtpmap:18 G729/8000{CRLF}a=rtpmap:0 PCMU/8000{CRLF}a=rtpmap:8 PCMA/8000{CRLF}a=rtpmap:101 telephone-event/8000{CRLF}</ss:sdp>{CRLF}    </local>{CRLF}    <remote>{CRLF}      <identity>sip:music@iptel.org</identity>{CRLF}      <target uri='sip:music@213.192.59.78:5080' />{CRLF}      <cseq>1</cseq>{CRLF}      <ss:sdp>v=0{CRLF}o=sems 2134578198 1169488647 IN IP4 213.192.59.78{CRLF}s=session{CRLF}c=IN IP4 213.192.59.91{CRLF}t=0 0{CRLF}m=audio 27712 RTP/AVP 0 8 101{CRLF}a=rtpmap:0 PCMU/8000{CRLF}a=rtpmap:8 PCMA/8000{CRLF}a=rtpmap:101 telephone-event/8000{CRLF}a=fmtp:101 0-15{CRLF}</ss:sdp>{CRLF}    </remote>{CRLF}  </dialog>{CRLF}  <dialog id='b5f20497-c482-4b88-99d1-51b13f9d9167' call-id='4b20b31441064c599e63a3a1320322ae' local-tag='1468371802' remote-tag='1048320465' direction='recipient'>{CRLF}    <state>confirmed</state>{CRLF}    <duration>1676</duration>{CRLF}    <ss:bridgeid>1c47e24b-4c1b-4dae-af93-567f26a7c215</ss:bridgeid>{CRLF}    <local>{CRLF}      <identity>sip:hold@10.1.1.5@10.1.1.5</identity>{CRLF}      <cseq>2</cseq>{CRLF}      <ss:sdp>v=0{CRLF}o=sems 2134578198 1169488647 IN IP4 213.192.59.78{CRLF}s=session{CRLF}c=IN IP4 213.192.59.91{CRLF}t=0 0{CRLF}m=audio 27712 RTP/AVP 0 8 101{CRLF}a=rtpmap:0 PCMU/8000{CRLF}a=rtpmap:8 PCMA/8000{CRLF}a=rtpmap:101 telephone-event/8000{CRLF}a=fmtp:101 0-15{CRLF}</ss:sdp>{CRLF}    </local>{CRLF}    <remote>{CRLF}      <identity>sip:switchboard@10.1.1.5</identity>{CRLF}      <target uri='sip:10.1.1.5:62442;transport=tcp' />{CRLF}      <cseq>2</cseq>{CRLF}      <ss:sdp>v=0{CRLF}o=- 1268178554 1268178554 IN IP4 10.1.1.7{CRLF}s=Polycom IP Phone{CRLF}c=IN IP4 10.1.1.7{CRLF}t=0 0{CRLF}a=sendrecv{CRLF}m=audio 2262 RTP/AVP 18 0 8 101{CRLF}a=rtpmap:18 G729/8000{CRLF}a=rtpmap:0 PCMU/8000{CRLF}a=rtpmap:8 PCMA/8000{CRLF}a=rtpmap:101 telephone-event/8000{CRLF}</ss:sdp>{CRLF}    </remote>{CRLF}  </dialog>{CRLF}</dialog-info>";
 
             byte[] notifyRequestBytes = Encoding.ASCII.GetBytes(notifyRequest);
             byte[] parsedNotifyBytes = SIPMessageBuffer.ParseSIPMessageFromStream(notifyRequestBytes, 0, notifyRequestBytes.Length, out _);
@@ -435,48 +224,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
-            "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-CRLF +
-"includesdp=trueSUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bK82b1f0704fc31f47b4c9e0bc383d3e0e41f2a60f;rport" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bK6d88a47e4b5c4bde9c45270ca64a1c53;rport" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport=62647;received=10.1.1.5" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 69" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-"Proxy-ReceivedFrom: tcp:10.1.1.5:62647" + CRLF +
-"Proxy-ReceivedOn: tcp:10.1.1.5:4506" + CRLF +
-CRLF +
-"includesdp=trueSIP/2.0 200 Ok" + CRLF +
-"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKba4e75d7c55baef96457b36b7b570dae9a253dd8;rport=5060;received=127.0.0.1" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKc6f4c0fcd4684246abf539848017c0f0;rport" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bK17bbf15513b44e6aa88b605410148d2b;rport=62647;received=10.1.1.5" + CRLF +
-"To: <sip:switchboard@10.1.1.5>;tag=2140367015" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1557768010" + CRLF +
-"Call-ID: a65b4461-6929-4604-b498-256f6643e6ac" + CRLF +
-"CSeq: 2 REGISTER" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>;expires=113" + CRLF +
-"Date: Wed, 10 Mar 2010 00:21:14 GMT" + CRLF +
-"Content-Length: 0" + CRLF +
-"Server: www.sipsorcery.com" + CRLF + CRLF;
+            $"SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 70{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}{CRLF}includesdp=trueSUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bK82b1f0704fc31f47b4c9e0bc383d3e0e41f2a60f;rport{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bK6d88a47e4b5c4bde9c45270ca64a1c53;rport{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport=62647;received=10.1.1.5{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 69{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}Proxy-ReceivedFrom: tcp:10.1.1.5:62647{CRLF}Proxy-ReceivedOn: tcp:10.1.1.5:4506{CRLF}{CRLF}includesdp=trueSIP/2.0 200 Ok{CRLF}Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKba4e75d7c55baef96457b36b7b570dae9a253dd8;rport=5060;received=127.0.0.1{CRLF}Via: SIP/2.0/TCP 10.1.1.5:4506;branch=z9hG4bKc6f4c0fcd4684246abf539848017c0f0;rport{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bK17bbf15513b44e6aa88b605410148d2b;rport=62647;received=10.1.1.5{CRLF}To: <sip:switchboard@10.1.1.5>;tag=2140367015{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1557768010{CRLF}Call-ID: a65b4461-6929-4604-b498-256f6643e6ac{CRLF}CSeq: 2 REGISTER{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>;expires=113{CRLF}Date: Wed, 10 Mar 2010 00:21:14 GMT{CRLF}Content-Length: 0{CRLF}Server: www.sipsorcery.com{CRLF}{CRLF}";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(testReceive);
 
@@ -502,20 +250,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
-            "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-"" + CRLF +
-"includesdp=tru";
+            $"SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 70{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}{CRLF}includesdp=tru";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(testReceive);
             byte[] request1Bytes = SIPMessageBuffer.ParseSIPMessageFromStream(testReceiveBytes, 0, testReceiveBytes.Length, out _);
@@ -533,20 +268,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
-            "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-CRLF +
-"includesdp=true!";
+            $"SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 70{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}{CRLF}includesdp=true!";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(testReceive);
             byte[] request1Bytes = SIPMessageBuffer.ParseSIPMessageFromStream(testReceiveBytes, 0, testReceiveBytes.Length, out _);
@@ -566,20 +288,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
-            "SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-"" + CRLF +
-"include                                               ";
+            $"SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 70{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}{CRLF}include                                               ";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(testReceive);
             byte[] request1Bytes = SIPMessageBuffer.ParseSIPMessageFromStream(testReceiveBytes, 0, testReceiveBytes.Length - 100, out _);
@@ -597,20 +306,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
-            "    SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-CRLF +
-"includesdp=true";
+            $"    SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 70{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}{CRLF}includesdp=true";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(testReceive);
 
@@ -633,20 +329,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string testReceive =
-"            SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0" + CRLF +
-"Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport" + CRLF +
-"To: <sip:aaron@10.1.1.5>" + CRLF +
-"From: <sip:switchboard@10.1.1.5>;tag=1902440575" + CRLF +
-"Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a" + CRLF +
-"CSeq: 3 SUBSCRIBE" + CRLF +
-"Contact: <sip:10.1.1.5:62647;transport=tcp>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Expires: 600" + CRLF +
-"Content-Length: 15" + CRLF +
-"Content-Type: text/text" + CRLF +
-"Event: dialog" + CRLF +
-CRLF +
-"includesdp=true";
+$"            SUBSCRIBE sip:aaron@10.1.1.5 SIP/2.0{CRLF}Via: SIP/2.0/TCP 10.1.1.5:62647;branch=z9hG4bKa58b912c426f415daa887289efda50cd;rport{CRLF}To: <sip:aaron@10.1.1.5>{CRLF}From: <sip:switchboard@10.1.1.5>;tag=1902440575{CRLF}Call-ID: 1b569032-d1e4-4869-be9f-67d4ba8a4e3a{CRLF}CSeq: 3 SUBSCRIBE{CRLF}Contact: <sip:10.1.1.5:62647;transport=tcp>{CRLF}Max-Forwards: 70{CRLF}Expires: 600{CRLF}Content-Length: 15{CRLF}Content-Type: text/text{CRLF}Event: dialog{CRLF}{CRLF}includesdp=true";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(testReceive);
 
@@ -680,17 +363,7 @@ CRLF +
             Assert.True(SIPMessageBuffer.IsPing(buffer), "Buffer \\0\\0\\0\\0 is not a Ping message.");
 
             string sipMsg =
-                "SIP/2.0 100 Trying" + CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag=" + CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8" + CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142" + CRLF +
-                "To: <sip:303@bluesipd>" + CRLF +
-                "Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2" + CRLF +
-                "CSeq: 45560 INVITE" + CRLF +
-                "User-Agent: asterisk" + CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + CRLF +
-                "Contact: <sip:303@213.168.225.133>" + CRLF +
-                "Content-Length: 0" + CRLF + CRLF;
+                $"SIP/2.0 100 Trying{CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag={CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8{CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142{CRLF}To: <sip:303@bluesipd>{CRLF}Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2{CRLF}CSeq: 45560 INVITE{CRLF}User-Agent: asterisk{CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{CRLF}Contact: <sip:303@213.168.225.133>{CRLF}Content-Length: 0{CRLF}{CRLF}";
 
             Assert.False(SIPMessageBuffer.IsPing(Encoding.UTF8.GetBytes(sipMsg)), "The SIP message is a Ping.");
 
@@ -704,17 +377,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-    "SIP/2.0 100 Trying" + CRLF +
-    "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag=" + CRLF +
-    "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8" + CRLF +
-    "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142" + CRLF +
-    "To: <sip:303@bluesipd>" + CRLF +
-    "Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2" + CRLF +
-    "CSeq: 45560 INVITE" + CRLF +
-    "User-Agent: asterisk" + CRLF +
-    "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + CRLF +
-    "Contact: <sip:303@213.168.225.133>" + CRLF +
-    "Content-Length: 0" + CRLF + CRLF;
+    $"SIP/2.0 100 Trying{CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag={CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8{CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142{CRLF}To: <sip:303@bluesipd>{CRLF}Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2{CRLF}CSeq: 45560 INVITE{CRLF}User-Agent: asterisk{CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{CRLF}Contact: <sip:303@213.168.225.133>{CRLF}Content-Length: 0{CRLF}{CRLF}";
 
             byte[] testReceiveBytes = UTF8Encoding.UTF8.GetBytes(sipMsg);
             var localEndPoint = new SIPEndPoint(new IPEndPoint(IPAddress.Parse("192.168.1.1"), 5060));

--- a/test/unit/core/SIP/SIPRequestUnitTest.cs
+++ b/test/unit/core/SIP/SIPRequestUnitTest.cs
@@ -41,30 +41,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                "Content-Length: 271" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=aaronxten 423137371 423137414 IN IP4 192.168.1.2" + m_CRLF +
-                "s=X-PRO" + m_CRLF +
-                "c=IN IP4 192.168.1.2" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 8004 RTP/AVP 0 8 3 97 101" + m_CRLF +
-                "a=rtpmap:0 pcmu/8000" + m_CRLF +
-                "a=rtpmap:8 pcma/8000" + m_CRLF +
-                "a=rtpmap:3 gsm/8000" + m_CRLF +
-                "a=rtpmap:97 speex/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-15" + m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}Content-Length: 271{m_CRLF}{m_CRLF}v=0{m_CRLF}o=aaronxten 423137371 423137414 IN IP4 192.168.1.2{m_CRLF}s=X-PRO{m_CRLF}c=IN IP4 192.168.1.2{m_CRLF}t=0 0{m_CRLF}m=audio 8004 RTP/AVP 0 8 3 97 101{m_CRLF}a=rtpmap:0 pcmu/8000{m_CRLF}a=rtpmap:8 pcma/8000{m_CRLF}a=rtpmap:3 gsm/8000{m_CRLF}a=rtpmap:97 speex/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-15{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -92,19 +69,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-            "REGISTER sip:sip.sipsorcery.com SIP/2.0" + m_CRLF +
-            "CSeq: 1142 REGISTER" + m_CRLF +
-            "Via: SIP/2.0/UDP 24.183.120.253:5060;branch=z9hG4bKeab06dc6-4b03-1910-9cbd-0ceee68cfdc5;rport" + m_CRLF +
-            "User-Agent: Ekiga/3.2.7" + m_CRLF +
-            "Authorization: Digest username='twolmsted', realm='sipsorcery.com', nonce='14116380271465720944', uri='sip:sip.sipsorcery.com', algorithm=MD5, response='e9e190a05c482e0c287829ecf6d42207'" + m_CRLF +
-            "From: <sip:twolmsted@sip.sipsorcery.com>;tag=0021d3c4-4a03-1910-9c86-0ceee68cfdc5" + m_CRLF +
-            "Call-ID: 0021d3c4-4a03-1910-9c84-0ceee68cfdc5@two-PC" + m_CRLF +
-            "To: <sip:twolmsted@sip.sipsorcery.com>" + m_CRLF +
-            "Contact: <sip:twolmsted@24.183.120.253, sip:5060>" + m_CRLF +
-            "Allow: INVITE,ACK,OPTIONS,BYE,CANCEL,SUBSCRIBE,NOTIFY,REFER,MESSAGE,INFO,PING" + m_CRLF +
-            "Expires: 3600" + m_CRLF +
-            "Content-Length: 0" + m_CRLF +
-            "Max-Forwards: 70" + m_CRLF + m_CRLF;
+            $"REGISTER sip:sip.sipsorcery.com SIP/2.0{m_CRLF}CSeq: 1142 REGISTER{m_CRLF}Via: SIP/2.0/UDP 24.183.120.253:5060;branch=z9hG4bKeab06dc6-4b03-1910-9cbd-0ceee68cfdc5;rport{m_CRLF}User-Agent: Ekiga/3.2.7{m_CRLF}Authorization: Digest username='twolmsted', realm='sipsorcery.com', nonce='14116380271465720944', uri='sip:sip.sipsorcery.com', algorithm=MD5, response='e9e190a05c482e0c287829ecf6d42207'{m_CRLF}From: <sip:twolmsted@sip.sipsorcery.com>;tag=0021d3c4-4a03-1910-9c86-0ceee68cfdc5{m_CRLF}Call-ID: 0021d3c4-4a03-1910-9c84-0ceee68cfdc5@two-PC{m_CRLF}To: <sip:twolmsted@sip.sipsorcery.com>{m_CRLF}Contact: <sip:twolmsted@24.183.120.253, sip:5060>{m_CRLF}Allow: INVITE,ACK,OPTIONS,BYE,CANCEL,SUBSCRIBE,NOTIFY,REFER,MESSAGE,INFO,PING{m_CRLF}Expires: 3600{m_CRLF}Content-Length: 0{m_CRLF}Max-Forwards: 70{m_CRLF}{m_CRLF}";
 
             Assert.Throws<SIPValidationException>(() => SIPRequest.ParseSIPRequest(sipMsg));
         }
@@ -116,16 +81,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "ACK sip:303@213.168.225.133 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bK3667AD800F014BD685C2E0A8B2AB9D0F" + m_CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=396492091" + m_CRLF +
-                "To: <sip:303@bluesipd>;tag=as022cbb0e" + m_CRLF +
-                "Contact: <sip:bluesipd@192.168.1.2:5065>" + m_CRLF +
-                "Route: <sip:213.168.225.135;lr>" + m_CRLF +
-                "Call-ID: EDA17D42-034E-438B-8467-18DF1E4678A7@192.168.1.2" + m_CRLF +
-                "CSeq: 39639 ACK" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"ACK sip:303@213.168.225.133 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bK3667AD800F014BD685C2E0A8B2AB9D0F{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=396492091{m_CRLF}To: <sip:303@bluesipd>;tag=as022cbb0e{m_CRLF}Contact: <sip:bluesipd@192.168.1.2:5065>{m_CRLF}Route: <sip:213.168.225.135;lr>{m_CRLF}Call-ID: EDA17D42-034E-438B-8467-18DF1E4678A7@192.168.1.2{m_CRLF}CSeq: 39639 ACK{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest ackReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -146,19 +102,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "ACK sip:303@213.168.225.133:5061 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 89.100.92.186:5060;branch=z9hG4bK1254dba9" + m_CRLF +
-                "From: dev <sip:aaron@azaclauson.dyndns.org>" + m_CRLF +
-                "To: <sip:303@azaclauson.dyndns.org>;tag=as108bd3ae" + m_CRLF +
-                "Call-ID: 0013c339-acec0041-61c7c61e-3eb0b7c0@89.100.92.186" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Date: Mon, 07 Aug 2006 14:57:40 GMT" + m_CRLF +
-                "CSeq: 102 ACK" + m_CRLF +
-                "User-Agent: Cisco-CP7960G/8.0" + m_CRLF +
-                "Route: <sip:89.100.92.186:6060;lr>" + m_CRLF +
-                "Proxy-Authorization: Digest username=\"aaron\",realm=\"sip.blueface.ie\",uri=\"sip:303@azaclauson.dyndns.org\",response=\"638c8fb6186fe865e80f6232cc417c3f\",nonce=\"44f121a2\",algorithm=md5" + m_CRLF +
-                "Remote-Party-ID: \"dev\" <sip:aaron@89.100.92.186>;party=calling;id-type=subscriber;privacy=off;screen=yes" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"ACK sip:303@213.168.225.133:5061 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 89.100.92.186:5060;branch=z9hG4bK1254dba9{m_CRLF}From: dev <sip:aaron@azaclauson.dyndns.org>{m_CRLF}To: <sip:303@azaclauson.dyndns.org>;tag=as108bd3ae{m_CRLF}Call-ID: 0013c339-acec0041-61c7c61e-3eb0b7c0@89.100.92.186{m_CRLF}Max-Forwards: 70{m_CRLF}Date: Mon, 07 Aug 2006 14:57:40 GMT{m_CRLF}CSeq: 102 ACK{m_CRLF}User-Agent: Cisco-CP7960G/8.0{m_CRLF}Route: <sip:89.100.92.186:6060;lr>{m_CRLF}Proxy-Authorization: Digest username=\"aaron\",realm=\"sip.blueface.ie\",uri=\"sip:303@azaclauson.dyndns.org\",response=\"638c8fb6186fe865e80f6232cc417c3f\",nonce=\"44f121a2\",algorithm=md5{m_CRLF}Remote-Party-ID: \"dev\" <sip:aaron@89.100.92.186>;party=calling;id-type=subscriber;privacy=off;screen=yes{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest ackReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -179,17 +123,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "BYE sip:303@213.168.225.133 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bK7F023DE3FF8941008DE7DCE71A20CB78" + m_CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=396492091" + m_CRLF +
-                "To: <sip:303@bluesipd>;tag=as022cbb0e" + m_CRLF +
-                "Contact: <sip:bluesipd@192.168.1.2:5065>" + m_CRLF +
-                "Route: <sip:213.168.225.135;lr>" + m_CRLF +
-                "Call-ID: EDA17D42-034E-438B-8467-18DF1E4678A7@192.168.1.2" + m_CRLF +
-                "CSeq: 39640 BYE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"BYE sip:303@213.168.225.133 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bK7F023DE3FF8941008DE7DCE71A20CB78{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=396492091{m_CRLF}To: <sip:303@bluesipd>;tag=as022cbb0e{m_CRLF}Contact: <sip:bluesipd@192.168.1.2:5065>{m_CRLF}Route: <sip:213.168.225.135;lr>{m_CRLF}Call-ID: EDA17D42-034E-438B-8467-18DF1E4678A7@192.168.1.2{m_CRLF}CSeq: 39640 BYE{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest byeReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -209,16 +143,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK74ab714b;rport" + m_CRLF +
-                "Route: <sip:bluesipd@192.168.1.2:5065>" + m_CRLF +
-                "From: <sip:303@bluesipd>;tag=as6a65fae3" + m_CRLF +
-                "To: bluesipd <sip:bluesipd@bluesipd:5065>;tag=1898247079" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Call-ID: 80B34165-8C89-4623-B862-40AFB1884071@192.168.1.2" + m_CRLF +
-                "CSeq: 102 BYE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK74ab714b;rport{m_CRLF}Route: <sip:bluesipd@192.168.1.2:5065>{m_CRLF}From: <sip:303@bluesipd>;tag=as6a65fae3{m_CRLF}To: bluesipd <sip:bluesipd@bluesipd:5065>;tag=1898247079{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Call-ID: 80B34165-8C89-4623-B862-40AFB1884071@192.168.1.2{m_CRLF}CSeq: 102 BYE{m_CRLF}User-Agent: asterisk{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest byeReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -239,22 +164,13 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK483ca249;rport" + m_CRLF +
-                "Route: <sip:220.240.255.198:64300;lr>,<sip:bluesipd@192.168.1.2:5065>" + m_CRLF +
-                "From: <sip:303@bluesipd>;tag=as7a10c774" + m_CRLF +
-                "To: bluesipd <sip:bluesipd@bluesipd:5065>;tag=2561975990" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Call-ID: D9D08936-5455-476C-A5A2-A069D4B8DBFF@192.168.1.2" + m_CRLF +
-                "CSeq: 102 BYE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK483ca249;rport{m_CRLF}Route: <sip:220.240.255.198:64300;lr>,<sip:bluesipd@192.168.1.2:5065>{m_CRLF}From: <sip:303@bluesipd>;tag=as7a10c774{m_CRLF}To: bluesipd <sip:bluesipd@bluesipd:5065>;tag=2561975990{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Call-ID: D9D08936-5455-476C-A5A2-A069D4B8DBFF@192.168.1.2{m_CRLF}CSeq: 102 BYE{m_CRLF}User-Agent: asterisk{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest byeReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
 
             SIPRoute topRoute = byeReq.Header.Routes.PopRoute();
-            Assert.True(topRoute.Host == "220.240.255.198:64300", "The top route was not parsed correctly, top route IP address was " + topRoute.Host + ".");
+            Assert.True(topRoute.Host == "220.240.255.198:64300", $"The top route was not parsed correctly, top route IP address was {topRoute.Host}.");
 
             logger.LogDebug("-----------------------------------------");
         }
@@ -266,21 +182,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SUBSCRIBE sip:0123456@127.0.0.1 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.10:15796" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "From: \"user@sip.domain.com\" <sip:user@sipdomain.com>;tag=a6cf9fe4cdee4e1cad88240403b95669;epid=1bb41c1f89" + m_CRLF +
-                "To: <sip:0123456@sip.blueface.ie>;tag=as211b359e" + m_CRLF +
-                "Call-ID: abebae2060d747c3ba11a0d0cde9ab0b" + m_CRLF +
-                "CSeq: 81 SUBSCRIBE" + m_CRLF +
-                "Contact: <sip:192.168.1.10:15796>" + m_CRLF +
-                "User-Agent: RTC/1.3" + m_CRLF +
-                "Event: presence" + m_CRLF +
-                "Accept: application/xpidf+xml, text/xml+msrtc.pidf, application/pidf+xml" + m_CRLF +
-                "Supported: com.microsoft.autoextend" + m_CRLF +
-                "Supported: ms-benotify" + m_CRLF +
-                "Proxy-Require: ms-benotify" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"SUBSCRIBE sip:0123456@127.0.0.1 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.10:15796{m_CRLF}Max-Forwards: 70{m_CRLF}From: \"user@sip.domain.com\" <sip:user@sipdomain.com>;tag=a6cf9fe4cdee4e1cad88240403b95669;epid=1bb41c1f89{m_CRLF}To: <sip:0123456@sip.blueface.ie>;tag=as211b359e{m_CRLF}Call-ID: abebae2060d747c3ba11a0d0cde9ab0b{m_CRLF}CSeq: 81 SUBSCRIBE{m_CRLF}Contact: <sip:192.168.1.10:15796>{m_CRLF}User-Agent: RTC/1.3{m_CRLF}Event: presence{m_CRLF}Accept: application/xpidf+xml, text/xml+msrtc.pidf, application/pidf+xml{m_CRLF}Supported: com.microsoft.autoextend{m_CRLF}Supported: ms-benotify{m_CRLF}Proxy-Require: ms-benotify{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest subscribeReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -297,17 +199,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:Blue Face SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: PA168S" + m_CRLF +
-                "From: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5" + m_CRLF +
-                "To: \"user\" <sip:user@Blue Face>" + m_CRLF +
-                "Call-ID: DHZVs1HFuMoTQ6LO@82.114.95.1" + m_CRLF +
-                "CSeq: 15754 REGISTER" + m_CRLF +
-                "Contact: <sip:user@127.0.0.1:1720>" + m_CRLF +
-                "Expires: 30" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"REGISTER sip:Blue Face SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: PA168S{m_CRLF}From: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5{m_CRLF}To: \"user\" <sip:user@Blue Face>{m_CRLF}Call-ID: DHZVs1HFuMoTQ6LO@82.114.95.1{m_CRLF}CSeq: 15754 REGISTER{m_CRLF}Contact: <sip:user@127.0.0.1:1720>{m_CRLF}Expires: 30{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest registerReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -327,18 +219,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 83.70.206.42:5060port;branch=z9hG4bK77c61058c08e3a6737e4c76e6241cc3f" + m_CRLF +
-                "To: <sip:100001@sip.blueface.ie:5060>" + m_CRLF +
-                "From: <sip:100001@sip.blueface.ie:5060>;tag=AI5A09C508-2F0401CDFF625DD3" + m_CRLF +
-                "Call-ID: AI5A09C4D6-3122395B17A0C101@192.168.14.250" + m_CRLF +
-                "CSeq: 25015 REGISTER" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Expires: 3000" + m_CRLF +
-                "Contact: <sip:100001@83.70.206.42:5060\n" +
-                "Allow: ACK,BYE,CANCEL,INVITE,NOTIFY,OPTIONS,REFER" + m_CRLF +
-                "User-Agent: Aastra Intelligate" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"REGISTER sip:sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 83.70.206.42:5060port;branch=z9hG4bK77c61058c08e3a6737e4c76e6241cc3f{m_CRLF}To: <sip:100001@sip.blueface.ie:5060>{m_CRLF}From: <sip:100001@sip.blueface.ie:5060>;tag=AI5A09C508-2F0401CDFF625DD3{m_CRLF}Call-ID: AI5A09C4D6-3122395B17A0C101@192.168.14.250{m_CRLF}CSeq: 25015 REGISTER{m_CRLF}Max-Forwards: 70{m_CRLF}Expires: 3000{m_CRLF}Contact: <sip:100001@83.70.206.42:5060\nAllow: ACK,BYE,CANCEL,INVITE,NOTIFY,OPTIONS,REFER{m_CRLF}User-Agent: Aastra Intelligate{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.Throws<SIPValidationException>(() => SIPRequest.ParseSIPRequest(sipMessageBuffer));
@@ -351,36 +232,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:12345@sip.domain.com:5060;TCID-0 SIP/2.0" + m_CRLF +
-                "From: UNAVAILABLE<sip:user@sip.domain.com:5060>;tag=c0a83dfe-13c4-26bf01-975a21d0-2d8a" + m_CRLF +
-                "To: <sip:1234@sipdomain.com:5060>" + m_CRLF +
-                "Call-ID: 94b6e3f8-c0a83dfe-13c4-26bf01-975a21ce-52c@sip.domain.com" + m_CRLF +
-                "CSeq: 1 INVITE" + m_CRLF +
-                "Via: SIP/2.0/UDP 86.9.84.23:5060;branch=z9hG4bK-26bf01-975a21d0-1ffb" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: TA612V-V1.2_54" + m_CRLF +
-                "Supported: timer,replaces" + m_CRLF +
-                "Contact: <sip:user@88.8.88.88:5060>" + m_CRLF +
-                "Content-Type: application/SDP" + m_CRLF +
-                "Content-Length: 386" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=b0000 613 888 IN IP4 88.8.88.88" + m_CRLF +
-                "s=SIP Call" + m_CRLF +
-                "c=IN IP4 88.8.88.88" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 10000 RTP/AVP 0 101 18 100 101 2 103 8" + m_CRLF +
-                "a=fmtp:101 0-15" + m_CRLF +
-                "a=fmtp:18 annexb=no" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=rtpmap:100 G726-16/8000" + m_CRLF +
-                "a=rtpmap:101 G726-24/8000" + m_CRLF +
-                "a=rtpmap:2 G726-32/8000" + m_CRLF +
-                "a=rtpmap:103 G726-40/8000" + m_CRLF +
-                "a=rtpmap:8 PCMA/8000";
+                $"INVITE sip:12345@sip.domain.com:5060;TCID-0 SIP/2.0{m_CRLF}From: UNAVAILABLE<sip:user@sip.domain.com:5060>;tag=c0a83dfe-13c4-26bf01-975a21d0-2d8a{m_CRLF}To: <sip:1234@sipdomain.com:5060>{m_CRLF}Call-ID: 94b6e3f8-c0a83dfe-13c4-26bf01-975a21ce-52c@sip.domain.com{m_CRLF}CSeq: 1 INVITE{m_CRLF}Via: SIP/2.0/UDP 86.9.84.23:5060;branch=z9hG4bK-26bf01-975a21d0-1ffb{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: TA612V-V1.2_54{m_CRLF}Supported: timer,replaces{m_CRLF}Contact: <sip:user@88.8.88.88:5060>{m_CRLF}Content-Type: application/SDP{m_CRLF}Content-Length: 386{m_CRLF}{m_CRLF}v=0{m_CRLF}o=b0000 613 888 IN IP4 88.8.88.88{m_CRLF}s=SIP Call{m_CRLF}c=IN IP4 88.8.88.88{m_CRLF}t=0 0{m_CRLF}m=audio 10000 RTP/AVP 0 101 18 100 101 2 103 8{m_CRLF}a=fmtp:101 0-15{m_CRLF}a=fmtp:18 annexb=no{m_CRLF}a=sendrecv{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=rtpmap:100 G726-16/8000{m_CRLF}a=rtpmap:101 G726-24/8000{m_CRLF}a=rtpmap:2 G726-32/8000{m_CRLF}a=rtpmap:103 G726-40/8000{m_CRLF}a=rtpmap:8 PCMA/8000";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -397,18 +249,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.10:15796" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "From: <sip:user@sip.blueface.ie>;tag=1a52c38c46e3439c8b4fe8a58f5ae834;epid=1bb41c1f89" + m_CRLF +
-                "To: <sip:user@sip.blueface.ie>" + m_CRLF +
-                "Call-ID: aeb2c6c905a84610a54de60bb6ef476c" + m_CRLF +
-                "CSeq: 417 REGISTER" + m_CRLF +
-                "Contact: <sip:192.168.1.10:15796>;methods=\"INVITE, MESSAGE, INFO, SUBSCRIBE, OPTIONS, BYE, CANCEL, NOTIFY, ACK, REFER, BENOTIFY\"" + m_CRLF +
-                "User-Agent: RTC/1.3.5470 (Messenger 5.1.0680)" + m_CRLF +
-                "Event: registration" + m_CRLF +
-                "Allow-Events: presence" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"REGISTER sip:sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.10:15796{m_CRLF}Max-Forwards: 70{m_CRLF}From: <sip:user@sip.blueface.ie>;tag=1a52c38c46e3439c8b4fe8a58f5ae834;epid=1bb41c1f89{m_CRLF}To: <sip:user@sip.blueface.ie>{m_CRLF}Call-ID: aeb2c6c905a84610a54de60bb6ef476c{m_CRLF}CSeq: 417 REGISTER{m_CRLF}Contact: <sip:192.168.1.10:15796>;methods=\"INVITE, MESSAGE, INFO, SUBSCRIBE, OPTIONS, BYE, CANCEL, NOTIFY, ACK, REFER, BENOTIFY\"{m_CRLF}User-Agent: RTC/1.3.5470 (Messenger 5.1.0680){m_CRLF}Event: registration{m_CRLF}Allow-Events: presence{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest registerReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -423,17 +264,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:194.213.29.11 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 86.9.88.23:5060;branch=z9hG4bK15dbeda2" + m_CRLF +
-                "From: <sip:sip2@194.213.29.11;user=phone>" + m_CRLF +
-                "To: <sip:sip2@194.213.29.11;user=phone>" + m_CRLF +
-                "Call-ID: 0013c339-acec0005-7488d654-42a83bd0@192.168.1.100" + m_CRLF +
-                "Date: Sat, 22 Apr 2006 00:47:31 GMT" + m_CRLF +
-                "CSeq: 10389 REGISTER" + m_CRLF +
-                "User-Agent: CSCO/7" + m_CRLF +
-                "Contact: <sip:sip2@86.9.88.23:5060;user=phone>" + m_CRLF +
-                "Content-Length: 0" + m_CRLF +
-                "Expires: 3600" + m_CRLF + m_CRLF;
+                $"REGISTER sip:194.213.29.11 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 86.9.88.23:5060;branch=z9hG4bK15dbeda2{m_CRLF}From: <sip:sip2@194.213.29.11;user=phone>{m_CRLF}To: <sip:sip2@194.213.29.11;user=phone>{m_CRLF}Call-ID: 0013c339-acec0005-7488d654-42a83bd0@192.168.1.100{m_CRLF}Date: Sat, 22 Apr 2006 00:47:31 GMT{m_CRLF}CSeq: 10389 REGISTER{m_CRLF}User-Agent: CSCO/7{m_CRLF}Contact: <sip:sip2@86.9.88.23:5060;user=phone>{m_CRLF}Content-Length: 0{m_CRLF}Expires: 3600{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest registerReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -446,18 +277,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 86.9.88.23:10060;branch=z9hG4bK1DFDB76492E74691A3DF68AC672DAA7C" + m_CRLF +
-                "From: Aaron <sip:aaronxten@blueface.ie>;tag=2090971807" + m_CRLF +
-                "To: Aaron <sip:aaronxten@blueface.ie>" + m_CRLF +
-                "Call-ID: 19CBFF5EB6CB4668A29BEF0C3DC49910@blueface.ie" + m_CRLF +
-                "CSeq: 24291 REGISTER" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Contact: \"Aaron\" <sip:aaronxten@86.9.88.23:10060>" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                "Expires: 1800" + m_CRLF +
-                "Authorization: Digest realm=\"sip.blueface.ie\",nonce=\"1694683214\",username=\"aaronxten\",response=\"85f2089ac958e69ce4d74f5ae72a9a5f\",uri=\"sip:blueface.ie\"" + m_CRLF +
-                m_CRLF;
+                $"REGISTER sip:blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 86.9.88.23:10060;branch=z9hG4bK1DFDB76492E74691A3DF68AC672DAA7C{m_CRLF}From: Aaron <sip:aaronxten@blueface.ie>;tag=2090971807{m_CRLF}To: Aaron <sip:aaronxten@blueface.ie>{m_CRLF}Call-ID: 19CBFF5EB6CB4668A29BEF0C3DC49910@blueface.ie{m_CRLF}CSeq: 24291 REGISTER{m_CRLF}Max-Forwards: 70{m_CRLF}Contact: \"Aaron\" <sip:aaronxten@86.9.88.23:10060>{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}Expires: 1800{m_CRLF}Authorization: Digest realm=\"sip.blueface.ie\",nonce=\"1694683214\",username=\"aaronxten\",response=\"85f2089ac958e69ce4d74f5ae72a9a5f\",uri=\"sip:blueface.ie\"{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest registerReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -467,9 +287,9 @@ namespace SIPSorcery.SIP.UnitTests
             SIPAuthenticationHeader authHeader = registerReq.Header.AuthenticationHeaders[0];
 
             Assert.True(authHeader != null, "The Authorization header was not correctly extracted from the SIP Register Request.");
-            Assert.True(authHeader.SIPDigest.Nonce == "1694683214", "The Authorization header nonce was not correctly extracted from the SIP Register Request, header nonce = " + authHeader.SIPDigest.Nonce + ".");
+            Assert.True(authHeader.SIPDigest.Nonce == "1694683214", $"The Authorization header nonce was not correctly extracted from the SIP Register Request, header nonce = {authHeader.SIPDigest.Nonce}.");
             Assert.True(authHeader.SIPDigest.Realm == "sip.blueface.ie", "The Authorization header realm was not correctly extracted from the SIP Register Request.");
-            Assert.True(authHeader.SIPDigest.Username == "aaronxten", "The Authorization username nonce was not correctly extracted from the SIP Register Request, header username = " + authHeader.SIPDigest.Username + ".");
+            Assert.True(authHeader.SIPDigest.Username == "aaronxten", $"The Authorization username nonce was not correctly extracted from the SIP Register Request, header username = {authHeader.SIPDigest.Username}.");
             Assert.True(authHeader.SIPDigest.URI == "sip:blueface.ie", "The Authorization header URI was not correctly extracted from the SIP Register Request.");
             Assert.True(authHeader.SIPDigest.Response == "85f2089ac958e69ce4d74f5ae72a9a5f", "The Authorization header response was not correctly extracted from the SIP Register Request.");
         }
@@ -481,18 +301,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:aaronmsn SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.31:16879" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "From: <sip:aaronmsn>;tag=27359cb6dcdb4b8e9570dd9fc4b09c14;epid=5649ab5588" + m_CRLF +
-                "To: <sip:aaronmsn>" + m_CRLF +
-                "Call-ID: 19b7a4c8c6d647b19afe031df5e91332@192.168.1.31" + m_CRLF +
-                "CSeq: 1 REGISTER" + m_CRLF +
-                "Contact: <sip:192.168.1.31:16879>;methods=\"INVITE, MESSAGE, INFO, SUBSCRIBE, OPTIONS, BYE, CANCEL, NOTIFY, ACK, REFER\"" + m_CRLF +
-                "User-Agent: RTC/1.2.4949" + m_CRLF +
-                "Event: registration" + m_CRLF +
-                "Allow-Events: presence" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"REGISTER sip:aaronmsn SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.31:16879{m_CRLF}Max-Forwards: 70{m_CRLF}From: <sip:aaronmsn>;tag=27359cb6dcdb4b8e9570dd9fc4b09c14;epid=5649ab5588{m_CRLF}To: <sip:aaronmsn>{m_CRLF}Call-ID: 19b7a4c8c6d647b19afe031df5e91332@192.168.1.31{m_CRLF}CSeq: 1 REGISTER{m_CRLF}Contact: <sip:192.168.1.31:16879>;methods=\"INVITE, MESSAGE, INFO, SUBSCRIBE, OPTIONS, BYE, CANCEL, NOTIFY, ACK, REFER\"{m_CRLF}User-Agent: RTC/1.2.4949{m_CRLF}Event: registration{m_CRLF}Allow-Events: presence{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest registerReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -507,17 +316,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -539,8 +338,8 @@ namespace SIPSorcery.SIP.UnitTests
         {
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
-               
-            string sipMsg = 
+
+            string sipMsg =
                 "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
                 "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
                 "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
@@ -557,11 +356,11 @@ namespace SIPSorcery.SIP.UnitTests
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
 
             string branchId = inviteReq.CreateBranchId();
-				
+
             SIPViaHeader requestVia = new SIPViaHeader("192.168.1.2", 5065, branchId);
-                
+
             inviteReq.Header.Via.PushViaHeader(requestVia);
-				
+
             Assert.True(inviteReq.IsLoop("192.168.1.2", 5065, branchId), "The SIP request was not correctly detected as a loop.");
 
             logger.LogDebug("-----------------------------------------");
@@ -574,18 +373,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "Route: <sip:82.195.148.216:5062;lr>,<sip:89.100.92.186:45270;lr>" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}Route: <sip:82.195.148.216:5062;lr>,<sip:89.100.92.186:45270;lr>{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -608,18 +396,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "Route: <sip:82.195.148.216:5062;lr>,<sip:89.100.92.186:45270;lr>" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}Route: <sip:82.195.148.216:5062;lr>,<sip:89.100.92.186:45270;lr>{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -642,18 +419,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "Route: <sip:82.195.148.216:5062;lr>,<sip:89.100.92.186:45270;lr>" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}Route: <sip:82.195.148.216:5062;lr>,<sip:89.100.92.186:45270;lr>{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -674,18 +440,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:82.195.148.216:5062;lr SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "Route: <sip:89.100.92.186:45270;lr>,<sip:303@sip.blueface.ie>" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:82.195.148.216:5062;lr SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}Route: <sip:89.100.92.186:45270;lr>,<sip:303@sip.blueface.ie>{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -711,18 +466,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "Route: <sip:82.195.148.216:5062;lr>,<sip:10.10.10.10>,<sip:89.100.92.186:45270;lr>" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}Route: <sip:82.195.148.216:5062;lr>,<sip:10.10.10.10>,<sip:89.100.92.186:45270;lr>{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -749,18 +493,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "Route: <sip:sip.blueface.ie;lr>,<sip:89.100.92.186:45270;lr>" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: X-PRO release 1103v" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}Route: <sip:sip.blueface.ie;lr>,<sip:89.100.92.186:45270;lr>{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -784,17 +517,7 @@ namespace SIPSorcery.SIP.UnitTests
             // This is an example of a malformed response received in the wild. It matches the bnf format for a request,
             // if the format of the SIP URI is not taken into account.
             string sipMsg =
-                "16394SIP/2.0 200 OK" + m_CRLF +
-                "To: <sip:user@83.70.216.94:5056>;tag=56314300b3ccd13fi0" + m_CRLF +
-                "From: <sip:natkeepalive@194.213.29.52:5064>;tag=7816855980" + m_CRLF +
-                "Call-ID: 1652975648@194.213.29.52" + m_CRLF +
-                "CSeq: 685 OPTIONS" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK46427189218ce28213adfb77e9df73b8ba6f6f0b" + m_CRLF +
-                "Via: SIP/2.0/UDP 194.213.29.52:5064;branch=z9hG4bK1531800555" + m_CRLF +
-                "Server: Linksys/PAP2-3.1.3(LS)" + m_CRLF +
-                "Content-Length: 5" + m_CRLF +
-                "Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, REFER" + m_CRLF +
-                "Supported: x-sipura" + m_CRLF + m_CRLF;
+                $"16394SIP/2.0 200 OK{m_CRLF}To: <sip:user@83.70.216.94:5056>;tag=56314300b3ccd13fi0{m_CRLF}From: <sip:natkeepalive@194.213.29.52:5064>;tag=7816855980{m_CRLF}Call-ID: 1652975648@194.213.29.52{m_CRLF}CSeq: 685 OPTIONS{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK46427189218ce28213adfb77e9df73b8ba6f6f0b{m_CRLF}Via: SIP/2.0/UDP 194.213.29.52:5064;branch=z9hG4bK1531800555{m_CRLF}Server: Linksys/PAP2-3.1.3(LS){m_CRLF}Content-Length: 5{m_CRLF}Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, REFER{m_CRLF}Supported: x-sipura{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.Throws<SIPValidationException>(() => SIPRequest.ParseSIPRequest(sipMessageBuffer));
@@ -809,16 +532,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:213.200.94.181 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.32:10254;branch=z9hG4bK-d87543-eb7c9f44883c5955-1--d87543-;rport;received=89.100.104.191" + m_CRLF +
-                "To: aaronxten <sip:aaronxten@213.200.94.181>" + m_CRLF +
-                "From: aaronxten <sip:aaronxten@213.200.94.181>;tag=774d2561" + m_CRLF +
-                "Call-ID: MTBhNGZjZmQ2OTc3MWU5MTZjNWUxMDYxOTk1MjdmYzk." + m_CRLF +
-                "CSeq: 2 REGISTER" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.32:10254;rinstance=6d2bbd8014ca7a76>;expires=0" + m_CRLF +
-                "Max-Forwards: 69" + m_CRLF +
-                "User-Agent: X-Lite release 1006e stamp 34025" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO" + m_CRLF + m_CRLF;
+                $"REGISTER sip:213.200.94.181 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.32:10254;branch=z9hG4bK-d87543-eb7c9f44883c5955-1--d87543-;rport;received=89.100.104.191{m_CRLF}To: aaronxten <sip:aaronxten@213.200.94.181>{m_CRLF}From: aaronxten <sip:aaronxten@213.200.94.181>;tag=774d2561{m_CRLF}Call-ID: MTBhNGZjZmQ2OTc3MWU5MTZjNWUxMDYxOTk1MjdmYzk.{m_CRLF}CSeq: 2 REGISTER{m_CRLF}Contact: <sip:aaronxten@192.168.1.32:10254;rinstance=6d2bbd8014ca7a76>;expires=0{m_CRLF}Max-Forwards: 69{m_CRLF}User-Agent: X-Lite release 1006e stamp 34025{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest registerReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -835,43 +549,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:194.213.29.100:5060 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 10.1.1.241;branch=z9hG4bK94fc63626" + m_CRLF +
-                "To: UNKNOWN <sip:8219000@sip.194.213.29.100>" + m_CRLF +
-                "From: 'Joe Bloggs' <sip:ei9gz@blueface.ie>;tag=cc16d34c122e5fe" + m_CRLF +
-                "Call-ID: 61d0b3a80f5727a9be56ac739e8b0581@blueface.ie" + m_CRLF +
-                "CSeq: 2009546910 INVITE" + m_CRLF +
-                "Contact: 'Val Gavin' <sip:ei9gz@10.1.1.241>" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Route: <sip:8219522@sip.194.213.29.100>" + m_CRLF +    // Strict Route header (this header is actually a fault but it ends up being a strict route).
-                "User-Agent: NeuralX MxSF/v3.2.6.26" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 318" + m_CRLF +
-                "P-Asserted-Identity: 'Joe Bloggs' <sip:9@blueface.ie>" + m_CRLF +
-                "Allow: INVITE" + m_CRLF +
-                "Allow: CANCEL" + m_CRLF +
-                "Allow: OPTIONS" + m_CRLF +
-                "Allow: BYE" + m_CRLF +
-                "Allow: REFER" + m_CRLF +
-                "Allow: INFO" + m_CRLF +
-                "Allow: UPDATE" + m_CRLF +
-                "Supported: replaces" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=xxxxx 1174909600 1174909601 IN IP4 10.1.1.241" + m_CRLF +
-                "s=-" + m_CRLF +
-                "c=IN IP4 10.1.1.241" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "m=audio 20026 RTP/AVP 8 0 18 101" + m_CRLF +
-                "a=rtpmap:8 PCMA/8000" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:18 annexb=no" + m_CRLF +
-                "a=fmtp:101 0-15" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=rtcp:20027 IN IP4 10.1.1.241";
+                $"INVITE sip:194.213.29.100:5060 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 10.1.1.241;branch=z9hG4bK94fc63626{m_CRLF}To: UNKNOWN <sip:8219000@sip.194.213.29.100>{m_CRLF}From: 'Joe Bloggs' <sip:ei9gz@blueface.ie>;tag=cc16d34c122e5fe{m_CRLF}Call-ID: 61d0b3a80f5727a9be56ac739e8b0581@blueface.ie{m_CRLF}CSeq: 2009546910 INVITE{m_CRLF}Contact: 'Val Gavin' <sip:ei9gz@10.1.1.241>{m_CRLF}Max-Forwards: 70{m_CRLF}Route: <sip:8219522@sip.194.213.29.100>{m_CRLF}User-Agent: NeuralX MxSF/v3.2.6.26{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 318{m_CRLF}P-Asserted-Identity: 'Joe Bloggs' <sip:9@blueface.ie>{m_CRLF}Allow: INVITE{m_CRLF}Allow: CANCEL{m_CRLF}Allow: OPTIONS{m_CRLF}Allow: BYE{m_CRLF}Allow: REFER{m_CRLF}Allow: INFO{m_CRLF}Allow: UPDATE{m_CRLF}Supported: replaces{m_CRLF}{m_CRLF}v=0{m_CRLF}o=xxxxx 1174909600 1174909601 IN IP4 10.1.1.241{m_CRLF}s=-{m_CRLF}c=IN IP4 10.1.1.241{m_CRLF}t=0 0{m_CRLF}a=sendrecv{m_CRLF}m=audio 20026 RTP/AVP 8 0 18 101{m_CRLF}a=rtpmap:8 PCMA/8000{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:18 annexb=no{m_CRLF}a=fmtp:101 0-15{m_CRLF}a=ptime:20{m_CRLF}a=rtcp:20027 IN IP4 10.1.1.241";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -896,31 +574,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:shebeen@sip.mysipswitch.com;switchtag=134308 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 77.75.25.45;branch=z9hG4bK048.7b51ac95.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.166.9.4:5060;branch=76c5c145958c18a58a4b8f83c82476d8;rport=5060" + m_CRLF +
-                "To: \"02031296073\" <sip:02031296073@213.166.9.4>" + m_CRLF +
-                "From: \"Anonymous\" <sip:213.166.9.4:5060>;tag=3433217327-893254" + m_CRLF +
-                "Call-ID: 334573-3433217327-893210@interface-e1000g0" + m_CRLF +
-                "CSeq: 1 INVITE" + m_CRLF +
-                "Contact: <sip:213.166.9.4:5060>" + m_CRLF +
-                "Max-Forwards: 12" + m_CRLF +
-                "Record-Route: <sip:77.75.25.45;lr=on;ftag=3433217327-893254>" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 162" + m_CRLF +
-                "Session-Expires: 3600;Refresher=uac" + m_CRLF +
-                "Supported: timer" + m_CRLF +
-                "P-Asserted-Identity:<sip:unknown@213.166.9.4>" + m_CRLF +
-                "Privacy: none" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=NexTone-MSW 1234 0 IN IP4 213.166.9.6" + m_CRLF +
-                "s=sip call" + m_CRLF +
-                "c=IN IP4 213.166.9.6" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 55694 RTP/AVP 0 8 18" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=fmtp:18 annexb=yes";
+                $"INVITE sip:shebeen@sip.mysipswitch.com;switchtag=134308 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 77.75.25.45;branch=z9hG4bK048.7b51ac95.0{m_CRLF}Via: SIP/2.0/UDP 213.166.9.4:5060;branch=76c5c145958c18a58a4b8f83c82476d8;rport=5060{m_CRLF}To: \"02031296073\" <sip:02031296073@213.166.9.4>{m_CRLF}From: \"Anonymous\" <sip:213.166.9.4:5060>;tag=3433217327-893254{m_CRLF}Call-ID: 334573-3433217327-893210@interface-e1000g0{m_CRLF}CSeq: 1 INVITE{m_CRLF}Contact: <sip:213.166.9.4:5060>{m_CRLF}Max-Forwards: 12{m_CRLF}Record-Route: <sip:77.75.25.45;lr=on;ftag=3433217327-893254>{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 162{m_CRLF}Session-Expires: 3600;Refresher=uac{m_CRLF}Supported: timer{m_CRLF}P-Asserted-Identity:<sip:unknown@213.166.9.4>{m_CRLF}Privacy: none{m_CRLF}{m_CRLF}v=0{m_CRLF}o=NexTone-MSW 1234 0 IN IP4 213.166.9.6{m_CRLF}s=sip call{m_CRLF}c=IN IP4 213.166.9.6{m_CRLF}t=0 0{m_CRLF}m=audio 55694 RTP/AVP 0 8 18{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=fmtp:18 annexb=yes";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -937,18 +591,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK483ca249;rport" + m_CRLF +
-                "Route: <sip:220.240.255.198:64300;lr>,<sip:bluesipd@192.168.1.2:5065>" + m_CRLF +
-                "Route: <sip:21.10.21.2;lr>,<sip:bluesipd@90.91.82.12>,<sip:bluesipd@90.91.82.12>" + m_CRLF +
-                "Route: <sip:2.3.22.2;lr>,<sip:bluesipd@90.91.82.12>" + m_CRLF +
-                "From: <sip:303@bluesipd>;tag=as7a10c774" + m_CRLF +
-                "To: bluesipd <sip:bluesipd@bluesipd:5065>;tag=2561975990" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Call-ID: D9D08936-5455-476C-A5A2-A069D4B8DBFF@192.168.1.2" + m_CRLF +
-                "CSeq: 102 BYE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"BYE sip:bluesipd@192.168.1.2:5065 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK483ca249;rport{m_CRLF}Route: <sip:220.240.255.198:64300;lr>,<sip:bluesipd@192.168.1.2:5065>{m_CRLF}Route: <sip:21.10.21.2;lr>,<sip:bluesipd@90.91.82.12>,<sip:bluesipd@90.91.82.12>{m_CRLF}Route: <sip:2.3.22.2;lr>,<sip:bluesipd@90.91.82.12>{m_CRLF}From: <sip:303@bluesipd>;tag=as7a10c774{m_CRLF}To: bluesipd <sip:bluesipd@bluesipd:5065>;tag=2561975990{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Call-ID: D9D08936-5455-476C-A5A2-A069D4B8DBFF@192.168.1.2{m_CRLF}CSeq: 102 BYE{m_CRLF}User-Agent: asterisk{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest byeReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -979,20 +622,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "INVITE sip:0447507533@69.59.142.213 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP checksecuritytester.sinologic.net:5060;branch=z9hG4bK34323636;rport" + m_CRLF +
-                "From: \"0447507533\" <sip:0447507533@checksecuritytester.sinologic.net>;tag=as55c3de87" + m_CRLF +
-                "To: <sip:0447507533@69.59.142.213>" + m_CRLF +
-                "Contact: <sip:0447507533@checksecuritytester.sinologic.net>" + m_CRLF +
-                "Call-ID: 5c4df8b003fe7b900fa3cfaf7f0e4d21@69.59.142.213" + m_CRLF +
-                "CSeq: 102 INVITE" + m_CRLF +
-                "User-Agent: SIP Security Tester" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Date: Fri, 1 Jul 2011 12:54:11 GMT" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY, INFO" + m_CRLF +
-                "Supported: replaces" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 232" + m_CRLF + m_CRLF;
+                $"INVITE sip:0447507533@69.59.142.213 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP checksecuritytester.sinologic.net:5060;branch=z9hG4bK34323636;rport{m_CRLF}From: \"0447507533\" <sip:0447507533@checksecuritytester.sinologic.net>;tag=as55c3de87{m_CRLF}To: <sip:0447507533@69.59.142.213>{m_CRLF}Contact: <sip:0447507533@checksecuritytester.sinologic.net>{m_CRLF}Call-ID: 5c4df8b003fe7b900fa3cfaf7f0e4d21@69.59.142.213{m_CRLF}CSeq: 102 INVITE{m_CRLF}User-Agent: SIP Security Tester{m_CRLF}Max-Forwards: 70{m_CRLF}Date: Fri, 1 Jul 2011 12:54:11 GMT{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY, INFO{m_CRLF}Supported: replaces{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 232{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest inviteReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -1007,16 +637,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "ACK sip:67.222.131.147 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 1234.s1.minisipserver.com;branch=z9hG4bK-MSS-508bd56b768a2403;rport" + m_CRLF +
-                "To: \"300\" <sip:300@sipsorcery.com>;tag=XPGJDZQUZD" + m_CRLF +
-                "From: \"user\" <sip:aaronminisip@sipsorcery.com>;tag=c76ba46e" + m_CRLF +
-                "Call-ID: A0D069D5C4FF31D9A627957CMSS33C800AB." + m_CRLF +
-                "CSeq: 2 ACK" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: miniSIPServer Cloud" + m_CRLF +
-                "Proxy-Authorization: Digest username=\"user\",realm=\"sipsorcery.com\",nonce=\"13046264131868153844\",uri=\"sip:300@sipsorcery.com\",response=\"7b3b69c82a8ca80e5d6c58d4be652a79\",opaque=\"\",algorithm=MD5" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"ACK sip:67.222.131.147 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 1234.s1.minisipserver.com;branch=z9hG4bK-MSS-508bd56b768a2403;rport{m_CRLF}To: \"300\" <sip:300@sipsorcery.com>;tag=XPGJDZQUZD{m_CRLF}From: \"user\" <sip:aaronminisip@sipsorcery.com>;tag=c76ba46e{m_CRLF}Call-ID: A0D069D5C4FF31D9A627957CMSS33C800AB.{m_CRLF}CSeq: 2 ACK{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: miniSIPServer Cloud{m_CRLF}Proxy-Authorization: Digest username=\"user\",realm=\"sipsorcery.com\",nonce=\"13046264131868153844\",uri=\"sip:300@sipsorcery.com\",response=\"7b3b69c82a8ca80e5d6c58d4be652a79\",opaque=\"\",algorithm=MD5{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest ackReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);
@@ -1095,17 +716,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sipRequestStr = "REGISTER sip:dummy@dummy SIP/2.0" + m_CRLF +
-"Via: SIP/2.0/UDP 0.0.0.0;branch=z9hG4bKb4313133e5fe42da87034c2b22ac2aab;rport" + m_CRLF +
-"To: <sip:dummy@dummy>" + m_CRLF +
-"From: <sip:0.0.0.0:0>;tag=OLBDXPNBTJ" + m_CRLF +
-"Call-ID: 2b79ac74010c494aa1eaaacb9819d77d" + m_CRLF +
-"CSeq: 1 REGISTER" + m_CRLF +
-"Max-Forwards: 70" + m_CRLF +
-"Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, PRACK, REFER, REGISTER, SUBSCRIBE" + m_CRLF +
-"Content-Length: 0" + m_CRLF +
-"" + m_CRLF +
-"";
+            string sipRequestStr = $"REGISTER sip:dummy@dummy SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 0.0.0.0;branch=z9hG4bKb4313133e5fe42da87034c2b22ac2aab;rport{m_CRLF}To: <sip:dummy@dummy>{m_CRLF}From: <sip:0.0.0.0:0>;tag=OLBDXPNBTJ{m_CRLF}Call-ID: 2b79ac74010c494aa1eaaacb9819d77d{m_CRLF}CSeq: 1 REGISTER{m_CRLF}Max-Forwards: 70{m_CRLF}Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, PRACK, REFER, REGISTER, SUBSCRIBE{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
             SIPRequest registerRequest = SIPRequest.ParseSIPRequest(sipRequestStr);
 
             logger.LogDebug("{RequestRequest}", registerRequest.ToString());
@@ -1388,7 +999,7 @@ Content-Length: 0
 
 ";
             SIPRequest req = SIPRequest.ParseSIPRequest(inviteReq);
-           
+
             Assert.True(req.Header.HistoryInfo.Count == 2);
             Assert.True(req.Header.HistoryInfo[0].Parameters.Get("index") == "1", "History-Info Header Sort error, HistoryInfo[0] does't contain 'index=1'");
             Assert.True(req.Header.HistoryInfo[1].Parameters.Get("index") == "1.1", "History-Info Header Sort error, HistoryInfo[1] does't contain 'index=1.1'");
@@ -1564,18 +1175,7 @@ Content-Length: 0
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SERVICE sip:user1@something.com SIP/2.0" + m_CRLF +
-                "From: <sip:user2@something.com>;epid=85D7DC3A61;tag=ddfb74b87" + m_CRLF +
-                "To: <sip:user1@something.com>" + m_CRLF +
-                "Call-ID: fc2gbd6449264ecfbe9rbf23f11f7be9" + m_CRLF +
-                "CSEQ: 73 SERVICE" + m_CRLF +
-                "CONTACT: <sip:user2@something.com>" + m_CRLF +
-                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;" + m_CRLF +
-                "Max-Forwards: 67" + m_CRLF +
-                "Content-Length: 5" + m_CRLF +
-                "CONTENT-TYPE: text/text" + m_CRLF +
-                "USER-AGENT: Agent" + m_CRLF + m_CRLF +
-                "abcd" + m_CRLF;
+                $"SERVICE sip:user1@something.com SIP/2.0{m_CRLF}From: <sip:user2@something.com>;epid=85D7DC3A61;tag=ddfb74b87{m_CRLF}To: <sip:user1@something.com>{m_CRLF}Call-ID: fc2gbd6449264ecfbe9rbf23f11f7be9{m_CRLF}CSEQ: 73 SERVICE{m_CRLF}CONTACT: <sip:user2@something.com>{m_CRLF}Via: SIP/2.0/UDP 10.0.0.1:5060;branch=yxxxcvvvbbbnnmm1;{m_CRLF}Max-Forwards: 67{m_CRLF}Content-Length: 5{m_CRLF}CONTENT-TYPE: text/text{m_CRLF}USER-AGENT: Agent{m_CRLF}{m_CRLF}abcd{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPRequest serviceReq = SIPRequest.ParseSIPRequest(sipMessageBuffer);

--- a/test/unit/core/SIP/SIPResponseUnitTest.cs
+++ b/test/unit/core/SIP/SIPResponseUnitTest.cs
@@ -45,17 +45,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 100 Trying" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag=" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8" + m_CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142" + m_CRLF +
-                "To: <sip:303@bluesipd>" + m_CRLF +
-                "Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2" + m_CRLF +
-                "CSeq: 45560 INVITE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"SIP/2.0 100 Trying{m_CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKD+ta2mJ+C+VV/L50aPO1lFJnrag={m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64193;branch=z9hG4bKB86FC8D2431F49E9862D1EE439C78AD8{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=3272744142{m_CRLF}To: <sip:303@bluesipd>{m_CRLF}Call-ID: FE63F90D-4339-4AD0-9D44-59F44A1935E7@192.168.1.2{m_CRLF}CSeq: 45560 INVITE{m_CRLF}User-Agent: asterisk{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse tryingResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -72,34 +62,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKT36BdhXPlT5cqPFQQr81yMmZ37U=" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64216;branch=z9hG4bK7D8B6549580844AEA104BD4A837049DD" + m_CRLF +
-                "From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=630217013" + m_CRLF +
-                "To: <sip:303@bluesipd>;tag=as46f418e9" + m_CRLF +
-                "Call-ID: 9AA41C8F-D691-49F3-B346-2538B5FD962F@192.168.1.2" + m_CRLF +
-                "CSeq: 27481 INVITE" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + m_CRLF +
-                "Contact: <sip:303@213.168.225.133>" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 352" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=root 24710 24712 IN IP4 213.168.225.133" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 213.168.225.133" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 18656 RTP/AVP 0 8 18 3 97 111 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:8 PCMA/8000" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=rtpmap:3 GSM/8000" + m_CRLF +
-                "a=rtpmap:97 iLBC/8000" + m_CRLF +
-                "a=rtpmap:111 G726-32/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF;
+                $"SIP/2.0 200 OK{m_CRLF}Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bKT36BdhXPlT5cqPFQQr81yMmZ37U={m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64216;branch=z9hG4bK7D8B6549580844AEA104BD4A837049DD{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=630217013{m_CRLF}To: <sip:303@bluesipd>;tag=as46f418e9{m_CRLF}Call-ID: 9AA41C8F-D691-49F3-B346-2538B5FD962F@192.168.1.2{m_CRLF}CSeq: 27481 INVITE{m_CRLF}User-Agent: asterisk{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 352{m_CRLF}{m_CRLF}v=0{m_CRLF}o=root 24710 24712 IN IP4 213.168.225.133{m_CRLF}s=session{m_CRLF}c=IN IP4 213.168.225.133{m_CRLF}t=0 0{m_CRLF}m=audio 18656 RTP/AVP 0 8 18 3 97 111 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:8 PCMA/8000{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=rtpmap:3 GSM/8000{m_CRLF}a=rtpmap:97 iLBC/8000{m_CRLF}a=rtpmap:111 G726-32/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -116,27 +79,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sipMsg = "SIP/2.0 200 OK" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK10a1fab0" + m_CRLF +
-                "From: \"Unknown\" <sip:Unknown@213.168.225.133>;tag=as18338373" + m_CRLF +
-                "To: <sip:unknown@194.46.240.216>;tag=OLg-20481" + m_CRLF +
-                "Call-ID: 675be0e1060ec5785593b125441ff9ac@213.168.225.133" + m_CRLF +
-                "CSeq: 102 OPTIONS" + m_CRLF +
-                "content-type: application/sdp" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, INFO, REFER, NOTIFY" + m_CRLF +
-                "Content-Length: 217" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=0 5972727 56415 IN IP4 0.0.0.0" + m_CRLF +
-                "s=SIP Call" + m_CRLF +
-                "c=IN IP4 0.0.0.0" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 0 RTP/AVP 18 0 8 4 2" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=rtpmap:0 pcmu/8000" + m_CRLF +
-                "a=rtpmap:8 pcma/8000" + m_CRLF +
-                "a=rtpmap:4 g723/8000" + m_CRLF +
-                "a=rtpmap:2 g726/8000" + m_CRLF;
+            string sipMsg = $"SIP/2.0 200 OK{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK10a1fab0{m_CRLF}From: \"Unknown\" <sip:Unknown@213.168.225.133>;tag=as18338373{m_CRLF}To: <sip:unknown@194.46.240.216>;tag=OLg-20481{m_CRLF}Call-ID: 675be0e1060ec5785593b125441ff9ac@213.168.225.133{m_CRLF}CSeq: 102 OPTIONS{m_CRLF}content-type: application/sdp{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, INFO, REFER, NOTIFY{m_CRLF}Content-Length: 217{m_CRLF}{m_CRLF}v=0{m_CRLF}o=0 5972727 56415 IN IP4 0.0.0.0{m_CRLF}s=SIP Call{m_CRLF}c=IN IP4 0.0.0.0{m_CRLF}t=0 0{m_CRLF}m=audio 0 RTP/AVP 18 0 8 4 2{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=rtpmap:0 pcmu/8000{m_CRLF}a=rtpmap:8 pcma/8000{m_CRLF}a=rtpmap:4 g723/8000{m_CRLF}a=rtpmap:2 g726/8000{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -153,16 +96,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sipMsg = "SIP/2.0 403 Forbidden" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.1;branch=z9hG4bKbcb78f72d221beec" + m_CRLF +
-                "From: <sip:sip.blueface.ie>;tag=9a4c86234adcc297" + m_CRLF +
-                "To: <sip:sip.blueface.ie>;tag=as6900b876" + m_CRLF +
-                "Call-ID: 5b7207d13137dfcc@192.168.1.1" + m_CRLF +
-                "CSeq: 100 REGISTER" + m_CRLF +
-                "User-Agent: asterisk" + m_CRLF +
-                "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY" + m_CRLF +
-                "Contact: <sip:sip.blueface.ie@213.168.225.133>" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+            string sipMsg = $"SIP/2.0 403 Forbidden{m_CRLF}Via: SIP/2.0/UDP 192.168.1.1;branch=z9hG4bKbcb78f72d221beec{m_CRLF}From: <sip:sip.blueface.ie>;tag=9a4c86234adcc297{m_CRLF}To: <sip:sip.blueface.ie>;tag=as6900b876{m_CRLF}Call-ID: 5b7207d13137dfcc@192.168.1.1{m_CRLF}CSeq: 100 REGISTER{m_CRLF}User-Agent: asterisk{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}Contact: <sip:sip.blueface.ie@213.168.225.133>{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse forbiddenResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -179,29 +113,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-            "SIP/2.0 200 OK" + m_CRLF +
-            "Via: SIP/2.0/UDP 194.213.29.11:5060;branch=z9hG4bK330f55c874" + m_CRLF +
-            "From: Anonymous <sip:194.213.29.11:5060>;tag=6859154930" + m_CRLF +
-            "To: <sip:sip2@86.9.88.23:10062>;tag=0013c339acec0fe007b80bbf-30071da3" + m_CRLF +
-            "Call-ID: 2501749a99424950b141bc994e48702d@194.213.29.11" + m_CRLF +
-            "Date: Mon, 01 May 2006 13:47:24 GMT" + m_CRLF +
-            "CSeq: 915 OPTIONS" + m_CRLF +
-            "Server: CSCO/7" + m_CRLF +
-            "Content-Type: application/sdp" + m_CRLF +
-            "Content-Length: 247" + m_CRLF +
-            "Allow: OPTIONS,INVITE,BYE,CANCEL,REGISTER,ACK,NOTIFY,REFER" + m_CRLF +
-            m_CRLF +
-            "v=0" + m_CRLF +
-            "o=Cisco-SIPUA (null) (null) IN IP4 192.168.1.100" + m_CRLF +
-            "s=SIP Call" + m_CRLF +
-            "c=IN IP4 192.168.1.100" + m_CRLF +
-            "t=0 0" + m_CRLF +
-            "m=audio 1 RTP/AVP 0 8 18 101" + m_CRLF +
-            "a=rtpmap:0 PCMU/8000" + m_CRLF +
-            "a=rtpmap:8 PCMA/8000" + m_CRLF +
-            "a=rtpmap:18 G729/8000" + m_CRLF +
-            "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-            "a=fmtp:101 0-15" + m_CRLF + m_CRLF;
+            $"SIP/2.0 200 OK{m_CRLF}Via: SIP/2.0/UDP 194.213.29.11:5060;branch=z9hG4bK330f55c874{m_CRLF}From: Anonymous <sip:194.213.29.11:5060>;tag=6859154930{m_CRLF}To: <sip:sip2@86.9.88.23:10062>;tag=0013c339acec0fe007b80bbf-30071da3{m_CRLF}Call-ID: 2501749a99424950b141bc994e48702d@194.213.29.11{m_CRLF}Date: Mon, 01 May 2006 13:47:24 GMT{m_CRLF}CSeq: 915 OPTIONS{m_CRLF}Server: CSCO/7{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 247{m_CRLF}Allow: OPTIONS,INVITE,BYE,CANCEL,REGISTER,ACK,NOTIFY,REFER{m_CRLF}{m_CRLF}v=0{m_CRLF}o=Cisco-SIPUA (null) (null) IN IP4 192.168.1.100{m_CRLF}s=SIP Call{m_CRLF}c=IN IP4 192.168.1.100{m_CRLF}t=0 0{m_CRLF}m=audio 1 RTP/AVP 0 8 18 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:8 PCMA/8000{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-15{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse optionsResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -218,15 +130,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + m_CRLF +
-                "To: <sip:user@1.2.3.4:5060>;tag=eba877fbb8dd284bi0" + m_CRLF +
-                "From: <sip:213.168.225.133:5060>;tag=5880003940" + m_CRLF +
-                "Call-ID: 1192348132@213.168.225.133" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK1702000048" + m_CRLF +
-                "Server: Linksys/RT31P2-2.0.10(LIc)" + m_CRLF +
-                "Content-Length: 0" + m_CRLF +
-                "Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, REFER" + m_CRLF +
-                "Supported: x-sipura" + m_CRLF + m_CRLF;
+                $"SIP/2.0 200 OK{m_CRLF}To: <sip:user@1.2.3.4:5060>;tag=eba877fbb8dd284bi0{m_CRLF}From: <sip:213.168.225.133:5060>;tag=5880003940{m_CRLF}Call-ID: 1192348132@213.168.225.133{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bK1702000048{m_CRLF}Server: Linksys/RT31P2-2.0.10(LIc){m_CRLF}Content-Length: 0{m_CRLF}Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, REFER{m_CRLF}Supported: x-sipura{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse optionsResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -247,30 +151,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + m_CRLF +
-                "From: Blue Face<sip:3000@127.0.0.1>;tag=as5fd53de7" + m_CRLF +
-                "To: sip:xxx@127.0.0.1;tag=MTHf2-ol1Yn0" + m_CRLF +
-                "Call-ID: 3e7df9d805ac596f3f091510164115e2@212.159.110.30:5061" + m_CRLF +
-                "CSeq: 102 INVITE" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bKG+WGOVwLyT6vOW9s" + m_CRLF +
-                "Via: SIP/2.0/UDP 213.168.225.133:5061;branch=z9hG4bK09db9c73" + m_CRLF +
-                "Contact: +3535xxx<sip:xxx@127.0.0.1:5061>" + m_CRLF +
-                "User-Agent: MSC/VC510  Build-Date Nov  7 2005" + m_CRLF +
-                "Allow: INVITE,BYE,CANCEL,OPTIONS,PRACK,NOTIFY,UPDATE,REFER" + m_CRLF +
-                "Supported: timer,replaces" + m_CRLF +
-                "Record-Route: <sip:213.168.225.133:5060;lr>,<sip:213.168.225.133:5061;lr>" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 182" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=xxxxxxxxx 75160 1 IN IP4 127.127.127.30" + m_CRLF +
-                "s=-" + m_CRLF +
-                "c=IN IP4 127.127.127.30" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 8002 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=ptime:20";
+                $"SIP/2.0 200 OK{m_CRLF}From: Blue Face<sip:3000@127.0.0.1>;tag=as5fd53de7{m_CRLF}To: sip:xxx@127.0.0.1;tag=MTHf2-ol1Yn0{m_CRLF}Call-ID: 3e7df9d805ac596f3f091510164115e2@212.159.110.30:5061{m_CRLF}CSeq: 102 INVITE{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5060;branch=z9hG4bKG+WGOVwLyT6vOW9s{m_CRLF}Via: SIP/2.0/UDP 213.168.225.133:5061;branch=z9hG4bK09db9c73{m_CRLF}Contact: +3535xxx<sip:xxx@127.0.0.1:5061>{m_CRLF}User-Agent: MSC/VC510  Build-Date Nov  7 2005{m_CRLF}Allow: INVITE,BYE,CANCEL,OPTIONS,PRACK,NOTIFY,UPDATE,REFER{m_CRLF}Supported: timer,replaces{m_CRLF}Record-Route: <sip:213.168.225.133:5060;lr>,<sip:213.168.225.133:5061;lr>{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 182{m_CRLF}{m_CRLF}v=0{m_CRLF}o=xxxxxxxxx 75160 1 IN IP4 127.127.127.30{m_CRLF}s=-{m_CRLF}c=IN IP4 127.127.127.30{m_CRLF}t=0 0{m_CRLF}m=audio 8002 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=ptime:20";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -290,15 +171,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.32:64226;branch=z9hG4bK-d87543-ac7a6a75bc519655-1--d87543-;rport=64226;received=89.100.104.191" + m_CRLF +
-                "To: \"253989\"<sip:253989@fwd.pulver.com>;tag=cb2000b247d89723001a836145f3b053.5b6c" + m_CRLF +
-                "From: \"253989\"<sip:253989@fwd.pulver.com>;tag=9812dd2f" + m_CRLF +
-                "Call-ID: ODllYWY1NDJiNGMwYmQ1MjVmZmViMmEyMDViMGM0Y2Y." + m_CRLF +
-                "CSeq: 2 REGISTER" + m_CRLF +
-                "Date: Fri, 17 Nov 2006 17:15:35 GMT" + m_CRLF +
-                "Contact: <sip:303@sip.blueface.ie>;q=0.1;expires=3298, \"Joe Bloggs\"<sip:253989@89.100.104.191:64226;rinstance=5720c5fed8cbcd34>;q=0.1;expires=3600" + m_CRLF +
-                "Content-Length: 0" + m_CRLF + m_CRLF;
+                $"SIP/2.0 200 OK{m_CRLF}Via: SIP/2.0/UDP 192.168.1.32:64226;branch=z9hG4bK-d87543-ac7a6a75bc519655-1--d87543-;rport=64226;received=89.100.104.191{m_CRLF}To: \"253989\"<sip:253989@fwd.pulver.com>;tag=cb2000b247d89723001a836145f3b053.5b6c{m_CRLF}From: \"253989\"<sip:253989@fwd.pulver.com>;tag=9812dd2f{m_CRLF}Call-ID: ODllYWY1NDJiNGMwYmQ1MjVmZmViMmEyMDViMGM0Y2Y.{m_CRLF}CSeq: 2 REGISTER{m_CRLF}Date: Fri, 17 Nov 2006 17:15:35 GMT{m_CRLF}Contact: <sip:303@sip.blueface.ie>;q=0.1;expires=3298, \"Joe Bloggs\"<sip:253989@89.100.104.191:64226;rinstance=5720c5fed8cbcd34>;q=0.1;expires=3600{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -324,34 +197,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + m_CRLF +
-                "Via: SIP/2.0/UDP 10.0.0.100:5060;rport=61540;branch=z9hG4bK40661a8b4a2d4973ae75fa52f1940383" + m_CRLF +
-                "From: <sip:xxxxx0@proxy.localphone.com>;tag=1014391101" + m_CRLF +
-                "To: <sip:0015619092899@proxy.localphone.com>;tag=gj-2k5-490f768a-00005cf1-00002e1aR2f0f2383.b" + m_CRLF +
-                "Call-ID: 1960514b216a465fb900e2966d30e9bb" + m_CRLF +
-                "CSeq: 2 INVITE" + m_CRLF +
-                "Record-Route: <sip:77.75.25.44:5060;lr=on>" + m_CRLF +
-                "Record-Route: <sip:77.75.25.45:5060;lr=on;ftag=1014391101>" + m_CRLF +
-                "Accept: application/sdp, application/isup, application/dtmf, application/dtmf-relay,  multipart/mixed" + m_CRLF +
-                "Contact: <sip:15619092899@64.152.60.78:5060>" + m_CRLF +
-                "Allow: INVITE,ACK,CANCEL,BYE,REGISTER,REFER,INFO,SUBSCRIBE,NOTIFY,PRACK,UPDATE,OPTIONS" + m_CRLF +
-                "Supported: timer" + m_CRLF +
-                "Session-Expires: 600;refresher=uas" + m_CRLF +
-                "Content-Length:  232" + m_CRLF +
-                "Content-Disposition: session; handling=required" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=Sonus_UAC 4125 3983 IN IP4 64.152.60.78" + m_CRLF +
-                "s=SIP Media Capabilities" + m_CRLF +
-                "c=IN IP4 64.152.60.164" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 19144 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-15" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "a=ptime:20" + m_CRLF;
+                $"SIP/2.0 200 OK{m_CRLF}Via: SIP/2.0/UDP 10.0.0.100:5060;rport=61540;branch=z9hG4bK40661a8b4a2d4973ae75fa52f1940383{m_CRLF}From: <sip:xxxxx0@proxy.localphone.com>;tag=1014391101{m_CRLF}To: <sip:0015619092899@proxy.localphone.com>;tag=gj-2k5-490f768a-00005cf1-00002e1aR2f0f2383.b{m_CRLF}Call-ID: 1960514b216a465fb900e2966d30e9bb{m_CRLF}CSeq: 2 INVITE{m_CRLF}Record-Route: <sip:77.75.25.44:5060;lr=on>{m_CRLF}Record-Route: <sip:77.75.25.45:5060;lr=on;ftag=1014391101>{m_CRLF}Accept: application/sdp, application/isup, application/dtmf, application/dtmf-relay,  multipart/mixed{m_CRLF}Contact: <sip:15619092899@64.152.60.78:5060>{m_CRLF}Allow: INVITE,ACK,CANCEL,BYE,REGISTER,REFER,INFO,SUBSCRIBE,NOTIFY,PRACK,UPDATE,OPTIONS{m_CRLF}Supported: timer{m_CRLF}Session-Expires: 600;refresher=uas{m_CRLF}Content-Length:  232{m_CRLF}Content-Disposition: session; handling=required{m_CRLF}Content-Type: application/sdp{m_CRLF}{m_CRLF}v=0{m_CRLF}o=Sonus_UAC 4125 3983 IN IP4 64.152.60.78{m_CRLF}s=SIP Media Capabilities{m_CRLF}c=IN IP4 64.152.60.164{m_CRLF}t=0 0{m_CRLF}m=audio 19144 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-15{m_CRLF}a=sendrecv{m_CRLF}a=ptime:20{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -377,33 +223,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "SIP/2.0 200 OK" + m_CRLF +
-                "Via: SIP/2.0/UDP 194.213.29.100:5060;branch=z9hG4bK5feb18267ce40fb05969b4ba843681dbfc9ffcff, SIP/2.0/UDP 127.0.0.1:5061;branch=z9hG4bK52b6a8b7" + m_CRLF +
-                "Record-Route: <sip:194.213.29.100:5060;lr>" + m_CRLF +
-                "From: Unknown <sip:Unknown@127.0.0.1:5061>;tag=as58cbdbd1" + m_CRLF +
-                "To: <sip:designersink01@10.10.49.155:5060>;tag=1144090013" + m_CRLF +
-                "Call-ID: 40741a72794b85ed197e1e020bf42bb9@127.0.0.1" + m_CRLF +
-                "CSeq: 102 INVITE" + m_CRLF +
-                "Contact: <sip:xxxxxxx1@10.10.49.155:5060>" + m_CRLF +
-                "Server: Patton SN4634 3BIS 00A0BA04469B R5.3 2009-01-15 H323 SIP BRI M5T SIP Stack/4.0.28.28" + m_CRLF +
-                "Supported: replaces" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 298" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=MxSIP 0 56 IN IP4 10.10.10.155" + m_CRLF +
-                "s=SIP Call" + m_CRLF +
-                "c=IN IP4 10.10.10.155" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 4974 RTP/AVP 0 18 8 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=rtpmap:8 PCMA/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:18 annexb=no" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "m=video 0 RTP/AVP 31 34 103 99";
+                $"SIP/2.0 200 OK{m_CRLF}Via: SIP/2.0/UDP 194.213.29.100:5060;branch=z9hG4bK5feb18267ce40fb05969b4ba843681dbfc9ffcff, SIP/2.0/UDP 127.0.0.1:5061;branch=z9hG4bK52b6a8b7{m_CRLF}Record-Route: <sip:194.213.29.100:5060;lr>{m_CRLF}From: Unknown <sip:Unknown@127.0.0.1:5061>;tag=as58cbdbd1{m_CRLF}To: <sip:designersink01@10.10.49.155:5060>;tag=1144090013{m_CRLF}Call-ID: 40741a72794b85ed197e1e020bf42bb9@127.0.0.1{m_CRLF}CSeq: 102 INVITE{m_CRLF}Contact: <sip:xxxxxxx1@10.10.49.155:5060>{m_CRLF}Server: Patton SN4634 3BIS 00A0BA04469B R5.3 2009-01-15 H323 SIP BRI M5T SIP Stack/4.0.28.28{m_CRLF}Supported: replaces{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 298{m_CRLF}{m_CRLF}v=0{m_CRLF}o=MxSIP 0 56 IN IP4 10.10.10.155{m_CRLF}s=SIP Call{m_CRLF}c=IN IP4 10.10.10.155{m_CRLF}t=0 0{m_CRLF}m=audio 4974 RTP/AVP 0 18 8 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=rtpmap:8 PCMA/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:18 annexb=no{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=sendrecv{m_CRLF}m=video 0 RTP/AVP 31 34 103 99";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);
@@ -539,13 +359,13 @@ namespace SIPSorcery.SIP.UnitTests
                 int eSemi = e.IndexOf(';');
                 int aSemi = a.IndexOf(';');
                 Assert.True(eSemi >= 0 && aSemi >= 0,
-                    "Header line " + i + " differs and has no parameters; expected=" + e + " actual=" + a);
+                    $"Header line {i} differs and has no parameters; expected={e} actual={a}");
                 Assert.Equal(e.Substring(0, eSemi), a.Substring(0, aSemi));
 
                 var eParams = new HashSet<string>(e.Substring(eSemi + 1).Split(';'));
                 var aParams = new HashSet<string>(a.Substring(aSemi + 1).Split(';'));
                 Assert.True(eParams.SetEquals(aParams),
-                    "Header line " + i + " parameter sets differ; expected=[" + string.Join(";", eParams) + "] actual=[" + string.Join(";", aParams) + "]");
+                    $"Header line {i} parameter sets differ; expected=[{string.Join(";", eParams)}] actual=[{string.Join(";", aParams)}]");
             }
         }
 
@@ -560,32 +380,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipResponse =
-                "SIP/2.0 200 Ok" + m_CRLF +
-                "Via: SIP/2.0/UDP 172.17.3.2:5060; branch=z9hG4bKd9a520e54fca43438806fbdaf46e2532; rport=5060; received=172.17.3.2" + m_CRLF +
-                "To: \"被叫方名字\" <sip:5030003202@172.17.2.2;CallScope=2;CallPriority=1;tag=ENVNTODUZJ>" + m_CRLF +
-                "From: \"呼叫方名字\" <sip:57660000@172.17.2.2;tag=FLYTRWSZOS>" + m_CRLF +
-                "Call-ID: f99d53b50a254d9194381082b21af2cc" + m_CRLF +
-                "CSeq: 1 INVITE" + m_CRLF +
-                "Contact: sip: 172.17.2.2:5060" + m_CRLF +
-                "User-Agent: SCT_DSS V1.0" + m_CRLF +
-                "Server: sipsorcery_v6.0.6.5" + m_CRLF +
-                "Supported: replaces, norefersub, 100rel" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 250" + m_CRLF +
-                m_CRLF +
-                "v=0" + m_CRLF +
-                "o=-1307081803 2 IN IP4 172.17.2.10" + m_CRLF +
-                "s=Asterisk" + m_CRLF +
-                "c=IN IP4 172.17.2.10" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 19722 RTP/AVP 0 8 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:8 PCMA/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=maxptime:150" + m_CRLF +
-                "a=sendrecv" + m_CRLF;
+                $"SIP/2.0 200 Ok{m_CRLF}Via: SIP/2.0/UDP 172.17.3.2:5060; branch=z9hG4bKd9a520e54fca43438806fbdaf46e2532; rport=5060; received=172.17.3.2{m_CRLF}To: \"被叫方名字\" <sip:5030003202@172.17.2.2;CallScope=2;CallPriority=1;tag=ENVNTODUZJ>{m_CRLF}From: \"呼叫方名字\" <sip:57660000@172.17.2.2;tag=FLYTRWSZOS>{m_CRLF}Call-ID: f99d53b50a254d9194381082b21af2cc{m_CRLF}CSeq: 1 INVITE{m_CRLF}Contact: sip: 172.17.2.2:5060{m_CRLF}User-Agent: SCT_DSS V1.0{m_CRLF}Server: sipsorcery_v6.0.6.5{m_CRLF}Supported: replaces, norefersub, 100rel{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 250{m_CRLF}{m_CRLF}v=0{m_CRLF}o=-1307081803 2 IN IP4 172.17.2.10{m_CRLF}s=Asterisk{m_CRLF}c=IN IP4 172.17.2.10{m_CRLF}t=0 0{m_CRLF}m=audio 19722 RTP/AVP 0 8 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:8 PCMA/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=ptime:20{m_CRLF}a=maxptime:150{m_CRLF}a=sendrecv{m_CRLF}";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipResponse), null, null);
             SIPResponse okResp = SIPResponse.ParseSIPResponse(sipMessageBuffer);

--- a/test/unit/core/SIP/SIPViaHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPViaHeaderUnitTest.cs
@@ -44,12 +44,12 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("branch = {Branch}.", sipViaHeaders[0].Branch);
             logger.LogDebug("Parsed header = {ParsedHeader}.", sipViaHeaders[0].ToString());
 
-            Assert.True("SIP/2.0" == sipViaHeaders[0].Version, "The Via header Version was not correctly parsed, " + sipViaHeaders[0].Version + ".");
-            Assert.True(SIPProtocolsEnum.udp == sipViaHeaders[0].Transport, "The Via header Transport was not correctly parsed, " + sipViaHeaders[0].Transport + ".");
-            Assert.True("192.168.1.2:5065" == sipViaHeaders[0].ContactAddress, "The Via header contact address was not correctly parsed, " + sipViaHeaders[0].ContactAddress + ".");
-            Assert.True(null == sipViaHeaders[0].ReceivedFromIPAddress, "The Via header received field was not correctly parsed, " + sipViaHeaders[0].ReceivedFromIPAddress + ".");
-            Assert.True(0 == sipViaHeaders[0].ReceivedFromPort, "The Via header rport field was not correctly parsed, " + sipViaHeaders[0].ReceivedFromPort + ".");
-            Assert.True("z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeaders[0].Branch, "The Via header branch was not correctly parsed, " + sipViaHeaders[0].Branch + ".");
+            Assert.True("SIP/2.0" == sipViaHeaders[0].Version, $"The Via header Version was not correctly parsed, {sipViaHeaders[0].Version}.");
+            Assert.True(SIPProtocolsEnum.udp == sipViaHeaders[0].Transport, $"The Via header Transport was not correctly parsed, {sipViaHeaders[0].Transport}.");
+            Assert.True("192.168.1.2:5065" == sipViaHeaders[0].ContactAddress, $"The Via header contact address was not correctly parsed, {sipViaHeaders[0].ContactAddress}.");
+            Assert.True(null == sipViaHeaders[0].ReceivedFromIPAddress, $"The Via header received field was not correctly parsed, {sipViaHeaders[0].ReceivedFromIPAddress}.");
+            Assert.True(0 == sipViaHeaders[0].ReceivedFromPort, $"The Via header rport field was not correctly parsed, {sipViaHeaders[0].ReceivedFromPort}.");
+            Assert.True("z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeaders[0].Branch, $"The Via header branch was not correctly parsed, {sipViaHeaders[0].Branch}.");
 
             //Assert.True("SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeader.ToString(), "The Via header was not parsed correctly.");
 
@@ -74,12 +74,12 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("branch = {Branch}.", sipViaHeaders[0].Branch);
             logger.LogDebug("Parsed header = {ParsedHeader}.", sipViaHeaders[0].ToString());
 
-            Assert.True("SIP/2.0" == sipViaHeaders[0].Version, "The Via header Version was not correctly parsed, " + sipViaHeaders[0].Version + ".");
-            Assert.True(SIPProtocolsEnum.udp == sipViaHeaders[0].Transport, "The Via header Transport was not correctly parsed, " + sipViaHeaders[0].Transport + ".");
-            Assert.True("192.168.1.2:5065" == sipViaHeaders[0].ContactAddress, "The Via header contact address was not correctly parsed, " + sipViaHeaders[0].ContactAddress + ".");
-            Assert.True("88.99.88.99" == sipViaHeaders[0].ReceivedFromIPAddress, "The Via header received field was not correctly parsed, " + sipViaHeaders[0].ReceivedFromIPAddress + ".");
-            Assert.True(10060 == sipViaHeaders[0].ReceivedFromPort, "The Via header rport field was not correctly parsed, " + sipViaHeaders[0].ReceivedFromPort + ".");
-            Assert.True("z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeaders[0].Branch, "The Via header branch was not correctly parsed, " + sipViaHeaders[0].Branch + ".");
+            Assert.True("SIP/2.0" == sipViaHeaders[0].Version, $"The Via header Version was not correctly parsed, {sipViaHeaders[0].Version}.");
+            Assert.True(SIPProtocolsEnum.udp == sipViaHeaders[0].Transport, $"The Via header Transport was not correctly parsed, {sipViaHeaders[0].Transport}.");
+            Assert.True("192.168.1.2:5065" == sipViaHeaders[0].ContactAddress, $"The Via header contact address was not correctly parsed, {sipViaHeaders[0].ContactAddress}.");
+            Assert.True("88.99.88.99" == sipViaHeaders[0].ReceivedFromIPAddress, $"The Via header received field was not correctly parsed, {sipViaHeaders[0].ReceivedFromIPAddress}.");
+            Assert.True(10060 == sipViaHeaders[0].ReceivedFromPort, $"The Via header rport field was not correctly parsed, {sipViaHeaders[0].ReceivedFromPort}.");
+            Assert.True("z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeaders[0].Branch, $"The Via header branch was not correctly parsed, {sipViaHeaders[0].Branch}.");
 
             //Assert.True("SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeader.ToString(), "The Via header was not parsed correctly.");
 
@@ -100,7 +100,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Via Header Received From Address = {ReceivedFromAddress}", sipViaHeaders[0].ReceivedFromAddress);
 
             Assert.True(sipViaHeaders[0].Host == "192.168.1.1", "The Via header host was not parsed correctly");
-            Assert.True("192.168.1.1" == sipViaHeaders[0].ContactAddress, "The Via header contact address was not correctly parsed, " + sipViaHeaders[0].ContactAddress + ".");
+            Assert.True("192.168.1.1" == sipViaHeaders[0].ContactAddress, $"The Via header contact address was not correctly parsed, {sipViaHeaders[0].ContactAddress}.");
 
             logger.LogDebug("---------------------------------------------------");
         }
@@ -145,7 +145,7 @@ namespace SIPSorcery.SIP.UnitTests
             SIPViaHeader[] sipViaHeaders = SIPViaHeader.ParseSIPViaHeader(noSemiColonViaHeader);
 
             Assert.True(sipViaHeaders[0].Host == "192.168.1.1", "The Via header host was not parsed correctly");
-            Assert.True("192.168.1.1:1234" == sipViaHeaders[0].ContactAddress, "The Via header contact address was not correctly parsed, " + sipViaHeaders[0].ContactAddress + ".");
+            Assert.True("192.168.1.1:1234" == sipViaHeaders[0].ContactAddress, $"The Via header contact address was not correctly parsed, {sipViaHeaders[0].ContactAddress}.");
             Assert.True(sipViaHeaders[0].Branch == "z9hG4bKFBB7EAC06934405182D13950BD51F001", "The Via header branch was not parsed correctly.");
 
             logger.LogDebug("---------------------------------------------------");
@@ -243,9 +243,9 @@ namespace SIPSorcery.SIP.UnitTests
             SIPViaHeader[] sipViaHeaders = SIPViaHeader.ParseSIPViaHeader(noPortViaHeader);
 
             Assert.True(sipViaHeaders[0].Host == "192.168.1.1", "The first Via header host was not parsed correctly");
-            Assert.True("192.168.1.1:5060" == sipViaHeaders[0].ContactAddress, "The first Via header contact address was not correctly parsed, " + sipViaHeaders[0].ContactAddress + ".");
+            Assert.True("192.168.1.1:5060" == sipViaHeaders[0].ContactAddress, $"The first Via header contact address was not correctly parsed, {sipViaHeaders[0].ContactAddress}.");
             Assert.True(sipViaHeaders[1].Host == "192.168.0.1", "The second Via header host was not parsed correctly");
-            Assert.True("192.168.0.1:5061" == sipViaHeaders[1].ContactAddress, "The second Via header contact address was not correctly parsed, " + sipViaHeaders[1].ContactAddress + ".");
+            Assert.True("192.168.0.1:5061" == sipViaHeaders[1].ContactAddress, $"The second Via header contact address was not correctly parsed, {sipViaHeaders[1].ContactAddress}.");
 
             logger.LogDebug("---------------------------------------------------");
         }
@@ -261,9 +261,9 @@ namespace SIPSorcery.SIP.UnitTests
             SIPViaHeader[] sipViaHeaders = SIPViaHeader.ParseSIPViaHeader(noPortViaHeader);
 
             Assert.True(sipViaHeaders[0].Host == "194.213.29.100", "The first Via header host was not parsed correctly");
-            Assert.True("194.213.29.100:5060" == sipViaHeaders[0].ContactAddress, "The first Via header contact address was not correctly parsed, " + sipViaHeaders[0].ContactAddress + ".");
+            Assert.True("194.213.29.100:5060" == sipViaHeaders[0].ContactAddress, $"The first Via header contact address was not correctly parsed, {sipViaHeaders[0].ContactAddress}.");
             Assert.True(sipViaHeaders[1].Host == "127.0.0.1", "The second Via header host was not parsed correctly");
-            Assert.True("127.0.0.1:5061" == sipViaHeaders[1].ContactAddress, "The second Via header contact address was not correctly parsed, " + sipViaHeaders[1].ContactAddress + ".");
+            Assert.True("127.0.0.1:5061" == sipViaHeaders[1].ContactAddress, $"The second Via header contact address was not correctly parsed, {sipViaHeaders[1].ContactAddress}.");
 
             logger.LogDebug("---------------------------------------------------");
         }

--- a/test/unit/core/SIP/TortureTests.cs
+++ b/test/unit/core/SIP/TortureTests.cs
@@ -23,7 +23,7 @@ namespace SIPSorcery.SIP.UnitTests
     /// <summary>
     /// Torture tests from RFC4475 https://tools.ietf.org/html/rfc4475
     /// Tests must be extracted from the base64 blob at the bottom of the RFC:
-    /// $ cat torture.b64 | base64 -d > torture.tar.gz  
+    /// $ cat torture.b64 | base64 -d > torture.tar.gz
     /// $ tar zxvf torture.tar.gz
     /// Which gives the dat files needed.
     /// Cutting and pasting is no good as things like white space getting interpreted as end of line screws up
@@ -81,15 +81,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"REGISTER sip:[2001:db8::10] SIP/2.0" + CRLF +
-"To: sip:user@example.com" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::1]>" + CRLF +
-"CSeq: 98176 REGISTER" + CRLF +
-"Content-Length: 0";
+$"REGISTER sip:[2001:db8::10] SIP/2.0{CRLF}To: sip:user@example.com{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Max-Forwards: 70{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::1]>{CRLF}CSeq: 98176 REGISTER{CRLF}Content-Length: 0";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -125,15 +117,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"REGISTER sip:2001:db8::10 SIP/2.0" + CRLF +
-"To: sip:user@example.com" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::1]>" + CRLF +
-"CSeq: 98176 REGISTER" + CRLF +
-"Content-Length: 0";
+$"REGISTER sip:2001:db8::10 SIP/2.0{CRLF}To: sip:user@example.com{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Max-Forwards: 70{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::1]>{CRLF}CSeq: 98176 REGISTER{CRLF}Content-Length: 0";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.True(sipMessageBuffer != null, "The SIP message not parsed correctly.");
@@ -163,17 +147,9 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"REGISTER sip:[2001:db8::10:5070] SIP/2.0" + CRLF +
-"To: sip:user@example.com" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::1]>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"CSeq: 98176 REGISTER" + CRLF +
-"Content-Length: 0";
+$"REGISTER sip:[2001:db8::10:5070] SIP/2.0{CRLF}To: sip:user@example.com{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::1]>{CRLF}Max-Forwards: 70{CRLF}CSeq: 98176 REGISTER{CRLF}Content-Length: 0";
 
-            //parsing is correct, but port is ambiguous, 
+            //parsing is correct, but port is ambiguous,
             //intention was to target port 5070
             //but that's nothing a program can find out
 
@@ -209,15 +185,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"REGISTER sip:[2001:db8::10]:5070 SIP/2.0" + CRLF +
-"To: sip:user@example.com" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::1]>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"CSeq: 98176 REGISTER" + CRLF +
-"Content-Length: 0";
+$"REGISTER sip:[2001:db8::10]:5070 SIP/2.0{CRLF}To: sip:user@example.com{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::1]>{CRLF}Max-Forwards: 70{CRLF}CSeq: 98176 REGISTER{CRLF}Content-Length: 0";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -255,14 +223,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"BYE sip:[2001:db8::10] SIP/2.0" + CRLF +
-"To: sip:user@example.com;tag=bd76ya" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];received=[2001:db8::9:255];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"CSeq: 321 BYE" + CRLF +
-"Content-Length: 0";
+$"BYE sip:[2001:db8::10] SIP/2.0{CRLF}To: sip:user@example.com;tag=bd76ya{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];received=[2001:db8::9:255];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Max-Forwards: 70{CRLF}CSeq: 321 BYE{CRLF}Content-Length: 0";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.True(sipMessageBuffer != null, "The SIP message not parsed correctly.");
@@ -294,15 +255,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"OPTIONS sip:[2001:db8::10] SIP/2.0" + CRLF +
-"To: sip:user @example.com" + CRLF +
-"From: sip:user @example.com; tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];received=2001:db8::9:255;branch=z9hG4bKas3" + CRLF +
-"Call-ID: SSG95523997077 @hlau_4100" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::9:1]>" + CRLF +
-"CSeq: 921 OPTIONS" + CRLF +
-"Content-Length: 0";
+$"OPTIONS sip:[2001:db8::10] SIP/2.0{CRLF}To: sip:user @example.com{CRLF}From: sip:user @example.com; tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];received=2001:db8::9:255;branch=z9hG4bKas3{CRLF}Call-ID: SSG95523997077 @hlau_4100{CRLF}Max-Forwards: 70{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::9:1]>{CRLF}CSeq: 921 OPTIONS{CRLF}Content-Length: 0";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.True(sipMessageBuffer != null, "The SIP message not parsed correctly.");
@@ -337,26 +290,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"INVITE sip:user@[2001:db8::10] SIP/2.0" + CRLF +
-"To: sip:user@[2001:db8::10]" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::20];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::20]>" + CRLF +
-"CSeq: 8612 INVITE" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Content-Type: application/sdp" + CRLF +
-"Content-Length: 268" + CRLF +
-CRLF +
-"v=0" + CRLF +
-"o=assistant 971731711378798081 0 IN IP6 2001:db8::20" + CRLF +
-"s=Live video feed for today's meeting" + CRLF +
-"c=IN IP6 2001:db8::20" + CRLF +
-"t=3338481189 3370017201" + CRLF +
-"m=audio 6000 RTP/AVP 2" + CRLF +
-"a=rtpmap:2 G726-32/8000" + CRLF +
-"m=video 6024 RTP/AVP 107" + CRLF +
-"a=rtpmap:107 H263-1998/90000";
+$"INVITE sip:user@[2001:db8::10] SIP/2.0{CRLF}To: sip:user@[2001:db8::10]{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::20];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::20]>{CRLF}CSeq: 8612 INVITE{CRLF}Max-Forwards: 70{CRLF}Content-Type: application/sdp{CRLF}Content-Length: 268{CRLF}{CRLF}v=0{CRLF}o=assistant 971731711378798081 0 IN IP6 2001:db8::20{CRLF}s=Live video feed for today's meeting{CRLF}c=IN IP6 2001:db8::20{CRLF}t=3338481189 3370017201{CRLF}m=audio 6000 RTP/AVP 2{CRLF}a=rtpmap:2 G726-32/8000{CRLF}m=video 6024 RTP/AVP 107{CRLF}a=rtpmap:107 H263-1998/90000";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -397,16 +331,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"BYE sip:user@host.example.net SIP/2.0" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1]:6050;branch=z9hG4bKas3-111" + CRLF +
-"Via: SIP/2.0/UDP 192.0.2.1;branch=z9hG4bKjhja8781hjuaij65144" + CRLF +
-"Via: SIP/2.0/TCP [2001:db8::9:255];branch=z9hG4bK451jj;received=192.0.2.200" + CRLF +
-"Call-ID: 997077@lau_4100" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"CSeq: 89187 BYE" + CRLF +
-"To: sip:user@example.net;tag=9817--94" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Content-Length: 0";
+$"BYE sip:user@host.example.net SIP/2.0{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1]:6050;branch=z9hG4bKas3-111{CRLF}Via: SIP/2.0/UDP 192.0.2.1;branch=z9hG4bKjhja8781hjuaij65144{CRLF}Via: SIP/2.0/TCP [2001:db8::9:255];branch=z9hG4bK451jj;received=192.0.2.200{CRLF}Call-ID: 997077@lau_4100{CRLF}Max-Forwards: 70{CRLF}CSeq: 89187 BYE{CRLF}To: sip:user@example.net;tag=9817--94{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Content-Length: 0";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -448,26 +373,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"INVITE sip:user@[2001:db8::10] SIP/2.0" + CRLF +
-"To: sip:user@[2001:db8::10]" + CRLF +
-"From: sip:user@example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Contact: \"Caller\" <sip:caller@[2001:db8::9:1]>" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"CSeq: 8912 INVITE" + CRLF +
-"Content-Type: application/sdp" + CRLF +
-"Content-Length: 181" + CRLF +
-CRLF +
-"v=0" + CRLF +
-"o=bob 280744730 28977631 IN IP4 host.example.com" + CRLF +
-"s=" + CRLF +
-"t=0 0" + CRLF +
-"m=audio 22334 RTP/AVP 0" + CRLF +
-"c=IN IP4 192.0.2.1" + CRLF +
-"m=video 6024 RTP/AVP 107" + CRLF +
-"c=IN IP6 2001:db8::1" + CRLF +
-"a=rtpmap:107 H263-1998/90000";
+$"INVITE sip:user@[2001:db8::10] SIP/2.0{CRLF}To: sip:user@[2001:db8::10]{CRLF}From: sip:user@example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [2001:db8::9:1];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Contact: \"Caller\" <sip:caller@[2001:db8::9:1]>{CRLF}Max-Forwards: 70{CRLF}CSeq: 8912 INVITE{CRLF}Content-Type: application/sdp{CRLF}Content-Length: 181{CRLF}{CRLF}v=0{CRLF}o=bob 280744730 28977631 IN IP4 host.example.com{CRLF}s={CRLF}t=0 0{CRLF}m=audio 22334 RTP/AVP 0{CRLF}c=IN IP4 192.0.2.1{CRLF}m=video 6024 RTP/AVP 107{CRLF}c=IN IP6 2001:db8::1{CRLF}a=rtpmap:107 H263-1998/90000";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -516,27 +422,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"INVITE sip:user@example.com SIP/2.0" + CRLF +
-"To: sip:user@example.com" + CRLF +
-"From: sip:user@east.example.com;tag=81x2" + CRLF +
-"Via: SIP/2.0/UDP [::ffff:192.0.2.10]:19823;branch=z9hG4bKbh19" + CRLF +
-"Via: SIP/2.0/UDP [::ffff:192.0.2.2];branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: SSG9559905523997077@hlau_4100" + CRLF +
-"Contact: \"T. desk phone\" <sip:ted@[::ffff:192.0.2.2]>" + CRLF +
-"CSeq: 612 INVITE" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Content-Type: application/sdp" + CRLF +
-"Content-Length: 236" + CRLF +
-CRLF +
-"v=0" + CRLF +
-"o=assistant 971731711378798081 0 IN IP6 ::ffff:192.0.2.2" + CRLF +
-"s=Call me soon, please!" + CRLF +
-"c=IN IP6 ::ffff:192.0.2.2" + CRLF +
-"t=3338481189 3370017201" + CRLF +
-"m=audio 6000 RTP/AVP 2" + CRLF +
-"a=rtpmap:2 G726-32/8000" + CRLF +
-"m=video 6024 RTP/AVP 107" + CRLF +
-"a=rtpmap:107 H263-1998/90000";
+$"INVITE sip:user@example.com SIP/2.0{CRLF}To: sip:user@example.com{CRLF}From: sip:user@east.example.com;tag=81x2{CRLF}Via: SIP/2.0/UDP [::ffff:192.0.2.10]:19823;branch=z9hG4bKbh19{CRLF}Via: SIP/2.0/UDP [::ffff:192.0.2.2];branch=z9hG4bKas3-111{CRLF}Call-ID: SSG9559905523997077@hlau_4100{CRLF}Contact: \"T. desk phone\" <sip:ted@[::ffff:192.0.2.2]>{CRLF}CSeq: 612 INVITE{CRLF}Max-Forwards: 70{CRLF}Content-Type: application/sdp{CRLF}Content-Length: 236{CRLF}{CRLF}v=0{CRLF}o=assistant 971731711378798081 0 IN IP6 ::ffff:192.0.2.2{CRLF}s=Call me soon, please!{CRLF}c=IN IP6 ::ffff:192.0.2.2{CRLF}t=3338481189 3370017201{CRLF}m=audio 6000 RTP/AVP 2{CRLF}a=rtpmap:2 G726-32/8000{CRLF}m=video 6024 RTP/AVP 107{CRLF}a=rtpmap:107 H263-1998/90000";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -583,14 +469,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"OPTIONS sip:user@[2001:db8:::192.0.2.1] SIP/2.0" + CRLF +
-"To: sip:user@[2001:db8:::192.0.2.1]" + CRLF +
-"From: sip:user@example.com;tag=810x2" + CRLF +
-"Via: SIP/2.0/UDP lab1.east.example.com;branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: G9559905523997077@hlau_4100" + CRLF +
-"CSeq: 689 OPTIONS" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Content-Length: 0";
+$"OPTIONS sip:user@[2001:db8:::192.0.2.1] SIP/2.0{CRLF}To: sip:user@[2001:db8:::192.0.2.1]{CRLF}From: sip:user@example.com;tag=810x2{CRLF}Via: SIP/2.0/UDP lab1.east.example.com;branch=z9hG4bKas3-111{CRLF}Call-ID: G9559905523997077@hlau_4100{CRLF}CSeq: 689 OPTIONS{CRLF}Max-Forwards: 70{CRLF}Content-Length: 0";
 
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
@@ -620,14 +499,7 @@ CRLF +
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-"OPTIONS sip:user@[2001:db8::192.0.2.1] SIP/2.0" + CRLF +
-"To: sip:user@[2001:db8::192.0.2.1]" + CRLF +
-"From: sip:user@example.com;tag=810x2" + CRLF +
-"Via: SIP/2.0/UDP lab1.east.example.com;branch=z9hG4bKas3-111" + CRLF +
-"Call-ID: G9559905523997077@hlau_4100" + CRLF +
-"CSeq: 689 OPTIONS" + CRLF +
-"Max-Forwards: 70" + CRLF +
-"Content-Length: 0";
+$"OPTIONS sip:user@[2001:db8::192.0.2.1] SIP/2.0{CRLF}To: sip:user@[2001:db8::192.0.2.1]{CRLF}From: sip:user@example.com;tag=810x2{CRLF}Via: SIP/2.0/UDP lab1.east.example.com;branch=z9hG4bKas3-111{CRLF}Call-ID: G9559905523997077@hlau_4100{CRLF}CSeq: 689 OPTIONS{CRLF}Max-Forwards: 70{CRLF}Content-Length: 0";
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.True(sipMessageBuffer != null, "The SIP message not parsed correctly.");

--- a/test/unit/core/SIPEvents/Dialog/SIPEventDialogInfoUnitTest.cs
+++ b/test/unit/core/SIPEvents/Dialog/SIPEventDialogInfoUnitTest.cs
@@ -154,13 +154,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string eventDialogInfoStr = "<?xml version='1.0' encoding='utf-16'?>" +
-                 "<dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'>" +
-                 " <dialog id='as7d900as8' call-id='a84b4c76e66710' local-tag='1928301774' direction='initiator'>" +
-                 "  <state event='remote-bye' code='486'>terminated</state>" +
-                 "  <duration>13</duration>" +
-                 " </dialog>" +
-                 "</dialog-info>";
+            string eventDialogInfoStr = $"<?xml version='1.0' encoding='utf-16'?><dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'> <dialog id='as7d900as8' call-id='a84b4c76e66710' local-tag='1928301774' direction='initiator'>  <state event='remote-bye' code='486'>terminated</state>  <duration>13</duration> </dialog></dialog-info>";
 
             SIPEventDialogInfo dialogInfo = SIPEventDialogInfo.Parse(eventDialogInfoStr);
 
@@ -190,16 +184,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string eventDialogInfoStr = "<?xml version='1.0' encoding='utf-16'?>" +
-                 "<dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'>" +
-                 " <dialog id='as7d900as8' call-id='a84b4c76e66710' local-tag='1928301774' direction='initiator'>" +
-                 "  <state event='remote-bye' code='486'>terminated</state>" +
-                 "  <duration>13</duration>" +
-                 " </dialog>" +
-                 " <dialog id='4353458'>" +
-                 "  <state>progressing</state>" +
-                 " </dialog>" +
-                 "</dialog-info>";
+            string eventDialogInfoStr = $"<?xml version='1.0' encoding='utf-16'?><dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'> <dialog id='as7d900as8' call-id='a84b4c76e66710' local-tag='1928301774' direction='initiator'>  <state event='remote-bye' code='486'>terminated</state>  <duration>13</duration> </dialog> <dialog id='4353458'>  <state>progressing</state> </dialog></dialog-info>";
 
             SIPEventDialogInfo dialogInfo = SIPEventDialogInfo.Parse(eventDialogInfoStr);
 
@@ -223,22 +208,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string eventDialogInfoStr = "<?xml version='1.0' encoding='utf-16'?>" +
-                 "<dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'>" +
-                 " <dialog id='as7d900as8' call-id='a84b4c76e66710' local-tag='1928301774' direction='initiator'>" +
-                 "  <state event='remote-bye' code='486'>terminated</state>" +
-                 "  <duration>13</duration>" +
-                 "  <local>" +
-                 "   <identity>sip:109@sipsorcery.com;user=phone</identity>" +
-                 "   <cseq>2</cseq>" +
-                 "  </local>" +
-                 "  <remote>" +
-                 "   <identity display-name='Joe Bloggs'>sip:thisis@anonymous.invalid</identity>" +
-                 "   <target uri='sip:user@10.1.1.7:5070' />" +
-                 "   <cseq>1</cseq>" +
-                 "  </remote>" +
-                 " </dialog>" +
-                 "</dialog-info>";
+            string eventDialogInfoStr = $"<?xml version='1.0' encoding='utf-16'?><dialog-info version='1' state='full' entity='sip:test@test.com' xmlns='urn:ietf:params:xml:ns:dialog-info'> <dialog id='as7d900as8' call-id='a84b4c76e66710' local-tag='1928301774' direction='initiator'>  <state event='remote-bye' code='486'>terminated</state>  <duration>13</duration>  <local>   <identity>sip:109@sipsorcery.com;user=phone</identity>   <cseq>2</cseq>  </local>  <remote>   <identity display-name='Joe Bloggs'>sip:thisis@anonymous.invalid</identity>   <target uri='sip:user@10.1.1.7:5070' />   <cseq>1</cseq>  </remote> </dialog></dialog-info>";
 
             SIPEventDialogInfo dialogInfo = SIPEventDialogInfo.Parse(eventDialogInfoStr);
 

--- a/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
@@ -62,31 +62,12 @@ namespace SIPSorcery.SIP.UnitTests
             SIPTransport sipTransport = new SIPTransport();
             SIPTransactionEngine transactionEngine = sipTransport.m_transactionEngine;
 
-            SIPRequest inviteRequest = SIPRequest.ParseSIPRequest("INVITE sip:dummy@127.0.0.1:12014 SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 127.0.0.1:1234;branch=z9hG4bK5f37455955ca433a902f8fea0ce2dc27" + m_CRLF +
-                "To: <sip:dummy@127.0.0.1:12014>" + m_CRLF +
-                "From: <sip:unittest@mysipswitch.com>;tag=2062917371" + m_CRLF +
-                "Call-ID: 8ae45c15425040179a4285d774ccbaf6" + m_CRLF +
-                "CSeq: 1 INVITE" + m_CRLF +
-                "Contact: <sip:127.0.0.1:1234>" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: unittest" + m_CRLF +
-                "Content-Length: 5" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                m_CRLF +
-                "dummy");
+            SIPRequest inviteRequest = SIPRequest.ParseSIPRequest($"INVITE sip:dummy@127.0.0.1:12014 SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 127.0.0.1:1234;branch=z9hG4bK5f37455955ca433a902f8fea0ce2dc27{m_CRLF}To: <sip:dummy@127.0.0.1:12014>{m_CRLF}From: <sip:unittest@mysipswitch.com>;tag=2062917371{m_CRLF}Call-ID: 8ae45c15425040179a4285d774ccbaf6{m_CRLF}CSeq: 1 INVITE{m_CRLF}Contact: <sip:127.0.0.1:1234>{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: unittest{m_CRLF}Content-Length: 5{m_CRLF}Content-Type: application/sdp{m_CRLF}{m_CRLF}dummy");
 
             SIPTransaction tx = new UACInviteTransaction(sipTransport, inviteRequest, null);
             transactionEngine.AddTransaction(tx);
 
-            SIPResponse sipResponse = SIPResponse.ParseSIPResponse("SIP/2.0 603 Nothing listening" + m_CRLF +
-                "Via: SIP/2.0/UDP 127.0.0.1:1234;branch=z9hG4bK5f37455955ca433a902f8fea0ce2dc27;rport=12013" + m_CRLF +
-                "To: <sip:dummy@127.0.0.1:12014>" + m_CRLF +
-                "From: <sip:unittest@mysipswitch.com>;tag=2062917371" + m_CRLF +
-                "Call-ID: 8ae45c15425040179a4285d774ccbaf6" + m_CRLF +
-                "CSeq: 1 INVITE" + m_CRLF +
-                "Content-Length: 0" + m_CRLF +
-                m_CRLF);
+            SIPResponse sipResponse = SIPResponse.ParseSIPResponse($"SIP/2.0 603 Nothing listening{m_CRLF}Via: SIP/2.0/UDP 127.0.0.1:1234;branch=z9hG4bK5f37455955ca433a902f8fea0ce2dc27;rport=12013{m_CRLF}To: <sip:dummy@127.0.0.1:12014>{m_CRLF}From: <sip:unittest@mysipswitch.com>;tag=2062917371{m_CRLF}Call-ID: 8ae45c15425040179a4285d774ccbaf6{m_CRLF}CSeq: 1 INVITE{m_CRLF}Content-Length: 0{m_CRLF}{m_CRLF}");
 
             Assert.True(transactionEngine.GetTransaction(sipResponse) != null, "Transaction should have matched, check the hashing mechanism.");
         }
@@ -186,17 +167,7 @@ namespace SIPSorcery.SIP.UnitTests
             SIPTransactionEngine engine = sipTransport.m_transactionEngine;     // Client side of the INVITE.
 
             string inviteRequestStr =
-                "INVITE sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 INVITE" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "User-Agent: Dummy" + m_CRLF +
-                m_CRLF;
+                $"INVITE sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: Dummy{m_CRLF}{m_CRLF}";
 
             SIPRequest inviteRequest = SIPRequest.ParseSIPRequest(inviteRequestStr);
 
@@ -206,16 +177,7 @@ namespace SIPSorcery.SIP.UnitTests
             engine.AddTransaction(serverTransaction);
 
             string ackRequestStr =
-                "ACK sip:303@sip.blueface.ie SIP/2.0" + m_CRLF +
-                "Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" + m_CRLF +
-                "From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136" + m_CRLF +
-                "To: <sip:303@sip.blueface.ie>" + m_CRLF +
-                "Contact: <sip:aaronxten@192.168.1.2:5065>" + m_CRLF +
-                "Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2" + m_CRLF +
-                "CSeq: 49429 ACK" + m_CRLF +
-                "Max-Forwards: 70" + m_CRLF +
-                "User-Agent: Dummy" + m_CRLF +
-                m_CRLF;
+                $"ACK sip:303@sip.blueface.ie SIP/2.0{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 ACK{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: Dummy{m_CRLF}{m_CRLF}";
 
             SIPRequest ackRequest = SIPRequest.ParseSIPRequest(ackRequestStr);
 

--- a/test/unit/core/SIPTransactions/SIPTransactionUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionUnitTest.cs
@@ -34,43 +34,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipRequestStr =
-                "INVITE sip:023434211@213.200.94.182;switchtag=902888 SIP/2.0" + m_CRLF +
-                "Record-Route: <sip:2.3.4.5;ftag=9307C640-33C;lr=on>" + m_CRLF +
-                "Via: SIP/2.0/UDP  5.6.7.2:5060" + m_CRLF +
-                "Via: SIP/2.0/UDP 1.2.3.4;branch=z9hG4bKa7ac.2bfad091.0" + m_CRLF +
-                "From: \"unknown\" <sip:00.000.00.0>;tag=9307C640-33C" + m_CRLF +
-                "To: <sip:0113001211@82.209.165.194>" + m_CRLF +
-                "Date: Thu, 21 Feb 2008 01:46:30 GMT" + m_CRLF +
-                "Call-ID: A8706191-DF5511DC-B886ED7B-395C3F7E" + m_CRLF +
-                "Supported: timer,100rel" + m_CRLF +
-                "Min-SE:  1800" + m_CRLF +
-                "Cisco-Guid: 2825897321-3746894300-3095653755-962346878" + m_CRLF +
-                "User-Agent: Cisco-SIPGateway/IOS-12.x" + m_CRLF +
-                "Allow: INVITE, OPTIONS, BYE, CANCEL, ACK, PRACK, COMET, REFER, SUBSCRIBE, NOTIFY, INFO" + m_CRLF +
-                "CSeq: 101 INVITE" + m_CRLF +
-                "Max-Forwards: 5" + m_CRLF +
-                "Timestamp: 1203558390" + m_CRLF +
-                "Contact: <sip:1.2.3.4:5060>" + m_CRLF +
-                "Expires: 180" + m_CRLF +
-                "Allow-Events: telephone-event" + m_CRLF +
-                "Content-Type: application/sdp" + m_CRLF +
-                "Content-Length: 370" + m_CRLF +
-                 m_CRLF +
-                "v=0" + m_CRLF +
-                "o=CiscoSystemsSIP-GW-UserAgent 9312 7567 IN IP4 00.00.00.0" + m_CRLF +
-                "s=SIP Call" + m_CRLF +
-                "c=IN IP4 00.000.00.0" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 16434 RTP/AVP 8 0 4 18 3 101" + m_CRLF +
-                "c=IN IP4 00.000.00.0" + m_CRLF +
-                "a=rtpmap:8 PCMA/8000" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:4 G723/8000" + m_CRLF +
-                "a=fmtp:4 annexa=no" + m_CRLF +
-                "a=rtpmap:18 G729/8000" + m_CRLF +
-                "a=fmtp:18 annexb=no" + m_CRLF +
-                "a=rtpmap:3 GSM/8000" + m_CRLF +
-                "a=rtpmap:101 telepho";
+                $"INVITE sip:023434211@213.200.94.182;switchtag=902888 SIP/2.0{m_CRLF}Record-Route: <sip:2.3.4.5;ftag=9307C640-33C;lr=on>{m_CRLF}Via: SIP/2.0/UDP  5.6.7.2:5060{m_CRLF}Via: SIP/2.0/UDP 1.2.3.4;branch=z9hG4bKa7ac.2bfad091.0{m_CRLF}From: \"unknown\" <sip:00.000.00.0>;tag=9307C640-33C{m_CRLF}To: <sip:0113001211@82.209.165.194>{m_CRLF}Date: Thu, 21 Feb 2008 01:46:30 GMT{m_CRLF}Call-ID: A8706191-DF5511DC-B886ED7B-395C3F7E{m_CRLF}Supported: timer,100rel{m_CRLF}Min-SE:  1800{m_CRLF}Cisco-Guid: 2825897321-3746894300-3095653755-962346878{m_CRLF}User-Agent: Cisco-SIPGateway/IOS-12.x{m_CRLF}Allow: INVITE, OPTIONS, BYE, CANCEL, ACK, PRACK, COMET, REFER, SUBSCRIBE, NOTIFY, INFO{m_CRLF}CSeq: 101 INVITE{m_CRLF}Max-Forwards: 5{m_CRLF}Timestamp: 1203558390{m_CRLF}Contact: <sip:1.2.3.4:5060>{m_CRLF}Expires: 180{m_CRLF}Allow-Events: telephone-event{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 370{m_CRLF}{m_CRLF}v=0{m_CRLF}o=CiscoSystemsSIP-GW-UserAgent 9312 7567 IN IP4 00.00.00.0{m_CRLF}s=SIP Call{m_CRLF}c=IN IP4 00.000.00.0{m_CRLF}t=0 0{m_CRLF}m=audio 16434 RTP/AVP 8 0 4 18 3 101{m_CRLF}c=IN IP4 00.000.00.0{m_CRLF}a=rtpmap:8 PCMA/8000{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:4 G723/8000{m_CRLF}a=fmtp:4 annexa=no{m_CRLF}a=rtpmap:18 G729/8000{m_CRLF}a=fmtp:18 annexb=no{m_CRLF}a=rtpmap:3 GSM/8000{m_CRLF}a=rtpmap:101 telepho";
 
             SIPRequest request = SIPRequest.ParseSIPRequest(sipRequestStr);
             SIPTransport sipTransport = new SIPTransport();

--- a/test/unit/net/Helpers/SdpAssert.cs
+++ b/test/unit/net/Helpers/SdpAssert.cs
@@ -147,8 +147,7 @@ namespace SIPSorcery.Net.UnitTests.Helpers
                 f.ID == payloadId
                 && string.Equals(f.Name(), codecName, System.StringComparison.OrdinalIgnoreCase));
             Assert.True(present,
-                $"Expected m={m.Media} to advertise {codecName} (PT {payloadId}). Got: " +
-                string.Join(", ", m.MediaFormats.Values.Select(f => f.Name() + "/" + f.ID)));
+                $"Expected m={m.Media} to advertise {codecName} (PT {payloadId}). Got: {string.Join(", ", m.MediaFormats.Values.Select(f => $"{f.Name()}/{f.ID}"))}");
         }
 
         public static void DoesNotHaveCodec(SDPMediaAnnouncement m, string codecName)

--- a/test/unit/net/Helpers/SdpNormaliser.cs
+++ b/test/unit/net/Helpers/SdpNormaliser.cs
@@ -114,26 +114,25 @@ namespace SIPSorcery.Net.UnitTests.Helpers
             string s = sdp.Replace("\r\n", "\n");
 
             s = s_oLine.Replace(s, m =>
-                "o=" + m.Groups["user"].Value + " <SID> <SVER> " +
-                m.Groups["net"].Value + " " + m.Groups["addr"].Value + " " + m.Groups["host"].Value);
+                $"o={m.Groups["user"].Value} <SID> <SVER> {m.Groups["net"].Value} {m.Groups["addr"].Value} {m.Groups["host"].Value}");
 
             s = s_mLine.Replace(s, m =>
-                "m=" + m.Groups["kind"].Value + " <PORT>" + m.Groups["rest"].Value);
+                $"m={m.Groups["kind"].Value} <PORT>{m.Groups["rest"].Value}");
 
             s = s_cLine.Replace(s, m =>
-                "c=" + m.Groups["net"].Value + " " + m.Groups["addr"].Value + " <IP>");
+                $"c={m.Groups["net"].Value} {m.Groups["addr"].Value} <IP>");
 
             s = s_iceUfrag.Replace(s, "a=ice-ufrag:<UFRAG>");
             s = s_icePwd.Replace(s, "a=ice-pwd:<PWD>");
 
             s = s_fingerprint.Replace(s, m =>
-                "a=fingerprint:" + m.Groups["alg"].Value + " <HASH>");
+                $"a=fingerprint:{m.Groups["alg"].Value} <HASH>");
 
             s = s_ssrc.Replace(s, m =>
-                "a=ssrc:<SSRC>" + m.Groups["rest"].Value);
+                $"a=ssrc:<SSRC>{m.Groups["rest"].Value}");
 
             s = s_ssrcGroup.Replace(s, m =>
-                "a=ssrc-group:" + m.Groups["sem"].Value + " <SSRC>");
+                $"a=ssrc-group:{m.Groups["sem"].Value} <SSRC>");
 
             s = s_candidate.Replace(s, "a=candidate:<CANDIDATE>");
 

--- a/test/unit/net/RTP/RTPSessionCodecMatchingUnitTest.cs
+++ b/test/unit/net/RTP/RTPSessionCodecMatchingUnitTest.cs
@@ -21,6 +21,7 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -77,7 +78,7 @@ a=sendrecv");
                     session.SetRemoteDescription(SdpType.offer, offer));
 
                 var voiceCaps = session.AudioStream.LocalTrack.Capabilities
-                    .Where(c => c.Name().ToLower() != SDP.TELEPHONE_EVENT_ATTRIBUTE)
+                    .Where(c => !string.Equals(c.Name(), SDP.TELEPHONE_EVENT_ATTRIBUTE, StringComparison.OrdinalIgnoreCase))
                     .ToList();
                 Assert.Single(voiceCaps);
                 Assert.Equal("PCMA", voiceCaps[0].Name());
@@ -104,7 +105,7 @@ a=sendrecv");
                     session.SetRemoteDescription(SdpType.offer, offer));
 
                 bool hasTelephoneEvent = session.AudioStream.LocalTrack.Capabilities
-                    .Any(c => c.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                    .Any(c => string.Equals(c.Name(), SDP.TELEPHONE_EVENT_ATTRIBUTE, StringComparison.OrdinalIgnoreCase));
                 Assert.True(hasTelephoneEvent,
                     "Expected DefaultRTPEventFormat to be injected when neither side advertises telephone-event.");
             }
@@ -215,7 +216,7 @@ a=sendrecv");
 
                 // The local track's telephone-event should now use PT 100.
                 var teCap = session.AudioStream.LocalTrack.Capabilities
-                    .FirstOrDefault(c => c.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                    .FirstOrDefault(c => string.Equals(c.Name(), SDP.TELEPHONE_EVENT_ATTRIBUTE, StringComparison.OrdinalIgnoreCase));
                 Assert.False(teCap.IsEmpty());
                 Assert.Equal(100, teCap.ID);
 
@@ -248,7 +249,7 @@ a=sendrecv");
                     session.SetRemoteDescription(SdpType.offer, offer));
 
                 var teCap = session.AudioStream.LocalTrack.Capabilities
-                    .FirstOrDefault(c => c.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                    .FirstOrDefault(c => string.Equals(c.Name(), SDP.TELEPHONE_EVENT_ATTRIBUTE, StringComparison.OrdinalIgnoreCase));
                 Assert.False(teCap.IsEmpty());
                 Assert.Equal(101, teCap.ID);
                 Assert.Equal(101, session.AudioStream.NegotiatedRtpEventPayloadID);
@@ -294,7 +295,7 @@ a=sendrecv");
                 // PCMA must lead the local capability list because the
                 // offerer (remote) put it first.
                 var caps = session.AudioStream.LocalTrack.Capabilities
-                    .Where(c => c.Name().ToLower() != SDP.TELEPHONE_EVENT_ATTRIBUTE)
+                    .Where(c => !string.Equals(c.Name(), SDP.TELEPHONE_EVENT_ATTRIBUTE, StringComparison.OrdinalIgnoreCase))
                     .ToList();
                 Assert.Equal(2, caps.Count);
                 Assert.Equal("PCMA", caps[0].Name());

--- a/test/unit/net/RTSP/RTSPMessageUnitTest.cs
+++ b/test/unit/net/RTSP/RTSPMessageUnitTest.cs
@@ -5,11 +5,11 @@
 //
 // Author(s):
 // Aaron Clauson (aaron@sipsorcery.com)
-// 
+//
 // History:
 // 20 Jan 2014	Aaron Clauson	Created, Hobart, Australia.
 //
-// License: 
+// License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
@@ -44,12 +44,7 @@ namespace SIPSorcery.Net.UnitTests
 
             int cseq = 23;
             string session = Guid.NewGuid().ToString();
-            string body = "v=0" + m_CRLF +
-"o=- 2890844526 2890842807 IN IP4 192.16.24.202" + m_CRLF +
-"s=RTSP Session" + m_CRLF +
-"m=audio 3456 RTP/AVP 0" + m_CRLF +
-"a=control:rtsp://live.example.com/concert/audio" + m_CRLF +
-"c=IN IP4 224.2.0.1/16";
+            string body = $"v=0{m_CRLF}o=- 2890844526 2890842807 IN IP4 192.16.24.202{m_CRLF}s=RTSP Session{m_CRLF}m=audio 3456 RTP/AVP 0{m_CRLF}a=control:rtsp://live.example.com/concert/audio{m_CRLF}c=IN IP4 224.2.0.1/16";
 
             RTSPResponse describeResponse = new RTSPResponse(RTSPResponseStatusCodesEnum.OK, null);
             describeResponse.Header = new RTSPHeader(cseq, session);

--- a/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
@@ -155,10 +155,7 @@ namespace SIPSorcery.Net.UnitTests
 
             Assert.Equal(expectedAckTSN, receiver.CumulativeAckTSN);
             Assert.True(sw.ElapsedMilliseconds < 2000,
-                $"Throughput regression: {chunksToSend * mtu} bytes took {sw.ElapsedMilliseconds} ms " +
-                $"(effective {(double)(chunksToSend * mtu) / sw.ElapsedMilliseconds:F1} KB/s). " +
-                $"Expected under 2000 ms with SACK-wake race fix. Pre-fix throughput is " +
-                $"capped at ~104 KB/s by the Reset race, giving ~{chunksToSend * mtu / 104} ms.");
+                $"Throughput regression: {chunksToSend * mtu} bytes took {sw.ElapsedMilliseconds} ms (effective {(double)(chunksToSend * mtu) / sw.ElapsedMilliseconds:F1} KB/s). Expected under 2000 ms with SACK-wake race fix. Pre-fix throughput is capped at ~104 KB/s by the Reset race, giving ~{chunksToSend * mtu / 104} ms.");
         }
 
         /// <summary>

--- a/test/unit/net/SDP/SDPSecurityDescriptionUnitTest.cs
+++ b/test/unit/net/SDP/SDPSecurityDescriptionUnitTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Polyfills;
 using SIPSorcery.SIP;
 using SIPSorcery.UnitTests;
 using Xunit;
@@ -165,43 +166,44 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-            "INVITE sip:33@10.2.0.110:5061;transport=tls SIP/2.0" + CRLF +
-            "Via: SIP/2.0/TLS 10.2.19.102:58179;rport;branch=z9hG4bKPj9893426a070f4c26ab494ceb746836a6" + CRLF +
-            "Max-Forwards: 70" + CRLF +
-            "From: <sip:a@10.2.0.110>;tag=b0d60b9dda9043818dea1f0e8ff9667c" + CRLF +
-            "To: <sip:33@10.2.0.110>" + CRLF +
-            "Contact: <sip:a@10.2.19.102:58179;ob>" + CRLF +
-            "Call-ID: 6410bc5eb6724efd8717831ac2af5c35" + CRLF +
-            "CSeq: 9941 INVITE" + CRLF +
-            "Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS" + CRLF +
-            "Supported: replaces, 100rel, timer, norefersub" + CRLF +
-            "Session-Expires: 1800" + CRLF +
-            "Min-SE: 90" + CRLF +
-            "User-Agent: MicroSIP/3.19.8" + CRLF +
-            "Content-Type: application/sdp" + CRLF +
-            "Content-Length:   720" + CRLF +
-            "" + CRLF +
-            "v=0" + CRLF +
-            "o=- 3784977145 3784977145 IN IP4 10.2.19.102" + CRLF +
-            "s=pjmedia" + CRLF +
-            "b=AS:84" + CRLF +
-            "t=0 0" + CRLF +
-            "a=X-nat:0" + CRLF +
-            "m=audio 4000 RTP/AVP 8 0 101" + CRLF +
-            "c=IN IP4 10.2.19.102" + CRLF +
-            "b=TIAS:64000" + CRLF +
-            "a=rtcp:4001 IN IP4 10.2.19.102" + CRLF +
-            "a=sendrecv" + CRLF +
-            "a=rtpmap:8 PCMA/8000" + CRLF +
-            "a=rtpmap:0 PCMU/8000" + CRLF +
-            "a=rtpmap:101 telephone-event/8000" + CRLF +
-            "a=fmtp:101 0-16" + CRLF +
-            "a=ssrc:370289018 cname:089912e5446c1847" + CRLF +
-            "a=crypto:1 AES_256_CM_HMAC_SHA1_80 inline:i/aQZXuTQXF8NcIPG/8ClKLXjzJZiZkFqNerJJaWtX9ShjuamMQgFocXUEkWCQ==" + CRLF +
-            "a=crypto:2 AES_256_CM_HMAC_SHA1_32 inline:WEXYOzOomH16+KpVRc8RKHkGUEW6DdvYHWSFKePVy9RzC5DB2Ciw+4t9huV8KA==" + CRLF +
-            "a=crypto:3 AES_CM_128_HMAC_SHA1_80 inline:6wGxadTFLGO9iKPSC8XfRQsOFDRFgJdmpBfdWp9r" + CRLF +
-            "a=crypto:4 AES_CM_128_HMAC_SHA1_32 inline:SdihJallj5frjwWc5yeXbMZlJSLlS+o2bkH3Jsle"
-            ;
+                """
+                INVITE sip:33@10.2.0.110:5061;transport=tls SIP/2.0
+                Via: SIP/2.0/TLS 10.2.19.102:58179;rport;branch=z9hG4bKPj9893426a070f4c26ab494ceb746836a6
+                Max-Forwards: 70
+                From: <sip:a@10.2.0.110>;tag=b0d60b9dda9043818dea1f0e8ff9667c
+                To: <sip:33@10.2.0.110>
+                Contact: <sip:a@10.2.19.102:58179;ob>
+                Call-ID: 6410bc5eb6724efd8717831ac2af5c35
+                CSeq: 9941 INVITE
+                Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS
+                Supported: replaces, 100rel, timer, norefersub
+                Session-Expires: 1800
+                Min-SE: 90
+                User-Agent: MicroSIP/3.19.8
+                Content-Type: application/sdp
+                Content-Length:   720
+
+                v=0
+                o=- 3784977145 3784977145 IN IP4 10.2.19.102
+                s=pjmedia
+                b=AS:84
+                t=0 0
+                a=X-nat:0
+                m=audio 4000 RTP/AVP 8 0 101
+                c=IN IP4 10.2.19.102
+                b=TIAS:64000
+                a=rtcp:4001 IN IP4 10.2.19.102
+                a=sendrecv
+                a=rtpmap:8 PCMA/8000
+                a=rtpmap:0 PCMU/8000
+                a=rtpmap:101 telephone-event/8000
+                a=fmtp:101 0-16
+                a=ssrc:370289018 cname:089912e5446c1847
+                a=crypto:1 AES_256_CM_HMAC_SHA1_80 inline:i/aQZXuTQXF8NcIPG/8ClKLXjzJZiZkFqNerJJaWtX9ShjuamMQgFocXUEkWCQ==
+                a=crypto:2 AES_256_CM_HMAC_SHA1_32 inline:WEXYOzOomH16+KpVRc8RKHkGUEW6DdvYHWSFKePVy9RzC5DB2Ciw+4t9huV8KA==
+                a=crypto:3 AES_CM_128_HMAC_SHA1_80 inline:6wGxadTFLGO9iKPSC8XfRQsOFDRFgJdmpBfdWp9r
+                a=crypto:4 AES_CM_128_HMAC_SHA1_32 inline:SdihJallj5frjwWc5yeXbMZlJSLlS+o2bkH3Jsle
+                """.ReplaceLineEndings(CRLF);
 
             SIPMessageBuffer sipMessageBuffer = SIPMessageBuffer.ParseSIPMessage(Encoding.UTF8.GetBytes(sipMsg), null, null);
             Assert.True(sipMessageBuffer != null, "The SIP message not parsed correctly.");

--- a/test/unit/net/SDP/SDPUnitTests.cs
+++ b/test/unit/net/SDP/SDPUnitTests.cs
@@ -41,18 +41,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendrecv";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendrecv";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -73,17 +62,8 @@ namespace SIPSorcery.Net.UnitTests
         {
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
-            string sdpStr = 
-                "v=0" + 
-                "o=- 5 2 IN IP4 10.1.1.2" + m_CRLF +
-                "s=CounterPath Bria" + m_CRLF +
-                "c=IN IP4 144.137.16.240" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 34640 RTP/AVP 0 8 101" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-15" + m_CRLF +
-                "a=alt:1 1 : STu/ZtOu 7hiLQmUp 10.1.1.2 34640";
+            string sdpStr =
+                $"v=0o=- 5 2 IN IP4 10.1.1.2{m_CRLF}s=CounterPath Bria{m_CRLF}c=IN IP4 144.137.16.240{m_CRLF}t=0 0{m_CRLF}m=audio 34640 RTP/AVP 0 8 101{m_CRLF}a=sendrecv{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-15{m_CRLF}a=alt:1 1 : STu/ZtOu 7hiLQmUp 10.1.1.2 34640";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -105,18 +85,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                " v=0" + m_CRLF +
-                " o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                " s=session" + m_CRLF +
-                " c=IN IP4 10.0.0.4" + m_CRLF +
-                " t=0 0" + m_CRLF +
-                " m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                " a=rtpmap:0 PCMU/8000" + m_CRLF +
-                " a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                " a=fmtp:101 0-16" + m_CRLF +
-                " a=silenceSupp:off - - - -" + m_CRLF +
-                " a=ptime:20" + m_CRLF +
-                " a=sendrecv";
+                $" v=0{m_CRLF} o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF} s=session{m_CRLF} c=IN IP4 10.0.0.4{m_CRLF} t=0 0{m_CRLF} m=audio 12228 RTP/AVP 0 101{m_CRLF} a=rtpmap:0 PCMU/8000{m_CRLF} a=rtpmap:101 telephone-event/8000{m_CRLF} a=fmtp:101 0-16{m_CRLF} a=silenceSupp:off - - - -{m_CRLF} a=ptime:20{m_CRLF} a=sendrecv";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -155,19 +124,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-              "v=0" + m_CRLF +
-              "o=jdoe 2890844526 2890842807 IN IP4 10.0.1.1" + m_CRLF +
-              "s=" + m_CRLF +
-              "c=IN IP4 192.0.2.3" + m_CRLF +
-              "t=0 0" + m_CRLF +
-              "a=ice-pwd:asd88fgpdd777uzjYhagZg" + m_CRLF +
-              "a=ice-ufrag:8hhY" + m_CRLF +
-              "m=audio 45664 RTP/AVP 0" + m_CRLF +
-              "b=RS:0" + m_CRLF +
-              "b=RR:0" + m_CRLF +
-              "a=rtpmap:0 PCMU/8000" + m_CRLF +
-              "a=candidate:1 1 UDP 2130706431 10.0.1.1 8998 typ host" + m_CRLF +
-              "a=candidate:2 1 UDP 1694498815 192.0.2.3 45664 typ srflx raddr 10.0.1.1 rport 8998";
+              $"v=0{m_CRLF}o=jdoe 2890844526 2890842807 IN IP4 10.0.1.1{m_CRLF}s={m_CRLF}c=IN IP4 192.0.2.3{m_CRLF}t=0 0{m_CRLF}a=ice-pwd:asd88fgpdd777uzjYhagZg{m_CRLF}a=ice-ufrag:8hhY{m_CRLF}m=audio 45664 RTP/AVP 0{m_CRLF}b=RS:0{m_CRLF}b=RR:0{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=candidate:1 1 UDP 2130706431 10.0.1.1 8998 typ host{m_CRLF}a=candidate:2 1 UDP 1694498815 192.0.2.3 45664 typ srflx raddr 10.0.1.1 rport 8998";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -187,24 +144,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sdpStr = "v=0" + m_CRLF +
-                "o=- 13064410510996677 3 IN IP4 10.1.1.2" + m_CRLF +
-                "s=Bria 4 release 4.1.1 stamp 74246" + m_CRLF +
-                "c=IN IP4 10.1.1.2" + m_CRLF +
-                "b=AS:2064" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 49290 RTP/AVP 0" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "m=video 56674 RTP/AVP 96" + m_CRLF +
-                "b=TIAS:2000000" + m_CRLF +
-                "a=rtpmap:96 VP8/90000" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "a=rtcp-fb:* nack pli" + m_CRLF +
-                "m=text 60216 RTP/AVP 98" + m_CRLF +
-                "mid:1" + m_CRLF +
-                "a=rtpmap:98 T140/1000" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "a=ssrc:1679134341 cname:de431dae-58f3-4191-9efe-5d86c1235b60";
+            string sdpStr = $"v=0{m_CRLF}o=- 13064410510996677 3 IN IP4 10.1.1.2{m_CRLF}s=Bria 4 release 4.1.1 stamp 74246{m_CRLF}c=IN IP4 10.1.1.2{m_CRLF}b=AS:2064{m_CRLF}t=0 0{m_CRLF}m=audio 49290 RTP/AVP 0{m_CRLF}a=sendrecv{m_CRLF}m=video 56674 RTP/AVP 96{m_CRLF}b=TIAS:2000000{m_CRLF}a=rtpmap:96 VP8/90000{m_CRLF}a=sendrecv{m_CRLF}a=rtcp-fb:* nack pli{m_CRLF}m=text 60216 RTP/AVP 98{m_CRLF}mid:1{m_CRLF}a=rtpmap:98 T140/1000{m_CRLF}a=sendrecv{m_CRLF}a=ssrc:1679134341 cname:de431dae-58f3-4191-9efe-5d86c1235b60";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -225,19 +165,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sdpStr = "v=0" + m_CRLF +
-                "o=Cisco-SIPUA 6396 0 IN IP4 101.180.234.134" + m_CRLF +
-                "s=SIP Call" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 19586 RTP/AVP 0" + m_CRLF +
-                "c=IN IP4 101.180.234.134" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=sendrecv" + m_CRLF +
-                "m=video 0 RTP/AVP 96" + m_CRLF +
-                "c=IN IP4 10.0.0.10" + m_CRLF +
-                "m=text 11000 RTP/AVP 98 100" + m_CRLF +
-                "a=rtpmap:98 t140/1000" + m_CRLF +
-                "a=fmtp:100 98/98";
+            string sdpStr = $"v=0{m_CRLF}o=Cisco-SIPUA 6396 0 IN IP4 101.180.234.134{m_CRLF}s=SIP Call{m_CRLF}t=0 0{m_CRLF}m=audio 19586 RTP/AVP 0{m_CRLF}c=IN IP4 101.180.234.134{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=sendrecv{m_CRLF}m=video 0 RTP/AVP 96{m_CRLF}c=IN IP4 10.0.0.10{m_CRLF}m=text 11000 RTP/AVP 98 100{m_CRLF}a=rtpmap:98 t140/1000{m_CRLF}a=fmtp:100 98/98";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -258,14 +186,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sdpStr = "v=0" + m_CRLF +
-                "o=OfficeMasterDirectSIP 806542878 806542879 IN IP4 10.2.0.110" + m_CRLF +
-                "s=FOIP Call" + m_CRLF +
-                "c=IN IP4 10.2.0.110" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=image 50594 udptl t38" + m_CRLF +
-                "a=T38FaxRateManagement:transferredTCF" + m_CRLF +
-                "a=T38FaxVersion:0";
+            string sdpStr = $"v=0{m_CRLF}o=OfficeMasterDirectSIP 806542878 806542879 IN IP4 10.2.0.110{m_CRLF}s=FOIP Call{m_CRLF}c=IN IP4 10.2.0.110{m_CRLF}t=0 0{m_CRLF}m=image 50594 udptl t38{m_CRLF}a=T38FaxRateManagement:transferredTCF{m_CRLF}a=T38FaxVersion:0";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -287,32 +208,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sdpStr = "v=0" + m_CRLF +
-                "o=- 8028343537520473029 0 IN IP4 127.0.0.1" + m_CRLF +
-                "s=-" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "a=msid-semantic: WMS" + m_CRLF +
-                "a=group:BUNDLE audio" + m_CRLF +
-                "m=audio 7038 UDP/TLS/RTP/SAVPF 0" + m_CRLF +
-                "c=IN IP4 10.0.75.1" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtcp:9 IN IP4 0.0.0.0" + m_CRLF +
-                "a=setup:active" + m_CRLF +
-                "a=mid:audio" + m_CRLF +
-                "a=maxptime:60" + m_CRLF +
-                "a=recvonly" + m_CRLF +
-                "a=ice-ufrag:1Fs+" + m_CRLF +
-                "a=ice-pwd:oiLbCgce1c9xzyamdrWtn9Q/" + m_CRLF +
-                "a=fingerprint:sha-256 B0:1F:2C:72:8F:1A:14:CD:92:15:47:F0:C3:0A:69:F9:A9:43:35:EE:10:CB:F0:11:18:B8:0E:F9:A6:95:5F:B1" + m_CRLF +
-                "a=candidate:1 1 udp 2130706431 10.0.75.1 7038 typ host" + m_CRLF +
-                "a=candidate:2 1 udp 2130705919 172.22.240.1 31136 typ host" + m_CRLF +
-                "a=candidate:3 1 udp 2130705407 172.22.48.1 21390 typ host" + m_CRLF +
-                "a=candidate:4 1 udp 2130704895 192.168.11.50 26878 typ host" + m_CRLF +
-                "a=candidate:5 1 tcp 1684797439 10.0.75.1 7038 typ srflx raddr 10.0.75.1 rport 7038 tcptype active" + m_CRLF +
-                "a=rtcp-mux" + m_CRLF +
-                "m=video 0 UDP/TLS/RTP/SAVPF" + m_CRLF +
-                "c=IN IP4 0.0.0.0" + m_CRLF +
-                "a=inactive";
+            string sdpStr = $"v=0{m_CRLF}o=- 8028343537520473029 0 IN IP4 127.0.0.1{m_CRLF}s=-{m_CRLF}t=0 0{m_CRLF}a=msid-semantic: WMS{m_CRLF}a=group:BUNDLE audio{m_CRLF}m=audio 7038 UDP/TLS/RTP/SAVPF 0{m_CRLF}c=IN IP4 10.0.75.1{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtcp:9 IN IP4 0.0.0.0{m_CRLF}a=setup:active{m_CRLF}a=mid:audio{m_CRLF}a=maxptime:60{m_CRLF}a=recvonly{m_CRLF}a=ice-ufrag:1Fs+{m_CRLF}a=ice-pwd:oiLbCgce1c9xzyamdrWtn9Q/{m_CRLF}a=fingerprint:sha-256 B0:1F:2C:72:8F:1A:14:CD:92:15:47:F0:C3:0A:69:F9:A9:43:35:EE:10:CB:F0:11:18:B8:0E:F9:A6:95:5F:B1{m_CRLF}a=candidate:1 1 udp 2130706431 10.0.75.1 7038 typ host{m_CRLF}a=candidate:2 1 udp 2130705919 172.22.240.1 31136 typ host{m_CRLF}a=candidate:3 1 udp 2130705407 172.22.48.1 21390 typ host{m_CRLF}a=candidate:4 1 udp 2130704895 192.168.11.50 26878 typ host{m_CRLF}a=candidate:5 1 tcp 1684797439 10.0.75.1 7038 typ srflx raddr 10.0.75.1 rport 7038 tcptype active{m_CRLF}a=rtcp-mux{m_CRLF}m=video 0 UDP/TLS/RTP/SAVPF{m_CRLF}c=IN IP4 0.0.0.0{m_CRLF}a=inactive";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -334,16 +230,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sdpStr = "v=0" + m_CRLF +
-                "o=nasa1 971731711378798081 0 IN IP6 2201:056D::112E:144A:1E24" + m_CRLF +
-                "s=(Almost) live video feed from Mars-II satellite" + m_CRLF +
-                "p=+1 713 555 1234" + m_CRLF +
-                "c=IN IP6 FF1E:03AD::7F2E:172A:1E24" + m_CRLF +
-                "t=3338481189 3370017201" + m_CRLF +
-                "m=audio 6000 RTP/AVP 2" + m_CRLF +
-                "a=rtpmap:2 G726-32/8000" + m_CRLF +
-                "m=video 6024 RTP/AVP 107" + m_CRLF +
-                "a=rtpmap:107 H263-1998/90000";
+            string sdpStr = $"v=0{m_CRLF}o=nasa1 971731711378798081 0 IN IP6 2201:056D::112E:144A:1E24{m_CRLF}s=(Almost) live video feed from Mars-II satellite{m_CRLF}p=+1 713 555 1234{m_CRLF}c=IN IP6 FF1E:03AD::7F2E:172A:1E24{m_CRLF}t=3338481189 3370017201{m_CRLF}m=audio 6000 RTP/AVP 2{m_CRLF}a=rtpmap:2 G726-32/8000{m_CRLF}m=video 6024 RTP/AVP 107{m_CRLF}a=rtpmap:107 H263-1998/90000";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -363,18 +250,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendrecv";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendrecv";
 
             IPEndPoint audioRtpEndPoint = SDP.GetSDPRTPEndPoint(sdpStr);
 
@@ -391,16 +267,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            string sdpStr = "v=0" + m_CRLF +
-                "o=nasa1 971731711378798081 0 IN IP6 2201:056D::112E:144A:1E24" + m_CRLF +
-                "s=(Almost) live video feed from Mars-II satellite" + m_CRLF +
-                "p=+1 713 555 1234" + m_CRLF +
-                "c=IN IP6 FF1E:03AD::7F2E:172A:1E24" + m_CRLF +
-                "t=3338481189 3370017201" + m_CRLF +
-                "m=audio 6000 RTP/AVP 2" + m_CRLF +
-                "a=rtpmap:2 G726-32/8000" + m_CRLF +
-                "m=video 6024 RTP/AVP 107" + m_CRLF +
-                "a=rtpmap:107 H263-1998/90000";
+            string sdpStr = $"v=0{m_CRLF}o=nasa1 971731711378798081 0 IN IP6 2201:056D::112E:144A:1E24{m_CRLF}s=(Almost) live video feed from Mars-II satellite{m_CRLF}p=+1 713 555 1234{m_CRLF}c=IN IP6 FF1E:03AD::7F2E:172A:1E24{m_CRLF}t=3338481189 3370017201{m_CRLF}m=audio 6000 RTP/AVP 2{m_CRLF}a=rtpmap:2 G726-32/8000{m_CRLF}m=video 6024 RTP/AVP 107{m_CRLF}a=rtpmap:107 H263-1998/90000";
 
             IPEndPoint audioRtpEndPoint = SDP.GetSDPRTPEndPoint(sdpStr);
 
@@ -418,18 +285,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendrecv";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendrecv";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -447,18 +303,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendonly";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendonly";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -475,18 +320,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "a=recvonly" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}a=recvonly{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -505,19 +339,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "a=recvonly" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendonly";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}a=recvonly{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendonly";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -536,17 +358,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -564,18 +376,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendonly";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendonly";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -596,18 +397,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "a=recvonly" + m_CRLF +
-                "m=audio 12228 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}a=recvonly{m_CRLF}m=audio 12228 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -638,7 +428,7 @@ c=IN IP4 127.0.0.1
 a=candidate:1988909849 1 udp 1124657401 192.168.11.50 11158 typ host generation 0
 a=candidate:1846148317 1 udp 2094219785 127.0.0.1 11158 typ host generation 0
 a=candidate:2012632329 1 udp 2122820711 172.30.224.1 11158 typ host generation 0
-a=end-of-candidates 
+a=end-of-candidates
 a=ice-ufrag:UWWAVCUMPZHPCLNIMZYA
 a=ice-pwd:IEUVYLWMXMQZKCMLTXQHZZVWXRCBLPPNUYFPCABK
 a=fingerprint:sha-256 C6:ED:8C:9D:06:50:77:23:0A:4A:D8:42:68:29:D0:70:2F:BB:C7:72:EC:98:5C:62:07:1B:0C:5D:CB:CE:BE:CD
@@ -652,7 +442,7 @@ c=IN IP4 127.0.0.1
 a=ice-ufrag:UWWAVCUMPZHPCLNIMZYA
 a=ice-pwd:IEUVYLWMXMQZKCMLTXQHZZVWXRCBLPPNUYFPCABK
 a=fingerprint:sha-256 C6:ED:8C:9D:06:50:77:23:0A:4A:D8:42:68:29:D0:70:2F:BB:C7:72:EC:98:5C:62:07:1B:0C:5D:CB:CE:BE:CD
-a=bundle-only 
+a=bundle-only
 a=setup:actpass
 a=sendonly
 a=rtcp-mux
@@ -915,7 +705,7 @@ a=max-message-size:262144";
         }
 
         /// <summary>
-        /// Tests that parsing an SDP offer from the Pion Go library that only contains a data channel media 
+        /// Tests that parsing an SDP offer from the Pion Go library that only contains a data channel media
         /// announcement gets parsed correctly.
         /// </summary>
         [Fact]
@@ -1273,14 +1063,7 @@ a=ssrc-group:FID 3366495178 777490417";
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=message 57102 TCP/MSRP *" + m_CRLF +
-                "a=accept-types:text/plain text/x-msrp-heartbeat" + m_CRLF +
-                "a=path:msrp://192.168.0.105:57102/10vMB2Ee;tcp";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=message 57102 TCP/MSRP *{m_CRLF}a=accept-types:text/plain text/x-msrp-heartbeat{m_CRLF}a=path:msrp://192.168.0.105:57102/10vMB2Ee;tcp";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 
@@ -1335,18 +1118,7 @@ a=ssrc-group:FID 3366495178 777490417";
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sdpStr =
-                "v=0" + m_CRLF +
-                "o=root 3285 3285 IN IP4 10.0.0.4" + m_CRLF +
-                "s=session" + m_CRLF +
-                "c=IN IP4 10.0.0.4" + m_CRLF +
-                "t=0 0" + m_CRLF +
-                "m=audio 12228/2 RTP/AVP 0 101" + m_CRLF +
-                "a=rtpmap:0 PCMU/8000" + m_CRLF +
-                "a=rtpmap:101 telephone-event/8000" + m_CRLF +
-                "a=fmtp:101 0-16" + m_CRLF +
-                "a=silenceSupp:off - - - -" + m_CRLF +
-                "a=ptime:20" + m_CRLF +
-                "a=sendrecv";
+                $"v=0{m_CRLF}o=root 3285 3285 IN IP4 10.0.0.4{m_CRLF}s=session{m_CRLF}c=IN IP4 10.0.0.4{m_CRLF}t=0 0{m_CRLF}m=audio 12228/2 RTP/AVP 0 101{m_CRLF}a=rtpmap:0 PCMU/8000{m_CRLF}a=rtpmap:101 telephone-event/8000{m_CRLF}a=fmtp:101 0-16{m_CRLF}a=silenceSupp:off - - - -{m_CRLF}a=ptime:20{m_CRLF}a=sendrecv";
 
             SDP sdp = SDP.ParseSDPDescription(sdpStr);
 

--- a/test/unit/net/SRTP/SrtpContextRolloverUnitTest.cs
+++ b/test/unit/net/SRTP/SrtpContextRolloverUnitTest.cs
@@ -85,11 +85,7 @@ namespace SIPSorcery.Net.UnitTests
             // UnprotectRtp returns 0.
             int decryptResult = TryRoundTrip(sender, receiver, ssrcB, seq: 100);
             Assert.True(decryptResult == 0,
-                "Per-SSRC outbound ROC: SSRC B's encryption was corrupted by SSRC A's "
-                + "sequence wrap. UnprotectRtp returned " + decryptResult
-                + " (-3 = ERROR_HMAC_CHECK_FAILED).  Per RFC 3711 section 3.2.1 each SRTP "
-                + "stream maintains its own ROC; the SrtpContext must not share Roc "
-                + "across SSRCs.");
+                $"Per-SSRC outbound ROC: SSRC B's encryption was corrupted by SSRC A's sequence wrap. UnprotectRtp returned {decryptResult} (-3 = ERROR_HMAC_CHECK_FAILED).  Per RFC 3711 section 3.2.1 each SRTP stream maintains its own ROC; the SrtpContext must not share Roc across SSRCs.");
         }
 
         // ---- helpers ----
@@ -97,7 +93,7 @@ namespace SIPSorcery.Net.UnitTests
         private static void RoundTripOnePacket(SrtpContext sender, SrtpContext receiver, uint ssrc, ushort seq)
         {
             int rc = TryRoundTrip(sender, receiver, ssrc, seq);
-            Assert.True(rc == 0, "Round-trip failed on SSRC " + ssrc.ToString("x8") + " seq " + seq + " (rc=" + rc + ")");
+            Assert.True(rc == 0, $"Round-trip failed on SSRC {ssrc.ToString("x8")} seq {seq} (rc={rc})");
         }
 
         private static int TryRoundTrip(SrtpContext sender, SrtpContext receiver, uint ssrc, ushort seq)

--- a/test/unit/net/STUN/STUNUnitTest.cs
+++ b/test/unit/net/STUN/STUNUnitTest.cs
@@ -1,11 +1,11 @@
 ﻿//-----------------------------------------------------------------------------
 // Author(s):
 // Aaron Clauson
-// 
-// History:
-// 
 //
-// License: 
+// History:
+//
+//
+// License:
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
@@ -40,7 +40,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             byte[] stunReq = new byte[]{ 0x00, 0x01, 0x00, 0x60, 0x21, 0x12, 0xa4, 0x42, 0x66, 0x55, 0x55, 0x43, 0x4b, 0x48, 0x74, 0x73, 0x68, 0x4e, 0x71, 0x56,
-                                         // Att1: 
+                                         // Att1:
                                          0x00, 0x06, 0x00, 0x21,
                                          0x6d, 0x30, 0x71, 0x47, 0x77, 0x53, 0x71, 0x2f, 0x48, 0x56, 0x48, 0x71, 0x41, 0x62, 0x4b, 0x62, 0x3a, 0x73, 0x64, 0x43,
                                          0x48, 0x59, 0x6b, 0x35, 0x6e, 0x46, 0x34, 0x79, 0x44, 0x77, 0x55, 0x39, 0x53, 0x00, 0x00, 0x00,
@@ -365,8 +365,7 @@ namespace SIPSorcery.Net.UnitTests
             string icePassword = "DVJSBHBUIBFSZFKVECMPRISQ";
 
             byte[] buffer = TypeExtensions.ParseHexStr(
-                "0001003C2112A4424A5655444B44544753454455000600095A4C45423A4554454F00000000240" +
-                "008CC3A28000000000000080014B295EDA4BC88A0BC885D745644D36E51FE3CBD1880280004EDF60FF7");
+                $"0001003C2112A4424A5655444B44544753454455000600095A4C45423A4554454F00000000240008CC3A28000000000000080014B295EDA4BC88A0BC885D745644D36E51FE3CBD1880280004EDF60FF7");
 
             STUNMessage stunRequest = STUNMessage.ParseSTUNMessage(buffer, buffer.Length);
 
@@ -412,10 +411,10 @@ namespace SIPSorcery.Net.UnitTests
             var stunReq = STUNMessage.ParseSTUNMessage(buffer, buffer.Length);
 
             Assert.NotNull(stunReq);
-            Assert.Equal(1853882367U, 
+            Assert.Equal(1853882367U,
                 NetConvert.ParseUInt32(stunReq.Attributes.Single(x => x.AttributeType == STUNAttributeTypesEnum.Priority).Value, 0));
             Assert.Equal(8, stunReq.Attributes.Single(x => x.AttributeType == STUNAttributeTypesEnum.IceControlled).PaddedLength);
-            Assert.Equal(0x27ff2a171b888ffeU, 
+            Assert.Equal(0x27ff2a171b888ffeU,
                 NetConvert.ParseUInt64(stunReq.Attributes.Single(x => x.AttributeType == STUNAttributeTypesEnum.IceControlled).Value, 0));
         }
 

--- a/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionRenegotiationUnitTest.cs
@@ -12,6 +12,7 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -102,13 +103,13 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(SDPMediaTypesEnum.video, renegSdp.Media[0].Media);
             Assert.Equal("0", renegSdp.Media[0].MediaID);
             Assert.Contains(renegSdp.Media[0].MediaFormats.Values,
-                f => f.Name().ToUpper() == "VP8");
+                f => string.Equals(f.Name(), "VP8", StringComparison.OrdinalIgnoreCase));
 
             // Audio must be appended after video.
             Assert.Equal(SDPMediaTypesEnum.audio, renegSdp.Media[1].Media);
             Assert.Equal("1", renegSdp.Media[1].MediaID);
             Assert.Contains(renegSdp.Media[1].MediaFormats.Values,
-                f => f.Name().ToUpper() == "PCMU");
+                f => string.Equals(f.Name(), "PCMU", StringComparison.OrdinalIgnoreCase));
 
             offerer.close();
             answerer.close();
@@ -168,12 +169,12 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(SDPMediaTypesEnum.audio, renegSdp.Media[0].Media);
             Assert.Equal("0", renegSdp.Media[0].MediaID);
             Assert.Contains(renegSdp.Media[0].MediaFormats.Values,
-                f => f.Name().ToUpper() == "PCMU");
+                f => string.Equals(f.Name(), "PCMU", StringComparison.OrdinalIgnoreCase));
 
             Assert.Equal(SDPMediaTypesEnum.video, renegSdp.Media[1].Media);
             Assert.Equal("1", renegSdp.Media[1].MediaID);
             Assert.Contains(renegSdp.Media[1].MediaFormats.Values,
-                f => f.Name().ToUpper() == "VP8");
+                f => string.Equals(f.Name(), "VP8", StringComparison.OrdinalIgnoreCase));
 
             offerer.close();
             answerer.close();

--- a/test/unit/sys/BufferUtilsUnitTest.cs
+++ b/test/unit/sys/BufferUtilsUnitTest.cs
@@ -60,17 +60,7 @@ namespace SIPSorcery.Sys.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:Blue Face SIP/2.0\r\n" +
-                "Via: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\n" +
-                "Max-Forwards: 70\r\n" +
-                "User-Agent: PA168S\r\n" +
-                "From: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\n" +
-                "To: \"user\" <sip:user@Blue Face>\r\n" +
-                "Call-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\n" +
-                "CSeq: 15754 REGISTER\r\n" +
-                "Contact: <sip:user@127.0.0.1:1720>\r\n" +
-                "Expires: 30\r\n" +
-                "Content-Length: 0\r\n\r\n";
+                $"REGISTER sip:Blue Face SIP/2.0\r\nVia: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\nMax-Forwards: 70\r\nUser-Agent: PA168S\r\nFrom: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\nTo: \"user\" <sip:user@Blue Face>\r\nCall-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\nCSeq: 15754 REGISTER\r\nContact: <sip:user@127.0.0.1:1720>\r\nExpires: 30\r\nContent-Length: 0\r\n\r\n";
 
             byte[] sample = Encoding.ASCII.GetBytes(sipMsg);
 
@@ -86,17 +76,7 @@ namespace SIPSorcery.Sys.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:Blue Face SIP/2.0\r\n" +
-                "Via: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\n" +
-                "Max-Forwards: 70\r\n" +
-                "User-Agent: PA168S\r\n" +
-                "From: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\n" +
-                "To: \"user\" <sip:user@Blue Face>\r\n" +
-                "Call-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\n" +
-                "CSeq: 15754 REGISTER\r\n" +
-                "Contact: <sip:user@127.0.0.1:1720>\r\n" +
-                "Expires: 30\r\n" +
-                "Content-Length: 0\r\n\r\n";
+                $"REGISTER sip:Blue Face SIP/2.0\r\nVia: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\nMax-Forwards: 70\r\nUser-Agent: PA168S\r\nFrom: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\nTo: \"user\" <sip:user@Blue Face>\r\nCall-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\nCSeq: 15754 REGISTER\r\nContact: <sip:user@127.0.0.1:1720>\r\nExpires: 30\r\nContent-Length: 0\r\n\r\n";
 
             byte[] sample = Encoding.ASCII.GetBytes(sipMsg);
 
@@ -112,42 +92,13 @@ namespace SIPSorcery.Sys.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                 "INVITE sip:12345@sip.domain.com:5060;TCID-0 SIP/2.0\r\n" +
-                 "From: UNAVAILABLE<sip:user@sip.domain.com:5060>;tag=c0a83dfe-13c4-26bf01-975a21d0-2d8a\r\n" +
-                 "To: <sip:1234@sipdomain.com:5060>\r\n" +
-                 "Call-ID: 94b6e3f8-c0a83dfe-13c4-26bf01-975a21ce-52c@sip.domain.com\r\n" +
-                 "CSeq: 1 INVITE\r\n" +
-                 "Via: SIP/2.0/UDP 86.9.84.23:5060;branch=z9hG4bK-26bf01-975a21d0-1ffb\r\n" +
-                 "Max-Forwards: 70\r\n" +
-                 "User-Agent: TA612V-V1.2_54\r\n" +
-                 "Supported: timer,replaces\r\n" +
-                 "Contact: <sip:user@88.8.88.88:5060>\r\n" +
-                 "Content-Type: application/SDP\r\n" +
-                 "Content-Length: 386\r\n" +
-                 "\r\n" +
-                 "v=0\r\n" +
-                 "o=b0000 613 888 IN IP4 88.8.88.88\r\n" +
-                 "s=SIP Call\r\n" +
-                 "c=IN IP4 88.8.88.88\r\n" +
-                 "t=0 0\r\n" +
-                 "m=audio 10000 RTP/AVP 0 101 18 100 101 2 103 8\r\n" +
-                 "a=fmtp:101 0-15\r\n" +
-                 "a=fmtp:18 annexb=no\r\n" +
-                 "a=sendrecv\r\n" +
-                 "a=rtpmap:0 PCMU/8000\r\n" +
-                 "a=rtpmap:101 telephone-event/8000\r\n" +
-                 "a=rtpmap:18 G729/8000\r\n" +
-                 "a=rtpmap:100 G726-16/8000\r\n" +
-                 "a=rtpmap:101 G726-24/8000\r\n" +
-                 "a=rtpmap:2 G726-32/8000\r\n" +
-                 "a=rtpmap:103 G726-40/8000\r\n" +
-                 "a=rtpmap:8 PCMA/8000";
+                 $"INVITE sip:12345@sip.domain.com:5060;TCID-0 SIP/2.0\r\nFrom: UNAVAILABLE<sip:user@sip.domain.com:5060>;tag=c0a83dfe-13c4-26bf01-975a21d0-2d8a\r\nTo: <sip:1234@sipdomain.com:5060>\r\nCall-ID: 94b6e3f8-c0a83dfe-13c4-26bf01-975a21ce-52c@sip.domain.com\r\nCSeq: 1 INVITE\r\nVia: SIP/2.0/UDP 86.9.84.23:5060;branch=z9hG4bK-26bf01-975a21d0-1ffb\r\nMax-Forwards: 70\r\nUser-Agent: TA612V-V1.2_54\r\nSupported: timer,replaces\r\nContact: <sip:user@88.8.88.88:5060>\r\nContent-Type: application/SDP\r\nContent-Length: 386\r\n\r\nv=0\r\no=b0000 613 888 IN IP4 88.8.88.88\r\ns=SIP Call\r\nc=IN IP4 88.8.88.88\r\nt=0 0\r\nm=audio 10000 RTP/AVP 0 101 18 100 101 2 103 8\r\na=fmtp:101 0-15\r\na=fmtp:18 annexb=no\r\na=sendrecv\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:101 telephone-event/8000\r\na=rtpmap:18 G729/8000\r\na=rtpmap:100 G726-16/8000\r\na=rtpmap:101 G726-24/8000\r\na=rtpmap:2 G726-32/8000\r\na=rtpmap:103 G726-40/8000\r\na=rtpmap:8 PCMA/8000";
 
             byte[] sample = Encoding.ASCII.GetBytes(sipMsg);
 
             int endOfMsgIndex = BufferUtils.GetStringPosition(sample, 0, Int32.MaxValue, "\r\n\r\n", null);
 
-            Assert.True(endOfMsgIndex == sipMsg.IndexOf("\r\n\r\n"), "The string position was not correctly found in the buffer. Index found was " + endOfMsgIndex + ", should have been " + sipMsg.IndexOf("\r\n\r\n") + ".");
+            Assert.True(endOfMsgIndex == sipMsg.IndexOf("\r\n\r\n"), $"The string position was not correctly found in the buffer. Index found was {endOfMsgIndex}, should have been {sipMsg.IndexOf("\r\n\r\n")}.");
         }
 
         [Fact]
@@ -157,17 +108,7 @@ namespace SIPSorcery.Sys.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             string sipMsg =
-                "REGISTER sip:Blue Face SIP/2.0\r\n" +
-                "Via: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\n" +
-                "Max-Forwards: 70\r\n" +
-                "User-Agent: PA168S\r\n" +
-                "From: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\n" +
-                "To: \"user\" <sip:user@Blue Face>\r\n" +
-                "Call-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\n" +
-                "CSeq: 15754 REGISTER\r\n" +
-                "Contact: <sip:user@127.0.0.1:1720>\r\n" +
-                "Expires: 30\r\n" +
-                "Content-Length: 0\r\n";
+                $"REGISTER sip:Blue Face SIP/2.0\r\nVia: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\nMax-Forwards: 70\r\nUser-Agent: PA168S\r\nFrom: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\nTo: \"user\" <sip:user@Blue Face>\r\nCall-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\nCSeq: 15754 REGISTER\r\nContact: <sip:user@127.0.0.1:1720>\r\nExpires: 30\r\nContent-Length: 0\r\n";
 
             byte[] sample = Encoding.ASCII.GetBytes(sipMsg);
 


### PR DESCRIPTION
Update test and example code to use clearer string comparison patterns and raw string fixtures where appropriate.

Add Polyfill references to test projects for shared line-ending helpers.

Split of #1639