### PR TITLE
Add unit tests for RTSPHeader.SplitHeaders line folding

### DIFF
--- a/test/unit/net/RTSP/RTSPHeaderUnitTest.cs
+++ b/test/unit/net/RTSP/RTSPHeaderUnitTest.cs
@@ -1,0 +1,112 @@
+//-----------------------------------------------------------------------------
+// Filename: RTSPHeaderUnitTest.cs
+//
+// Description: Unit tests for the RTSPHeader class, in particular the header
+// splitting/line-folding logic in SplitHeaders.
+//
+// Author(s):
+// Aaron Clauson
+//
+// History:
+// 01 Jun 2026	Aaron Clauson	Created to characterise SplitHeaders line folding.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class RTSPHeaderUnitTest
+    {
+        private const string CRLF = "\r\n";
+
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public RTSPHeaderUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Tests that a well formed block of CRLF separated headers is split into one
+        /// entry per header line.
+        /// </summary>
+        [Fact]
+        public void SplitHeadersBasicTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            string message = "CSeq: 1" + CRLF + "Session: abc123" + CRLF + "Content-Length: 0";
+
+            string[] headers = RTSPHeader.SplitHeaders(message);
+
+            Assert.Equal(3, headers.Length);
+            Assert.Equal("CSeq: 1", headers[0]);
+            Assert.Equal("Session: abc123", headers[1]);
+            Assert.Equal("Content-Length: 0", headers[2]);
+        }
+
+        /// <summary>
+        /// Tests that a header value folded across multiple lines (a continuation line begins
+        /// with whitespace) is collapsed back onto a single line separated by a single space.
+        /// </summary>
+        [Fact]
+        public void SplitHeadersFoldedWithSpaceTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            string message = "Accept: application/sdp," + CRLF + " application/rtsl" + CRLF + "CSeq: 2";
+
+            string[] headers = RTSPHeader.SplitHeaders(message);
+
+            Assert.Equal(2, headers.Length);
+            Assert.Equal("Accept: application/sdp, application/rtsl", headers[0]);
+            Assert.Equal("CSeq: 2", headers[1]);
+        }
+
+        /// <summary>
+        /// Tests that a continuation line indented with a tab is also folded back onto the
+        /// previous line.
+        /// </summary>
+        [Fact]
+        public void SplitHeadersFoldedWithTabTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            string message = "Accept: a," + CRLF + "\tb" + CRLF + "CSeq: 3";
+
+            string[] headers = RTSPHeader.SplitHeaders(message);
+
+            Assert.Equal(2, headers.Length);
+            Assert.Equal("Accept: a, b", headers[0]);
+            Assert.Equal("CSeq: 3", headers[1]);
+        }
+
+        /// <summary>
+        /// Tests that a malformed line ending of a lone carriage return followed by a space
+        /// (some user agents don't get the \r\n right) is treated as a proper line break.
+        /// </summary>
+        [Fact]
+        public void SplitHeadersMalformedCarriageReturnTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            string message = "CSeq: 4\r Session: xyz";
+
+            string[] headers = RTSPHeader.SplitHeaders(message);
+
+            Assert.Equal(2, headers.Length);
+            Assert.Equal("CSeq: 4", headers[0]);
+            Assert.Equal("Session: xyz", headers[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`RTSPHeader.SplitHeaders` performs RTSP header **line folding** (collapsing continuation lines that begin with whitespace onto the previous line) and normalises malformed `\r ` (CR + space) line endings. Despite being non-trivial parsing logic, it had **no direct test coverage** — it was only exercised indirectly through well-formed round-trip messages.

This PR adds four characterisation tests for it:

- basic CRLF-separated splitting
- a continuation line folded with a leading **space**
- a continuation line folded with a leading **tab**
- a lone `"\r "` (CR + space) treated as a proper line break

## Why now

#1654 rewrites `SplitHeaders` to replace the `Regex` calls with a hand-rolled span-based normaliser. That's the kind of change where a behavioural regression could slip through silently, since the only existing RTSP test uses well-formed input that never folds.

I verified these tests pass against **both**:
- the current `master` regex-based implementation, and
- the span-based rewrite in #1654

…which confirms the two implementations are equivalent for these cases. The tests are written against `master` so they guard the behaviour regardless of whether/when #1654 lands.

## Test plan

```
dotnet test test/unit/SIPSorcery.UnitTests.csproj --filter "FullyQualifiedName~RTSPHeaderUnitTest"
```

Passed: 4/4 on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)