### PR TITLE
Refactor SIP code for clarity and consistency

### DIFF
--- a/src/SIPSorcery/core/SIP/SIPParameterlessURI.cs
+++ b/src/SIPSorcery/core/SIP/SIPParameterlessURI.cs
@@ -81,7 +81,7 @@ namespace SIPSorcery.SIP
             return new SIPParameterlessURI(sipURI);
         }
 
-        public new string ToString()
+        public override string ToString()
         {
             try
             {

--- a/src/SIPSorcery/core/SIPEvents/SIPEventPackages.cs
+++ b/src/SIPSorcery/core/SIPEvents/SIPEventPackages.cs
@@ -66,10 +66,11 @@ namespace SIPSorcery.SIP
             {
                 return false;
             }
-            else {
+            else
+            {
                 value = value.Trim();
 
-                return 
+                return
                     string.Equals(value, DIALOG_EVENT_VALUE, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(value, MESSAGE_SUMMARY_EVENT_VALUE, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(value, PRESENCE_EVENT_VALUE, StringComparison.OrdinalIgnoreCase) ||
@@ -85,26 +86,22 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                value = value.Trim().ToLower();
-                switch (value)
+                var valueSpan = value.AsSpan().Trim();
+
+                return valueSpan switch
                 {
-                    case DIALOG_EVENT_VALUE:
-                        return SIPEventPackagesEnum.Dialog;
-                    case MESSAGE_SUMMARY_EVENT_VALUE:
-                        return SIPEventPackagesEnum.MessageSummary;
-                    case PRESENCE_EVENT_VALUE:
-                        return SIPEventPackagesEnum.Presence;
-                    case REFER_EVENT_VALUE:
-                        return SIPEventPackagesEnum.Refer;
-                    default:
-                        return SIPEventPackagesEnum.None;
-                }
+                    _ when DIALOG_EVENT_VALUE.Equals(valueSpan, StringComparison.OrdinalIgnoreCase) => SIPEventPackagesEnum.Dialog,
+                    _ when MESSAGE_SUMMARY_EVENT_VALUE.Equals(valueSpan, StringComparison.OrdinalIgnoreCase) => SIPEventPackagesEnum.MessageSummary,
+                    _ when PRESENCE_EVENT_VALUE.Equals(valueSpan, StringComparison.OrdinalIgnoreCase) => SIPEventPackagesEnum.Presence,
+                    _ when REFER_EVENT_VALUE.Equals(valueSpan, StringComparison.OrdinalIgnoreCase) => SIPEventPackagesEnum.Refer,
+                    _ => SIPEventPackagesEnum.None,
+                };
             }
         }
 
         public static string GetEventHeader(SIPEventPackagesEnum eventPackage)
         {
-            switch(eventPackage)
+            switch (eventPackage)
             {
                 case SIPEventPackagesEnum.Dialog:
                     return DIALOG_EVENT_VALUE;
@@ -163,9 +160,13 @@ namespace SIPSorcery.SIP
             {
                 return false;
             }
-            else if (value.ToLower() == "cancelled" || value.ToLower() == "error" || value.ToLower() == "local-bye" ||
-                value.ToLower() == "rejected" || value.ToLower() == "replaced" || value.ToLower() == "remote-bye" ||
-                value.ToLower() == "timeout")
+            else if ("cancelled".Equals(value, StringComparison.OrdinalIgnoreCase) ||
+                "error".Equals(value, StringComparison.OrdinalIgnoreCase) ||
+                "local-bye".Equals(value, StringComparison.OrdinalIgnoreCase) ||
+                "rejected".Equals(value, StringComparison.OrdinalIgnoreCase) ||
+                "replaced".Equals(value, StringComparison.OrdinalIgnoreCase) ||
+                "remote-bye".Equals(value, StringComparison.OrdinalIgnoreCase) ||
+                "timeout".Equals(value, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -183,26 +184,18 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                string trimmedValue = value.Trim().ToLower();
-                switch (trimmedValue)
+                var trimmedValue = value.AsSpan().Trim();
+                return trimmedValue switch
                 {
-                    case "cancelled":
-                        return SIPEventDialogStateEvent.Cancelled;
-                    case "error":
-                        return SIPEventDialogStateEvent.Error;
-                    case "local-bye":
-                        return SIPEventDialogStateEvent.LocalBye;
-                    case "rejected":
-                        return SIPEventDialogStateEvent.Rejected;
-                    case "replaced":
-                        return SIPEventDialogStateEvent.Replaced;
-                    case "remote-bye":
-                        return SIPEventDialogStateEvent.RemoteBye;
-                    case "timeout":
-                        return SIPEventDialogStateEvent.Timeout;
-                    default:
-                        throw new ArgumentException("The value is not valid for a SIPEventDialogStateEvent.");
-                }
+                    _ when "cancelled".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.Cancelled,
+                    _ when "error".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.Error,
+                    _ when "local-bye".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.LocalBye,
+                    _ when "rejected".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.Rejected,
+                    _ when "replaced".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.Replaced,
+                    _ when "remote-bye".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.RemoteBye,
+                    _ when "timeout".Equals(trimmedValue, StringComparison.OrdinalIgnoreCase) => SIPEventDialogStateEvent.Timeout,
+                    _ => throw new ArgumentException("The value is not valid for a SIPEventDialogStateEvent."),
+                };
             }
         }
 

--- a/src/SIPSorcery/core/SIPTransactions/SIPTransaction.cs
+++ b/src/SIPSorcery/core/SIPTransactions/SIPTransaction.cs
@@ -411,7 +411,7 @@ namespace SIPSorcery.SIP
                     }
 
                     sipResponse.Header.RSeq = RSeq;
-                    sipResponse.Header.Require += SIPExtensionHeaders.REPLACES + ", " + SIPExtensionHeaders.NO_REFER_SUB + ", " + SIPExtensionHeaders.PRACK;
+                    sipResponse.Header.Require += $"{SIPExtensionHeaders.REPLACES}, {SIPExtensionHeaders.NO_REFER_SUB}, {SIPExtensionHeaders.PRACK}";
 
                     // If reliable provisional responses are supported then need to send this response reliably.
                     if (ReliableProvisionalResponse != null)

--- a/src/SIPSorcery/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/SIPSorcery/core/SIPTransactions/SIPTransactionEngine.cs
@@ -141,7 +141,7 @@ namespace SIPSorcery.SIP
         public SIPTransaction GetTransaction(SIPRequest sipRequest)
         {
             // The branch is mandatory but it doesn't stop some UA's not setting it.
-            if (sipRequest.Header.Vias.TopViaHeader.Branch == null || sipRequest.Header.Vias.TopViaHeader.Branch.Trim().Length == 0)
+            if (string.IsNullOrWhiteSpace(sipRequest.Header.Vias.TopViaHeader.Branch))
             {
                 return null;
             }
@@ -231,7 +231,7 @@ namespace SIPSorcery.SIP
 
         public SIPTransaction GetTransaction(SIPResponse sipResponse)
         {
-            if (sipResponse.Header.Vias.TopViaHeader.Branch == null || sipResponse.Header.Vias.TopViaHeader.Branch.Trim().Length == 0)
+            if (string.IsNullOrWhiteSpace(sipResponse.Header.Vias.TopViaHeader.Branch))
             {
                 return null;
             }

--- a/src/SIPSorcery/core/SIPTransactions/UASInviteTransaction.cs
+++ b/src/SIPSorcery/core/SIPTransactions/UASInviteTransaction.cs
@@ -155,8 +155,9 @@ namespace SIPSorcery.SIP
             okResponse.Header.Server = SIPConstants.SipUserAgentVersionString;
             okResponse.Header.MaxForwards = Int32.MinValue;
             okResponse.Header.RecordRoutes = requestHeader.RecordRoutes;
-            okResponse.Header.Supported = SIPExtensionHeaders.REPLACES + ", " + SIPExtensionHeaders.NO_REFER_SUB
-                + ((PrackSupported == true) ? ", " + SIPExtensionHeaders.PRACK : "");
+            okResponse.Header.Supported = PrackSupported == true
+                ? $"{SIPExtensionHeaders.REPLACES}, {SIPExtensionHeaders.NO_REFER_SUB}, {SIPExtensionHeaders.PRACK}"
+                : $"{SIPExtensionHeaders.REPLACES}, {SIPExtensionHeaders.NO_REFER_SUB}";
 
             okResponse.Body = messageBody;
             okResponse.Header.ContentType = contentType;


### PR DESCRIPTION
Replaced manual string comparisons with StringComparison.OrdinalIgnoreCase and placed constants first in comparisons. Refactored switch statements to use switch expressions with spans. Updated header concatenation to use string interpolation. Used string.IsNullOrWhiteSpace for null/whitespace checks. Changed method overrides to use override instead of new where appropriate.

Follow-up from #1645
Split of #1639