### PR TITLE
Refactor switch cases and clean up string interpolation for SCTP

### DIFF
--- a/src/SIPSorcery/net/SCTP/Chunks/SctpTlvChunkParameter.cs
+++ b/src/SIPSorcery/net/SCTP/Chunks/SctpTlvChunkParameter.cs
@@ -211,8 +211,7 @@ namespace SIPSorcery.Net
                 // The buffer was not big enough to supply the specified chunk parameter.
                 int bytesRequired = paramLen;
                 int bytesAvailable = buffer.Length - posn;
-                throw new ApplicationException($"The SCTP chunk parameter buffer was too short. " +
-                    $"Required {bytesRequired} bytes but only {bytesAvailable} available.");
+                throw new ApplicationException($"The SCTP chunk parameter buffer was too short. Required {bytesRequired} bytes but only {bytesAvailable} available.");
             }
 
             return paramLen;

--- a/src/SIPSorcery/net/SCTP/SctpAssociation.cs
+++ b/src/SIPSorcery/net/SCTP/SctpAssociation.cs
@@ -400,13 +400,13 @@ namespace SIPSorcery.Net
                             OnAbortReceived?.Invoke(abortReason);
                             break;
 
-                        case var ct when ct == SctpChunkType.COOKIE_ACK && State != SctpAssociationState.CookieEchoed:
+                        case var _ when chunkType == SctpChunkType.COOKIE_ACK && State != SctpAssociationState.CookieEchoed:
                             // https://tools.ietf.org/html/rfc4960#section-5.2.5
                             // At any state other than COOKIE-ECHOED, an endpoint should silently
                             // discard a received COOKIE ACK chunk.
                             break;
 
-                        case var ct when ct == SctpChunkType.COOKIE_ACK && State == SctpAssociationState.CookieEchoed:
+                        case var _ when chunkType == SctpChunkType.COOKIE_ACK && State == SctpAssociationState.CookieEchoed:
                             SetState(SctpAssociationState.Established);
                             CancelTimers();
                             _dataSender.StartSending();
@@ -468,13 +468,13 @@ namespace SIPSorcery.Net
                             SendChunk(chunk);
                             break;
 
-                        case var ct when ct == SctpChunkType.INIT_ACK && State != SctpAssociationState.CookieWait:
+                        case var _ when chunkType == SctpChunkType.INIT_ACK && State != SctpAssociationState.CookieWait:
                             // https://tools.ietf.org/html/rfc4960#section-5.2.3
                             // If an INIT ACK is received by an endpoint in any state other than the
                             // COOKIE - WAIT state, the endpoint should discard the INIT ACK chunk.
                             break;
 
-                        case var ct when ct == SctpChunkType.INIT_ACK && State == SctpAssociationState.CookieWait:
+                        case var _ when chunkType == SctpChunkType.INIT_ACK && State == SctpAssociationState.CookieWait:
 
                             if (_t1Init != null)
                             {
@@ -528,7 +528,7 @@ namespace SIPSorcery.Net
                             }
                             break;
 
-                        case var ct when ct == SctpChunkType.INIT_ACK && State != SctpAssociationState.CookieWait:
+                        case var _ when chunkType == SctpChunkType.INIT_ACK && State != SctpAssociationState.CookieWait:
                             logger.LogWarning("SCTP association received INIT_ACK chunk in wrong state of {State}, ignoring.", State);
                             break;
 
@@ -536,7 +536,7 @@ namespace SIPSorcery.Net
                             _dataSender.GotSack(chunk as SctpSackChunk);
                             break;
 
-                        case var ct when ct == SctpChunkType.SHUTDOWN && State == SctpAssociationState.Established:
+                        case var _ when chunkType == SctpChunkType.SHUTDOWN && State == SctpAssociationState.Established:
                             // TODO: Check outstanding data chunks.
                             _dataSender?.Close();
                             var shutdownAck = new SctpChunk(SctpChunkType.SHUTDOWN_ACK);
@@ -544,7 +544,7 @@ namespace SIPSorcery.Net
                             SetState(SctpAssociationState.ShutdownAckSent);
                             break;
 
-                        case var ct when ct == SctpChunkType.SHUTDOWN_ACK && State == SctpAssociationState.ShutdownSent:
+                        case var _ when chunkType == SctpChunkType.SHUTDOWN_ACK && State == SctpAssociationState.ShutdownSent:
                             SetState(SctpAssociationState.Closed);
                             var shutCompleteChunk = new SctpChunk(SctpChunkType.SHUTDOWN_COMPLETE,
                                 (byte)(_remoteVerificationTag != 0 ? SHUTDOWN_CHUNK_TBIT_FLAG : 0x00));


### PR DESCRIPTION
Refactor switch-case statements to use discard variable (_) for chunkType pattern matching in SctpAssociation.cs, improving clarity and modernizing syntax. Consolidate string interpolation in SctpTlvChunkParameter.cs for better readability.

Split of #1639