### PR TITLE
Fix tfm and package references in examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,5 @@ MigrationBackup/
 
 # Image files
 *.bmp
+
+.claude/

--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ This repository is the home of the **SIPSorcery** project - a comprehensive real
 | **SIPSorcery.OpenAI.Realtime** | [![NuGet](https://img.shields.io/nuget/v/SIPSorcery.OpenAI.Realtime.svg)](https://www.nuget.org/packages/SIPSorcery.OpenAI.Realtime) | [![NuGet](https://img.shields.io/nuget/dt/SIPSorcery.OpenAI.Realtime.svg)](https://www.nuget.org/packages/SIPSorcery.OpenAI.Realtime) | Support for OpenAI's Realtime WebRTC and SIP end points | [README](src/SIPSorcery.OpenAI.Realtime/README.md) |
 | **SIPSorcery.VP8** | [![NuGet](https://img.shields.io/nuget/v/SIPSorcery.VP8.svg)](https://www.nuget.org/packages/SIPSorcery.VP8) | [![NuGet](https://img.shields.io/nuget/dt/SIPSorcery.VP8.svg)](https://www.nuget.org/packages/SIPSorcery.VP8) | Pure C# VP8 video codec implementation | [README](src/SIPSorcery.VP8/README.md) |
 
-### FFmpeg Install
-
-See [SIPSorcery FFmpeg readme](src/SIPSorceryMedia.FFmpeg/README.md).
-
-For Windows the easiest option is:
-
-`winget install "FFmpeg (Shared)" --version 8.1`
 
 ### Examples
 
@@ -89,6 +82,14 @@ With Visual Studio Package Manager Console (or search for [SIPSorcery on NuGet](
 ````ps1
 Install-Package SIPSorcery
 ````
+
+### FFmpeg Install
+
+See [SIPSorcery FFmpeg readme](src/SIPSorceryMedia.FFmpeg/README.md).
+
+For Windows the easiest option is:
+
+`winget install "FFmpeg (Shared)" --version 8.1`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ This repository is the home of the **SIPSorcery** project - a comprehensive real
 | **SIPSorcery.OpenAI.Realtime** | [![NuGet](https://img.shields.io/nuget/v/SIPSorcery.OpenAI.Realtime.svg)](https://www.nuget.org/packages/SIPSorcery.OpenAI.Realtime) | [![NuGet](https://img.shields.io/nuget/dt/SIPSorcery.OpenAI.Realtime.svg)](https://www.nuget.org/packages/SIPSorcery.OpenAI.Realtime) | Support for OpenAI's Realtime WebRTC and SIP end points | [README](src/SIPSorcery.OpenAI.Realtime/README.md) |
 | **SIPSorcery.VP8** | [![NuGet](https://img.shields.io/nuget/v/SIPSorcery.VP8.svg)](https://www.nuget.org/packages/SIPSorcery.VP8) | [![NuGet](https://img.shields.io/nuget/dt/SIPSorcery.VP8.svg)](https://www.nuget.org/packages/SIPSorcery.VP8) | Pure C# VP8 video codec implementation | [README](src/SIPSorcery.VP8/README.md) |
 
+### FFmpeg Install
+
+See [SIPSorcery FFmpeg readme](src/SIPSorceryMedia.FFmpeg/README.md).
+
+For Windows the easiest option is:
+
+`winget install "FFmpeg (Shared)" --version 8.1`
+
 ### Examples
 
 This repository includes **[70+ example projects](examples/)** demonstrating various SIP and WebRTC scenarios:

--- a/SIPSorcery.slnx
+++ b/SIPSorcery.slnx
@@ -44,7 +44,6 @@
     <Project Path="examples/OpenAIExamples/LocalFunctions/LocalFunctions.csproj" />
   </Folder>
   <Folder Name="/examples/SIPExamples/">
-    <Project Path="examples/SIPExamples/AndroidSIPGetStarted/AndroidSIPGetStarted.csproj" />
     <Project Path="examples/SIPExamples/AsteriskIce/AsteriskIce.csproj" />
     <Project Path="examples/SIPExamples/AttendedTransfer/AttendedTransfer.csproj" />
     <Project Path="examples/SIPExamples/CallHoldAndTransfer/CallHoldAndTransfer.csproj" />

--- a/examples/Miscellaneous/SctpClientTestConsole/SctpClientTestConsole.csproj
+++ b/examples/Miscellaneous/SctpClientTestConsole/SctpClientTestConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPExamples/AsteriskIce/AsteriskIce.csproj
+++ b/examples/SIPExamples/AsteriskIce/AsteriskIce.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="SIPSorceryMedia.Encoders" Version="10.0.4" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/SIPExamples/AttendedTransfer/AttendedTransfer.csproj
+++ b/examples/SIPExamples/AttendedTransfer/AttendedTransfer.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/CallHoldAndTransfer/CallHoldAndTransfer.csproj
+++ b/examples/SIPExamples/CallHoldAndTransfer/CallHoldAndTransfer.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/CustomAudioCodec/CustomAudioCodec.csproj
+++ b/examples/SIPExamples/CustomAudioCodec/CustomAudioCodec.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/GetStartedVideo/GetStartedVideo.csproj
+++ b/examples/SIPExamples/GetStartedVideo/GetStartedVideo.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="SIPSorceryMedia.Encoders" Version="10.0.4" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/GetStartedWebSocket/GetStartedWebSocket.csproj
+++ b/examples/SIPExamples/GetStartedWebSocket/GetStartedWebSocket.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/NotifierClient/NotifierClient.csproj
+++ b/examples/SIPExamples/NotifierClient/NotifierClient.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/PlaySounds/PlaySounds.csproj
+++ b/examples/SIPExamples/PlaySounds/PlaySounds.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/ReceiveDtmf/ReceiveDtmf.csproj
+++ b/examples/SIPExamples/ReceiveDtmf/ReceiveDtmf.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/RecordCall/RecordCall.csproj
+++ b/examples/SIPExamples/RecordCall/RecordCall.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/RecordIncomingCall/RecordIncomingCall.csproj
+++ b/examples/SIPExamples/RecordIncomingCall/RecordIncomingCall.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/SIPCallResampleAudio/SIPCallResampleAudio.csproj
+++ b/examples/SIPExamples/SIPCallResampleAudio/SIPCallResampleAudio.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/SIPCallServer/SIPCallServer.csproj
+++ b/examples/SIPExamples/SIPCallServer/SIPCallServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPExamples/SIPProxy/SIPProxy.csproj
+++ b/examples/SIPExamples/SIPProxy/SIPProxy.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/SendDtmf/SendDtmf.csproj
+++ b/examples/SIPExamples/SendDtmf/SendDtmf.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/UserAgentClient/UserAgentClient.csproj
+++ b/examples/SIPExamples/UserAgentClient/UserAgentClient.csproj
@@ -3,13 +3,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/UserAgentRegister/UserAgentRegister.csproj
+++ b/examples/SIPExamples/UserAgentRegister/UserAgentRegister.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/UserAgentServer/UserAgentServer.csproj
+++ b/examples/SIPExamples/UserAgentServer/UserAgentServer.csproj
@@ -2,15 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPExamples/VideoPhoneCmdLine/VideoPhoneCmdLine.csproj
+++ b/examples/SIPExamples/VideoPhoneCmdLine/VideoPhoneCmdLine.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="SIPSorceryMedia.Encoders" Version="10.0.4" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/examples/SIPScenarios/AttendedTransferScenario/Target/Target.csproj
+++ b/examples/SIPScenarios/AttendedTransferScenario/Target/Target.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPScenarios/AttendedTransferScenario/Transferee/Transferee.csproj
+++ b/examples/SIPScenarios/AttendedTransferScenario/Transferee/Transferee.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPScenarios/AttendedTransferScenario/Transferor/Transferor.csproj
+++ b/examples/SIPScenarios/AttendedTransferScenario/Transferor/Transferor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/examples/SIPScenarios/BlindTransferScenario/Target/Target.csproj
+++ b/examples/SIPScenarios/BlindTransferScenario/Target/Target.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPScenarios/BlindTransferScenario/Transferee/Transferee.csproj
+++ b/examples/SIPScenarios/BlindTransferScenario/Transferee/Transferee.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPScenarios/BlindTransferScenario/Transferor/Transferor.csproj
+++ b/examples/SIPScenarios/BlindTransferScenario/Transferor/Transferor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/examples/SIPScenarios/LoadTestScenario/LoadClient/LoadClient.csproj
+++ b/examples/SIPScenarios/LoadTestScenario/LoadClient/LoadClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/examples/SIPScenarios/LoadTestScenario/LoadServer/LoadServer.csproj
+++ b/examples/SIPScenarios/LoadTestScenario/LoadServer/LoadServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPScenarios/OnHoldScenario/Callee/Callee.csproj
+++ b/examples/SIPScenarios/OnHoldScenario/Callee/Callee.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SIPScenarios/OnHoldScenario/Caller/Caller.csproj
+++ b/examples/SIPScenarios/OnHoldScenario/Caller/Caller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/examples/Softphone/SIPSorcery.SoftPhone.csproj
+++ b/examples/Softphone/SIPSorcery.SoftPhone.csproj
@@ -19,8 +19,6 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="SIPSorceryMedia.Encoders" Version="10.0.4" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
-    <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/StunServer/StunServer.csproj
+++ b/examples/StunServer/StunServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>StunServerExample</RootNamespace>
   </PropertyGroup>
 

--- a/examples/TurnServerExample/TurnServerExample.csproj
+++ b/examples/TurnServerExample/TurnServerExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>TurnServerExample</RootNamespace>
   </PropertyGroup>
 

--- a/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/RtspToWebRTCAudioAndVideo.csproj
+++ b/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/RtspToWebRTCAudioAndVideo.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/WebRTCExamples/sipjs/SipJs.csproj
+++ b/examples/WebRTCExamples/sipjs/SipJs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/sipcmdline/Program.cs
+++ b/examples/sipcmdline/Program.cs
@@ -55,14 +55,24 @@
 // dotnet run -- -d 127.0.0.1 -c 10000 -x 25 -s uac -b true
 // [19:17:03 INF] => Command completed task count 10000 success count 10000 duration 189.21
 //
-// Usage Exmaple:
-// Check RTP connectivity:
+// Usage Example - Check RTP connectivity:
 // dotnet run -- --s uac -d music@iptel.org -v
 // If successful a count of the RTP packets will be displayed:
 // RTP packet received from 212.79.111.155:13818, ssrc 314111075, seqnum 23320, count 48
 //
-// Check RTP connectivity via a TURN server. Contrived exmaple to force a TURN relay RTP path:
+// Check RTP connectivity via a TURN server. Contrived example to force a TURN relay RTP path:
 // dotnet run -- -d music@iptel.org -s uac -v --turn "turn:yourserver;username;password" --turnremotepeerip "212.79.111.155"
+//
+// Usage Example - Authenticated call:
+// dotnet run -- -s uac -d 1234@sipsorcery.com -u yourusername --password yourpassword -v
+//
+// Usage Example - Registration:
+// dotnet run -- -s reg -d sipsorcery.com -u yourusername --password yourpassword -v
+//
+// Usage Example - Check SIP server response to OPTIONS requests:
+// dotnet run -- -s opt -d "iptel.org"
+// dotnet run -- -s opt -d "iptel.org;transport=tcp"
+// dotnet run -- -s opt -d "iptel.org;transport=tls"
 //-----------------------------------------------------------------------------
 
 using System;

--- a/examples/sipcmdline/sipcmdline.csproj
+++ b/examples/sipcmdline/sipcmdline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/VideoCaptureTest/VideoCaptureTest.csproj
+++ b/test/VideoCaptureTest/VideoCaptureTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.22000</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
   </PropertyGroup>


### PR DESCRIPTION
TFM and package reference fixes while going through the SIP example programs.

No functional changes to the main library's source.