### PR TITLE
Refactor switch cases and improve string formatting

### DIFF
--- a/src/SIPSorcery/net/RTCP/RTCPFeedback.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPFeedback.cs
@@ -172,23 +172,23 @@ namespace SIPSorcery.Net
 
             switch (Header)
             {
-                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB && Header.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
+                case var h when h.PacketType == RTCPReportTypesEnum.RTPFB && h.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
                     SENDER_PAYLOAD_SIZE = 8;
                     // PLI feedback reports do no have any additional parameters.
                     break;
-                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB:
+                case var h when h.PacketType == RTCPReportTypesEnum.RTPFB:
                     SENDER_PAYLOAD_SIZE = 12;
                     PID = BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(payloadIndex + 8));
                     BLP = BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(payloadIndex + 10));
                     break;
 
-                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
+                case var h when h.PacketType == RTCPReportTypesEnum.PSFB && h.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
                     SENDER_PAYLOAD_SIZE = 8;
                     break;
 
                 // We have a lot of different kind of extension messages
                 // In case below we will handle the specific REMB Message https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#page-3
-                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
+                case var h when h.PacketType == RTCPReportTypesEnum.PSFB && h.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
 
                     // 0                   1                   2                   3
                     // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -267,7 +267,7 @@ namespace SIPSorcery.Net
 
             switch (Header)
             {
-                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB && Header.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
+                case var h when h.PacketType == RTCPReportTypesEnum.RTPFB && h.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
                     // PLI feedback reports do no have any additional parameters.
                     break;
                 case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB:
@@ -275,9 +275,9 @@ namespace SIPSorcery.Net
                     BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(payloadIndex + 10), BLP);
                     break;
 
-                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
+                case var h when h.PacketType == RTCPReportTypesEnum.PSFB && h.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
                     break;
-                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
+                case var h when h.PacketType == RTCPReportTypesEnum.PSFB && h.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
 
                     // There's have a lot of different kind of extension messages
                     // In case below we will handle the specific REMB Message https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#page-3

--- a/src/SIPSorcery/net/RTCP/RTCPFeedback.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPFeedback.cs
@@ -270,7 +270,7 @@ namespace SIPSorcery.Net
                 case var h when h.PacketType == RTCPReportTypesEnum.RTPFB && h.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
                     // PLI feedback reports do no have any additional parameters.
                     break;
-                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB:
+                case var h when h.PacketType == RTCPReportTypesEnum.RTPFB:
                     BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(payloadIndex + 8), PID);
                     BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(payloadIndex + 10), BLP);
                     break;

--- a/src/SIPSorcery/net/RTCP/RTCPFeedback.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPFeedback.cs
@@ -172,23 +172,23 @@ namespace SIPSorcery.Net
 
             switch (Header)
             {
-                case var x when x.PacketType == RTCPReportTypesEnum.RTPFB && x.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB && Header.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
                     SENDER_PAYLOAD_SIZE = 8;
                     // PLI feedback reports do no have any additional parameters.
                     break;
-                case var x when x.PacketType == RTCPReportTypesEnum.RTPFB:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB:
                     SENDER_PAYLOAD_SIZE = 12;
                     PID = BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(payloadIndex + 8));
                     BLP = BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(payloadIndex + 10));
                     break;
 
-                case var x when x.PacketType == RTCPReportTypesEnum.PSFB && x.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
                     SENDER_PAYLOAD_SIZE = 8;
                     break;
 
                 // We have a lot of different kind of extension messages
                 // In case below we will handle the specific REMB Message https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#page-3
-                case var x when x.PacketType == RTCPReportTypesEnum.PSFB && x.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
 
                     // 0                   1                   2                   3
                     // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -267,17 +267,17 @@ namespace SIPSorcery.Net
 
             switch (Header)
             {
-                case var x when x.PacketType == RTCPReportTypesEnum.RTPFB && x.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB && Header.FeedbackMessageType == RTCPFeedbackTypesEnum.RTCP_SR_REQ:
                     // PLI feedback reports do no have any additional parameters.
                     break;
-                case var x when x.PacketType == RTCPReportTypesEnum.RTPFB:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.RTPFB:
                     BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(payloadIndex + 8), PID);
                     BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(payloadIndex + 10), BLP);
                     break;
 
-                case var x when x.PacketType == RTCPReportTypesEnum.PSFB && x.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
                     break;
-                case var x when x.PacketType == RTCPReportTypesEnum.PSFB && x.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
+                case var _ when Header.PacketType == RTCPReportTypesEnum.PSFB && Header.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.AFB:
 
                     // There's have a lot of different kind of extension messages
                     // In case below we will handle the specific REMB Message https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#page-3

--- a/src/SIPSorcery/net/RTCP/RTCPHeader.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPHeader.cs
@@ -177,7 +177,7 @@ namespace SIPSorcery.Net
         {
             if (receptionReportCount > MAX_RECEPTIONREPORT_COUNT)
             {
-                throw new ApplicationException("The Reception Report Count value cannot be larger than " + MAX_RECEPTIONREPORT_COUNT + ".");
+                throw new ApplicationException($"The Reception Report Count value cannot be larger than {MAX_RECEPTIONREPORT_COUNT}.");
             }
 
             ReceptionReportCount = receptionReportCount;

--- a/src/SIPSorcery/net/RTCP/RTCPTWCCFeedback.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPTWCCFeedback.cs
@@ -524,9 +524,7 @@ namespace SIPSorcery.Net
             var packetStatusInfo = string.Join(", ", PacketStatuses.Select(ps =>
                 $"Seq:{ps.SequenceNumber}({ps.Status}{(ps.Delta.HasValue ? $",Δ:{ps.Delta.Value}" : "")})"));
 
-            return $"TWCC Feedback: SenderSSRC={SenderSSRC}, MediaSSRC={MediaSSRC}, BaseSeq={BaseSequenceNumber}, " +
-                   $"StatusCount={PacketStatusCount}, RefTime={ReferenceTime} (1/64 sec), " +
-                   $"FbkPktCount={FeedbackPacketCount}, PacketStatuses=[{packetStatusInfo}]";
+            return $"TWCC Feedback: SenderSSRC={SenderSSRC}, MediaSSRC={MediaSSRC}, BaseSeq={BaseSequenceNumber}, StatusCount={PacketStatusCount}, RefTime={ReferenceTime} (1/64 sec), FbkPktCount={FeedbackPacketCount}, PacketStatuses=[{packetStatusInfo}]";
         }
 
         #region Helper Methods


### PR DESCRIPTION
Refactored switch-case statements in RTCPFeedback.cs to use the Header property directly for pattern matching, enhancing clarity. Updated exception message in RTCPHeader.cs to use string interpolation. Simplified ToString() in RTCPTWCCFeedback.cs to use a single interpolated string for better readability.

Split of #1639