### PR TITLE
Refactor STUN code for clarity and consistency (#1653)

### DIFF
--- a/src/SIPSorcery/net/STUN/STUNAppState.cs
+++ b/src/SIPSorcery/net/STUN/STUNAppState.cs
@@ -40,7 +40,7 @@ namespace SIPSorcery.Net
 
                 if (byteStr.Length == 1)
                 {
-                    bufferStr += "0" + byteStr;
+                    bufferStr += $"0{byteStr}";
                 }
                 else
                 {

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNAddressAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNAddressAttribute.cs
@@ -95,7 +95,7 @@ namespace SIPSorcery.Net
 
         public override string ToString()
         {
-            string attrDescrStr = "STUN Attribute: " + base.AttributeType + ", address=" + Address.ToString() + ", port=" + Port + ".";
+            string attrDescrStr = $"STUN Attribute: {base.AttributeType}, address={Address.ToString()}, port={Port}.";
 
             return attrDescrStr;
         }

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNAttribute.cs
@@ -220,7 +220,7 @@ namespace SIPSorcery.Net
 
                     attributes.Add(attribute);
 
-                    // Attributes start on 32 bit word boundaries so where an attribute length is not a multiple of 4 it gets padded. 
+                    // Attributes start on 32 bit word boundaries so where an attribute length is not a multiple of 4 it gets padded.
                     int padding = (stunAttributeLength % 4 != 0) ? 4 - (stunAttributeLength % 4) : 0;
 
                     startAttIndex = startAttIndex + 4 + stunAttributeLength + padding;
@@ -258,7 +258,7 @@ namespace SIPSorcery.Net
 
         public new virtual string ToString()
         {
-            string attrDescrString = "STUN Attribute: " + AttributeType.ToString() + ", length=" + PaddedLength + ".";
+            string attrDescrString = $"STUN Attribute: {AttributeType.ToString()}, length={PaddedLength}.";
 
             return attrDescrString;
         }

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNChangeRequestAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNChangeRequestAttribute.cs
@@ -53,7 +53,7 @@ namespace SIPSorcery.Net
 
         public override string ToString()
         {
-            string attrDescrStr = "STUN Attribute: " + STUNAttributeTypesEnum.ChangeRequest.ToString() + ", key byte=" + m_changeRequestByte.ToString("X") + ", change address=" + ChangeAddress + ", change port=" + ChangePort + ".";
+            string attrDescrStr = $"STUN Attribute: {STUNAttributeTypesEnum.ChangeRequest.ToString()}, key byte={m_changeRequestByte.ToString("X")}, change address={ChangeAddress}, change port={ChangePort}.";
 
             return attrDescrStr;
         }

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNConnectionIdAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNConnectionIdAttribute.cs
@@ -44,7 +44,7 @@ namespace SIPSorcery.Net
 
         public override string ToString()
         {
-            string attrDescrStr = "STUN CONNECTION_ID Attribute: value=" + ConnectionId + ".";
+            string attrDescrStr = $"STUN CONNECTION_ID Attribute: value={ConnectionId}.";
 
             return attrDescrStr;
         }

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNErrorCodeAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNErrorCodeAttribute.cs
@@ -60,7 +60,7 @@ namespace SIPSorcery.Net
 
         public override string ToString()
         {
-            string attrDescrStr = "STUN ERROR_CODE_ADDRESS Attribute: error code=" + ErrorCode + ", reason phrase=" + ReasonPhrase + ".";
+            string attrDescrStr = $"STUN ERROR_CODE_ADDRESS Attribute: error code={ErrorCode}, reason phrase={ReasonPhrase}.";
 
             return attrDescrStr;
         }

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
@@ -133,7 +133,7 @@ namespace SIPSorcery.Net
 
         public override string ToString()
         {
-            string attrDescrStr = "STUN XOR_MAPPED_ADDRESS Attribute: " + base.AttributeType + ", address=" + Address.ToString() + ", port=" + Port + ".";
+            string attrDescrStr = $"STUN XOR_MAPPED_ADDRESS Attribute: {base.AttributeType}, address={Address.ToString()}, port={Port}.";
 
             return attrDescrStr;
         }

--- a/src/SIPSorcery/net/STUN/STUNMessage.cs
+++ b/src/SIPSorcery/net/STUN/STUNMessage.cs
@@ -198,13 +198,13 @@ namespace SIPSorcery.Net
             return buffer;
         }
 
-        public new string ToString()
+        public override string ToString()
         {
-            string messageDescr = "STUN Message: " + Header.MessageType.ToString() + ", length=" + Header.MessageLength;
+            string messageDescr = $"STUN Message: {Header.MessageType.ToString()}, length={Header.MessageLength}";
 
             foreach (STUNAttribute attribute in Attributes)
             {
-                messageDescr += "\n " + attribute.ToString();
+                messageDescr += $"\n {attribute.ToString()}";
             }
 
             return messageDescr;


### PR DESCRIPTION
Replaced manual string comparisons with StringComparison.OrdinalIgnoreCase and placed constants first in comparisons. Refactored switch statements to use switch expressions with spans. Updated header concatenation to use string interpolation. Used string.IsNullOrWhiteSpace for null/whitespace checks. Changed method overrides to use override instead of new where appropriate.

Split of #1639