### PR TITLE
Refactor WebRTC exception messages and fingerprint comparison

### DIFF
--- a/src/SIPSorcery/net/WebRTC/RTCDataChannel.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCDataChannel.cs
@@ -134,7 +134,7 @@ namespace SIPSorcery.Net
         {
             if (message != null && Encoding.UTF8.GetByteCount(message) > _transport.maxMessageSize)
             {
-                throw new ApplicationException($"Data channel {label} was requested to send data of length {Encoding.UTF8.GetByteCount(message)}  that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
+                throw new ApplicationException($"Data channel {label} was requested to send data of length {Encoding.UTF8.GetByteCount(message)} that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
             }
             else if (_transport.state != RTCSctpTransportState.Connected)
             {
@@ -172,7 +172,7 @@ namespace SIPSorcery.Net
 
             if (effectiveCount > _transport.maxMessageSize)
             {
-                throw new ApplicationException($"Data channel {label} was requested to send data of length {effectiveCount}  that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
+                throw new ApplicationException($"Data channel {label} was requested to send data of length {effectiveCount} that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
             }
             else if (_transport.state != RTCSctpTransportState.Connected)
             {

--- a/src/SIPSorcery/net/WebRTC/RTCDataChannel.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCDataChannel.cs
@@ -134,8 +134,7 @@ namespace SIPSorcery.Net
         {
             if (message != null && Encoding.UTF8.GetByteCount(message) > _transport.maxMessageSize)
             {
-                throw new ApplicationException($"Data channel {label} was requested to send data of length {Encoding.UTF8.GetByteCount(message)} " +
-                    $" that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
+                throw new ApplicationException($"Data channel {label} was requested to send data of length {Encoding.UTF8.GetByteCount(message)}  that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
             }
             else if (_transport.state != RTCSctpTransportState.Connected)
             {
@@ -173,8 +172,7 @@ namespace SIPSorcery.Net
 
             if (effectiveCount > _transport.maxMessageSize)
             {
-                throw new ApplicationException($"Data channel {label} was requested to send data of length {effectiveCount} " +
-                    $" that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
+                throw new ApplicationException($"Data channel {label} was requested to send data of length {effectiveCount}  that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");
             }
             else if (_transport.state != RTCSctpTransportState.Connected)
             {

--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -1876,12 +1876,13 @@ namespace SIPSorcery.Net
             }
             else
             {
-                logger.LogDebug($"RTCPeerConnection DTLS handshake result {handshakeResult}, is handshake complete {dtlsHandle.IsHandshakeComplete()}.");
+                logger.LogDebug("RTCPeerConnection DTLS handshake result {HandshakeResult}, is handshake complete {IsHandshakeComplete}.",
+                    handshakeResult, dtlsHandle.IsHandshakeComplete());
 
                 var expectedFp = RemotePeerDtlsFingerprint;
                 var remoteFingerprint = DtlsUtils.Fingerprint(expectedFp.algorithm, dtlsHandle.GetRemoteCertificate().GetCertificateAt(0));
 
-                if (remoteFingerprint.value?.ToUpper() != expectedFp.value?.ToUpper())
+                if (!string.Equals(remoteFingerprint.value, expectedFp.value, StringComparison.OrdinalIgnoreCase))
                 {
                     logger.LogWarning("RTCPeerConnection remote certificate fingerprint mismatch, expected {ExpectedFingerprint}, actual {RemoteFingerprint}.", expectedFp, remoteFingerprint);
                     Close("dtls fingerprint mismatch");

--- a/src/SIPSorcery/net/WebRTC/RTCSctpTransport.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCSctpTransport.cs
@@ -380,8 +380,7 @@ namespace SIPSorcery.Net
         {
             if (length > maxMessageSize)
             {
-                throw new ApplicationException($"RTCSctpTransport was requested to send data of length {length} " +
-                    $" that exceeded the maximum allowed message size of {maxMessageSize}.");
+                throw new ApplicationException($"RTCSctpTransport was requested to send data of length {length}  that exceeded the maximum allowed message size of {maxMessageSize}.");
             }
 
             if (!_isClosed)


### PR DESCRIPTION
Consolidate exception message formatting to single lines for clarity. Update certificate fingerprint comparison to use string.Equals with ordinal ignore case, following best practices and user preferences.

Split of #1639