### PR TITLE
Refactor SIP Regex usage for performance and clarity

### DIFF
--- a/src/SIPSorcery/app/SIPPacketMangler.cs
+++ b/src/SIPSorcery/app/SIPPacketMangler.cs
@@ -26,9 +26,25 @@ using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP.App
 {
-    public class SIPPacketMangler
+    public partial class SIPPacketMangler
     {
         private static readonly ILogger logger = LogFactory.CreateLogger<SIPPacketMangler>();
+        private const string SDP_IP6_REGEX_PATTERN = @"c=IN IP6 (?<ipaddress>([:a-fA-F0-9]+))";
+        private const string SDP_IP4_REGEX_PATTERN = @"c=IN IP4 (?<ipaddress>(\d+\.){3}\d+)";
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(SDP_IP6_REGEX_PATTERN, RegexOptions.Singleline)]
+        private static partial Regex SdpIp6Regex();
+
+        [GeneratedRegex(SDP_IP4_REGEX_PATTERN, RegexOptions.Singleline)]
+        private static partial Regex SdpIp4Regex();
+#else
+        private static readonly Regex m_sdpIp6Regex = new Regex(SDP_IP6_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex m_sdpIp4Regex = new Regex(SDP_IP4_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.Singleline);
+
+        private static Regex SdpIp6Regex() => m_sdpIp6Regex;
+        private static Regex SdpIp4Regex() => m_sdpIp4Regex;
+#endif
 
         public static string MangleSDP(string sdpBody, string publicIPAddress, out bool wasMangled)
         {
@@ -38,16 +54,9 @@ namespace SIPSorcery.SIP.App
             {
                 if (sdpBody != null && publicIPAddress != null)
                 {
-                    var sdpEndPoint = SDP.GetSDPRTPEndPoint(sdpBody);
-                    if(sdpEndPoint == null)
-                    {
-                        logger.LogWarning("SDP mangling failed to find a valid RTP endpoint in the SDP body.");
-                        return sdpBody;
-                    }
-
+                    IPAddress addr = SDP.GetSDPRTPEndPoint(sdpBody).Address;
                     //rj2: need to consider publicAddress and IPv6 for mangling
                     IPAddress pubaddr = IPAddress.Parse(publicIPAddress);
-                    var addr = sdpEndPoint.Address;
                     string sdpAddress = addr.ToString();
 
                     // Only mangle if there is something to change. For example the server could be on the same private subnet in which case it can't help.
@@ -55,7 +64,7 @@ namespace SIPSorcery.SIP.App
                         && pubaddr.AddressFamily == AddressFamily.InterNetworkV6
                         && addr.AddressFamily == AddressFamily.InterNetworkV6)
                     {
-                        string mangledSDP = Regex.Replace(sdpBody, @"c=IN IP6 (?<ipaddress>([:a-fA-F0-9]+))", $"c=IN IP6{publicIPAddress}", RegexOptions.Singleline);
+                        string mangledSDP = SdpIp6Regex().Replace(sdpBody, "c=IN IP6" + publicIPAddress);
                         wasMangled = true;
 
                         return mangledSDP;
@@ -65,7 +74,7 @@ namespace SIPSorcery.SIP.App
                         && addr.AddressFamily == AddressFamily.InterNetwork)
                     {
                         //logger.LogDebug("MangleSDP replacing private " + sdpAddress + " with " + publicIPAddress + ".");
-                        string mangledSDP = Regex.Replace(sdpBody, @"c=IN IP4 (?<ipaddress>(\d+\.){3}\d+)", $"c=IN IP4 {publicIPAddress}", RegexOptions.Singleline);
+                        string mangledSDP = SdpIp4Regex().Replace(sdpBody, "c=IN IP4 " + publicIPAddress);
                         wasMangled = true;
 
                         return mangledSDP;

--- a/src/SIPSorcery/app/SIPPacketMangler.cs
+++ b/src/SIPSorcery/app/SIPPacketMangler.cs
@@ -54,9 +54,16 @@ namespace SIPSorcery.SIP.App
             {
                 if (sdpBody != null && publicIPAddress != null)
                 {
-                    IPAddress addr = SDP.GetSDPRTPEndPoint(sdpBody).Address;
+                    var sdpEndPoint = SDP.GetSDPRTPEndPoint(sdpBody);
+                    if (sdpEndPoint == null)
+                    {
+                        logger.LogWarning("SDP mangling failed to find a valid RTP endpoint in the SDP body.");
+                        return sdpBody;
+                    }
+
                     //rj2: need to consider publicAddress and IPv6 for mangling
                     IPAddress pubaddr = IPAddress.Parse(publicIPAddress);
+                    var addr = sdpEndPoint.Address;
                     string sdpAddress = addr.ToString();
 
                     // Only mangle if there is something to change. For example the server could be on the same private subnet in which case it can't help.

--- a/src/SIPSorcery/app/SIPUserAgents/SIPCallDescriptor.cs
+++ b/src/SIPSorcery/app/SIPUserAgents/SIPCallDescriptor.cs
@@ -55,7 +55,7 @@ namespace SIPSorcery.SIP.App
         }
     }
 
-    public class SIPCallDescriptor
+    public partial class SIPCallDescriptor
     {
         private const int MAX_REINVITE_DELAY = 5;
         private const int DEFAULT_REINVITE_DELAY = 2;
@@ -82,8 +82,90 @@ namespace SIPSorcery.SIP.App
         private readonly static string m_defaultFromURI = SIPConstants.SIP_DEFAULT_FROMURI;
         private readonly static string m_sdpContentType = SDP.SDP_MIME_CONTENTTYPE;
         private static char m_customHeadersSeparator = '|';                 // Must match SIPProvider.CUSTOM_HEADERS_SEPARATOR.
+        private const string DELAY_CALL_REGEX_PATTERN = @"dt=(?<delaytime>\d+)";
+        private const string REDIRECT_MODE_REGEX_PATTERN = @"rm=(?<redirectmode>\w)";
+        private const string CALL_DURATION_REGEX_PATTERN = @"cd=(?<callduration>\d+)";
+        private const string MANGLE_MODE_REGEX_PATTERN = @"ma=(?<mangle>\w+)";
+        private const string FROM_DISPLAY_NAME_REGEX_PATTERN = @"fd=(?<displayname>.+?)(,|$)";
+        private const string FROM_USERNAME_REGEX_PATTERN = @"fu=(?<username>.+?)(,|$)";
+        private const string FROM_HOST_REGEX_PATTERN = @"fh=(?<host>.+?)(,|$)";
+        private const string TRANSFER_MODE_REGEX_PATTERN = @"tr=(?<transfermode>.+?)(,|$)";
+        private const string CALLER_DETAILS_REGEX_PATTERN = @"rcd=(?<callerdetails>\w+)";
+        private const string ACCOUNT_CODE_REGEX_PATTERN = @"ac=(?<accountCode>\w+)";
+        private const string RATE_CODE_REGEX_PATTERN = @"rc=(?<rateCode>\w+)";
+        private const string DELAYED_REINVITE_REGEX_PATTERN = @"dr=(?<delayedReinvite>\d+)";
+        private const string IMMEDIATE_REINVITE_REGEX_PATTERN = @"ir=\w+";
 
         private static readonly ILogger logger = LogFactory.CreateLogger<SIPCallDescriptor>();
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(DELAY_CALL_REGEX_PATTERN)]
+        private static partial Regex DelayCallRegex();
+
+        [GeneratedRegex(REDIRECT_MODE_REGEX_PATTERN)]
+        private static partial Regex RedirectModeRegex();
+
+        [GeneratedRegex(CALL_DURATION_REGEX_PATTERN)]
+        private static partial Regex CallDurationRegex();
+
+        [GeneratedRegex(MANGLE_MODE_REGEX_PATTERN)]
+        private static partial Regex MangleModeRegex();
+
+        [GeneratedRegex(FROM_DISPLAY_NAME_REGEX_PATTERN)]
+        private static partial Regex FromDisplayNameRegex();
+
+        [GeneratedRegex(FROM_USERNAME_REGEX_PATTERN)]
+        private static partial Regex FromUsernameRegex();
+
+        [GeneratedRegex(FROM_HOST_REGEX_PATTERN)]
+        private static partial Regex FromHostRegex();
+
+        [GeneratedRegex(TRANSFER_MODE_REGEX_PATTERN)]
+        private static partial Regex TransferModeRegex();
+
+        [GeneratedRegex(CALLER_DETAILS_REGEX_PATTERN)]
+        private static partial Regex CallerDetailsRegex();
+
+        [GeneratedRegex(ACCOUNT_CODE_REGEX_PATTERN)]
+        private static partial Regex AccountCodeRegex();
+
+        [GeneratedRegex(RATE_CODE_REGEX_PATTERN)]
+        private static partial Regex RateCodeRegex();
+
+        [GeneratedRegex(DELAYED_REINVITE_REGEX_PATTERN)]
+        private static partial Regex DelayedReinviteRegex();
+
+        [GeneratedRegex(IMMEDIATE_REINVITE_REGEX_PATTERN)]
+        private static partial Regex ImmediateReinviteRegex();
+#else
+        private static readonly Regex m_delayCallRegex = new Regex(DELAY_CALL_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_redirectModeRegex = new Regex(REDIRECT_MODE_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_callDurationRegex = new Regex(CALL_DURATION_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_mangleModeRegex = new Regex(MANGLE_MODE_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_fromDisplayNameRegex = new Regex(FROM_DISPLAY_NAME_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_fromUsernameRegex = new Regex(FROM_USERNAME_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_fromHostRegex = new Regex(FROM_HOST_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_transferModeRegex = new Regex(TRANSFER_MODE_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_callerDetailsRegex = new Regex(CALLER_DETAILS_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_accountCodeRegex = new Regex(ACCOUNT_CODE_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_rateCodeRegex = new Regex(RATE_CODE_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_delayedReinviteRegex = new Regex(DELAYED_REINVITE_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_immediateReinviteRegex = new Regex(IMMEDIATE_REINVITE_REGEX_PATTERN, RegexOptions.Compiled);
+
+        private static Regex DelayCallRegex() => m_delayCallRegex;
+        private static Regex RedirectModeRegex() => m_redirectModeRegex;
+        private static Regex CallDurationRegex() => m_callDurationRegex;
+        private static Regex MangleModeRegex() => m_mangleModeRegex;
+        private static Regex FromDisplayNameRegex() => m_fromDisplayNameRegex;
+        private static Regex FromUsernameRegex() => m_fromUsernameRegex;
+        private static Regex FromHostRegex() => m_fromHostRegex;
+        private static Regex TransferModeRegex() => m_transferModeRegex;
+        private static Regex CallerDetailsRegex() => m_callerDetailsRegex;
+        private static Regex AccountCodeRegex() => m_accountCodeRegex;
+        private static Regex RateCodeRegex() => m_rateCodeRegex;
+        private static Regex DelayedReinviteRegex() => m_delayedReinviteRegex;
+        private static Regex ImmediateReinviteRegex() => m_immediateReinviteRegex;
+#endif
 
         public string Username;                 // The username that will be used in the From header and to authenticate the call unless overridden by AuthUsername.
         public string AuthUsername;             // The username that will be used from authentication. Optional setting only needed if the From header user needs to be different from the digest username.
@@ -291,84 +373,84 @@ namespace SIPSorcery.SIP.App
                 options = options.Trim('[', ']');
 
                 // Parse delay time option.
-                Match delayCallMatch = Regex.Match(options, $@"{DELAY_CALL_OPTION_KEY}=(?<delaytime>\d+)");
+                var delayCallMatch = DelayCallRegex().Match(options);
                 if (delayCallMatch.Success)
                 {
                     int.TryParse(delayCallMatch.Result("${delaytime}"), out DelaySeconds);
                 }
 
                 // Parse redirect mode option.
-                Match redirectModeMatch = Regex.Match(options, $@"{REDIRECT_MODE_OPTION_KEY}=(?<redirectmode>\w)");
+                var redirectModeMatch = RedirectModeRegex().Match(options);
                 if (redirectModeMatch.Success)
                 {
                     string redirectMode = redirectModeMatch.Result("${redirectmode}");
-                    //if (redirectMode == "a" || redirectMode == "A")
+                    //if (redirectMode is "a" or "A")
                     //{
                     //    RedirectMode = SIPCallRedirectModesEnum.Add;
                     //}
-                    //else if (redirectMode == "r" || redirectMode == "R")
+                    //else if (redirectMode is "r" or "R")
                     //{
                     //    RedirectMode = SIPCallRedirectModesEnum.Replace;
                     //}
-                    if (redirectMode == "n" || redirectMode == "N")
+                    if (redirectMode is "n" or "N")
                     {
                         RedirectMode = SIPCallRedirectModesEnum.NewDialPlan;
                     }
-                    else if (redirectMode == "m" || redirectMode == "M")
+                    else if (redirectMode is "m" or "M")
                     {
                         RedirectMode = SIPCallRedirectModesEnum.Manual;
                     }
                 }
 
                 // Parse call duration limit option.
-                Match callDurationMatch = Regex.Match(options, $@"{CALL_DURATION_OPTION_KEY}=(?<callduration>\d+)");
+                var callDurationMatch = CallDurationRegex().Match(options);
                 if (callDurationMatch.Success)
                 {
                     int.TryParse(callDurationMatch.Result("${callduration}"), out CallDurationLimit);
                 }
 
                 // Parse the mangle option.
-                Match mangleMatch = Regex.Match(options, $@"{MANGLE_MODE_OPTION_KEY}=(?<mangle>\w+)");
+                var mangleMatch = MangleModeRegex().Match(options);
                 if (mangleMatch.Success)
                 {
                     bool.TryParse(mangleMatch.Result("${mangle}"), out MangleResponseSDP);
                 }
 
                 // Parse the From header display name option.
-                Match fromDisplayNameMatch = Regex.Match(options, $@"{FROM_DISPLAY_NAME_KEY}=(?<displayname>.+?)(,|$)");
+                var fromDisplayNameMatch = FromDisplayNameRegex().Match(options);
                 if (fromDisplayNameMatch.Success)
                 {
                     FromDisplayName = fromDisplayNameMatch.Result("${displayname}").Trim();
                 }
 
                 // Parse the From header URI username option.
-                Match fromUsernameNameMatch = Regex.Match(options, $@"{FROM_USERNAME_KEY}=(?<username>.+?)(,|$)");
+                var fromUsernameNameMatch = FromUsernameRegex().Match(options);
                 if (fromUsernameNameMatch.Success)
                 {
                     FromURIUsername = fromUsernameNameMatch.Result("${username}").Trim();
                 }
 
                 // Parse the From header URI host option.
-                Match fromURIHostMatch = Regex.Match(options, $@"{FROM_HOST_KEY}=(?<host>.+?)(,|$)");
+                var fromURIHostMatch = FromHostRegex().Match(options);
                 if (fromURIHostMatch.Success)
                 {
                     FromURIHost = fromURIHostMatch.Result("${host}").Trim();
                 }
 
                 // Parse the Transfer behaviour option.
-                Match transferMatch = Regex.Match(options, $@"{TRANSFER_MODE_OPTION_KEY}=(?<transfermode>.+?)(,|$)");
+                var transferMatch = TransferModeRegex().Match(options);
                 if (transferMatch.Success)
                 {
                     string transferMode = transferMatch.Result("${transfermode}");
-                    if (transferMode == "n" || transferMode == "N")
+                    if (transferMode is "n" or "N")
                     {
                         TransferMode = SIPDialogueTransferModesEnum.NotAllowed;
                     }
-                    else if (transferMode == "p" || transferMode == "P")
+                    else if (transferMode is "p" or "P")
                     {
                         TransferMode = SIPDialogueTransferModesEnum.PassThru;
                     }
-                    else if (transferMode == "c" || transferMode == "C")
+                    else if (transferMode is "c" or "C")
                     {
                         TransferMode = SIPDialogueTransferModesEnum.BlindPlaceCall;
                     }
@@ -387,28 +469,28 @@ namespace SIPSorcery.SIP.App
                 }
 
                 // Parse the request caller details option.
-                Match callerDetailsMatch = Regex.Match(options, $@"{REQUEST_CALLER_DETAILS}=(?<callerdetails>\w+)");
+                var callerDetailsMatch = CallerDetailsRegex().Match(options);
                 if (callerDetailsMatch.Success)
                 {
                     bool.TryParse(callerDetailsMatch.Result("${callerdetails}"), out RequestCallerDetails);
                 }
 
                 // Parse the accountcode.
-                Match accountCodeMatch = Regex.Match(options, $@"{ACCOUNT_CODE_KEY}=(?<accountCode>\w+)");
+                var accountCodeMatch = AccountCodeRegex().Match(options);
                 if (accountCodeMatch.Success)
                 {
                     AccountCode = accountCodeMatch.Result("${accountCode}");
                 }
 
                 // Parse the rate code.
-                Match rateCodeMatch = Regex.Match(options, $@"{RATE_CODE_KEY}=(?<rateCode>\w+)");
+                var rateCodeMatch = RateCodeRegex().Match(options);
                 if (rateCodeMatch.Success)
                 {
                     RateCode = rateCodeMatch.Result("${rateCode}");
                 }
 
                 // Parse the delayed reinvite option.
-                Match delayedReinviteMatch = Regex.Match(options, $@"{DELAYED_REINVITE_KEY}=(?<delayedReinvite>\d+)");
+                var delayedReinviteMatch = DelayedReinviteRegex().Match(options);
                 if (delayedReinviteMatch.Success)
                 {
                     int.TryParse(delayedReinviteMatch.Result("${delayedReinvite}"), out ReinviteDelay);
@@ -420,7 +502,7 @@ namespace SIPSorcery.SIP.App
                 }
 
                 // Parse the immediate reinvite option (TODO: remove after user switches to delayed reinvite option).
-                Match immediateReinviteMatch = Regex.Match(options, @"ir=\w+");
+                var immediateReinviteMatch = ImmediateReinviteRegex().Match(options);
                 if (immediateReinviteMatch.Success)
                 {
                     ReinviteDelay = DEFAULT_REINVITE_DELAY;

--- a/src/SIPSorcery/core/SIP/SIPHeader.cs
+++ b/src/SIPSorcery/core/SIP/SIPHeader.cs
@@ -19,8 +19,8 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using Polyfills;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP
@@ -35,6 +35,7 @@ namespace SIPSorcery.SIP
     /// it is optional."
     /// 
     /// The branch parameter on a Via therefore appears to be optionally mandatory?!
+    ///
     /// Any SIP application element that uses transactions depends on the branch parameter for transaction matching.
     /// Only the top Via header branch is used for transactions though so if the request has made it to this stack
     /// with missing branches then in theory it should be safe to proceed. It will be left up to the SIPTransaction
@@ -726,7 +727,7 @@ namespace SIPSorcery.SIP
             }
             catch (Exception excp)
             {
-                throw new SIPValidationException(SIPValidationFieldsEnum.ContactHeader, "Contact header invalid, parse failed. " + excp.Message);
+                throw new SIPValidationException(SIPValidationFieldsEnum.ContactHeader, $"Contact header invalid, parse failed. {excp.Message}");
             }
         }
 
@@ -756,7 +757,7 @@ namespace SIPSorcery.SIP
                 {
                     foreach (string key in contact1Keys)
                     {
-                        if (key is EXPIRES_PARAMETER_KEY or QVALUE_PARAMETER_KEY)
+                        if (key == EXPIRES_PARAMETER_KEY || key == QVALUE_PARAMETER_KEY)
                         {
                             continue;
                         }
@@ -774,7 +775,7 @@ namespace SIPSorcery.SIP
                 {
                     foreach (string key in contact2Keys)
                     {
-                        if (key is EXPIRES_PARAMETER_KEY or QVALUE_PARAMETER_KEY)
+                        if (key == EXPIRES_PARAMETER_KEY || key == QVALUE_PARAMETER_KEY)
                         {
                             continue;
                         }
@@ -1152,6 +1153,7 @@ namespace SIPSorcery.SIP
             {
                 m_sipRoutes.RemoveAt(m_sipRoutes.Count - 1);
             }
+            ;
         }
 
         public SIPRouteSet Reversed()
@@ -1416,7 +1418,7 @@ namespace SIPSorcery.SIP
             }
             catch
             {
-                throw new SIPValidationException(SIPValidationFieldsEnum.Unknown, "One of the SIP SIPMultiUriHeaders was invalid, header: " + headerStr);
+                throw new SIPValidationException(SIPValidationFieldsEnum.Unknown, $"One of the SIP SIPMultiUriHeaders was invalid, header: {headerStr}");
             }
         }
 
@@ -1433,7 +1435,7 @@ namespace SIPSorcery.SIP
         public string FriendlyDescription()
         {
             string caller = URI.ToAOR();
-            caller = (!string.IsNullOrEmpty(Name)) ? Name + " " + caller : caller;
+            caller = (!string.IsNullOrEmpty(Name)) ? $"{Name} {caller}" : caller;
             return caller;
         }
     }
@@ -1442,34 +1444,12 @@ namespace SIPSorcery.SIP
     /// header  =  "header-name" HCOLON header-value *(COMMA header-value)
     /// field-name: field-value CRLF
     /// </bnf>
-    public partial class SIPHeader
+    public class SIPHeader
     {
         public const int DEFAULT_CSEQ = 100;
 
         private static readonly ILogger logger = LogFactory.CreateLogger<SIPHeader>();
         private static string m_CRLF = SIPConstants.CRLF;
-        private const string CRLF_WHITESPACE_REGEX_PATTERN = @"\r\n\s+";
-        private const string CR_SPACE_REGEX_PATTERN = @"\r ";
-        private const string CRLF_SPLIT_REGEX_PATTERN = @"\r\n";
-
-#if NET7_0_OR_GREATER
-        [GeneratedRegex(CRLF_WHITESPACE_REGEX_PATTERN, RegexOptions.Singleline)]
-        private static partial Regex CRLFWhitespaceRegex();
-
-        [GeneratedRegex(CR_SPACE_REGEX_PATTERN, RegexOptions.Singleline)]
-        private static partial Regex CRSpaceRegex();
-
-        [GeneratedRegex(CRLF_SPLIT_REGEX_PATTERN)]
-        private static partial Regex CRLFSplitRegex();
-#else
-        private static readonly Regex m_crlfWhitespaceRegex = new Regex(CRLF_WHITESPACE_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.Singleline);
-        private static readonly Regex m_crSpaceRegex = new Regex(CR_SPACE_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.Singleline);
-        private static readonly Regex m_crlfSplitRegex = new Regex(CRLF_SPLIT_REGEX_PATTERN, RegexOptions.Compiled);
-
-        private static Regex CRLFWhitespaceRegex() => m_crlfWhitespaceRegex;
-        private static Regex CRSpaceRegex() => m_crSpaceRegex;
-        private static Regex CRLFSplitRegex() => m_crlfSplitRegex;
-#endif
 
         // RFC SIP headers.
         public string Accept;
@@ -1610,7 +1590,7 @@ namespace SIPSorcery.SIP
             Contact = contact;
             CallId = callId;
 
-            if (cseq is >= 0 and < int.MaxValue)
+            if (cseq >= 0 && cseq < Int32.MaxValue)
             {
                 CSeq = cseq;
             }
@@ -1622,13 +1602,71 @@ namespace SIPSorcery.SIP
 
         public static string[] SplitHeaders(string message)
         {
+            static string NormalizeFoldedHeaderLines(string headerBlock)
+            {
+                var normalised = default(StringBuilder);
+                var segmentStart = 0;
+                var position = 0;
+
+                while (position < headerBlock.Length)
+                {
+                    if (position + 2 < headerBlock.Length &&
+                        headerBlock[position] == '\r' &&
+                        headerBlock[position + 1] == '\n' &&
+                        char.IsWhiteSpace(headerBlock[position + 2]))
+                    {
+                        normalised ??= new StringBuilder(headerBlock.Length);
+                        normalised.Append(headerBlock, segmentStart, position - segmentStart);
+                        normalised.Append(' ');
+
+                        position += 2;
+                        while (position < headerBlock.Length && char.IsWhiteSpace(headerBlock[position]))
+                        {
+                            position++;
+                        }
+
+                        segmentStart = position;
+                        continue;
+                    }
+
+                    if (position + 1 < headerBlock.Length &&
+                        headerBlock[position] == '\r' &&
+                        headerBlock[position + 1] == ' ')
+                    {
+                        normalised ??= new StringBuilder(headerBlock.Length);
+                        normalised.Append(headerBlock, segmentStart, position - segmentStart);
+                        normalised.Append(m_CRLF);
+
+                        position += 2;
+                        segmentStart = position;
+                        continue;
+                    }
+
+                    position++;
+                }
+
+                if (normalised is null)
+                {
+                    return headerBlock;
+                }
+
+                normalised.Append(headerBlock, segmentStart, headerBlock.Length - segmentStart);
+                return normalised.ToString();
+            }
+
             // SIP headers can be extended across lines if the first character of the next line is at least on whitespace character.
-            message = CRLFWhitespaceRegex().Replace(message, " ");
+            // Some user agents couldn't get the \r\n bit right; normalise those at the same time.
+            message = NormalizeFoldedHeaderLines(message);
 
-            // Some user agents couldn't get the \r\n bit right.
-            message = CRSpaceRegex().Replace(message, m_CRLF);
+            var headers = new List<string>();
+            var messageSpan = message.AsSpan();
 
-            return CRLFSplitRegex().Split(message);
+            foreach (var headerRange in messageSpan.Split(m_CRLF.AsSpan()))
+            {
+                headers.Add(messageSpan[headerRange].ToString());
+            }
+
+            return headers.ToArray();
         }
 
         public static SIPHeader ParseSIPHeaders(string[] headersCollection)

--- a/src/SIPSorcery/core/SIP/SIPHeader.cs
+++ b/src/SIPSorcery/core/SIP/SIPHeader.cs
@@ -19,8 +19,8 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
-using Polyfills;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP
@@ -35,7 +35,6 @@ namespace SIPSorcery.SIP
     /// it is optional."
     /// 
     /// The branch parameter on a Via therefore appears to be optionally mandatory?!
-    ///
     /// Any SIP application element that uses transactions depends on the branch parameter for transaction matching.
     /// Only the top Via header branch is used for transactions though so if the request has made it to this stack
     /// with missing branches then in theory it should be safe to proceed. It will be left up to the SIPTransaction
@@ -727,7 +726,7 @@ namespace SIPSorcery.SIP
             }
             catch (Exception excp)
             {
-                throw new SIPValidationException(SIPValidationFieldsEnum.ContactHeader, $"Contact header invalid, parse failed. {excp.Message}");
+                throw new SIPValidationException(SIPValidationFieldsEnum.ContactHeader, "Contact header invalid, parse failed. " + excp.Message);
             }
         }
 
@@ -757,7 +756,7 @@ namespace SIPSorcery.SIP
                 {
                     foreach (string key in contact1Keys)
                     {
-                        if (key == EXPIRES_PARAMETER_KEY || key == QVALUE_PARAMETER_KEY)
+                        if (key is EXPIRES_PARAMETER_KEY or QVALUE_PARAMETER_KEY)
                         {
                             continue;
                         }
@@ -775,7 +774,7 @@ namespace SIPSorcery.SIP
                 {
                     foreach (string key in contact2Keys)
                     {
-                        if (key == EXPIRES_PARAMETER_KEY || key == QVALUE_PARAMETER_KEY)
+                        if (key is EXPIRES_PARAMETER_KEY or QVALUE_PARAMETER_KEY)
                         {
                             continue;
                         }
@@ -1153,7 +1152,6 @@ namespace SIPSorcery.SIP
             {
                 m_sipRoutes.RemoveAt(m_sipRoutes.Count - 1);
             }
-            ;
         }
 
         public SIPRouteSet Reversed()
@@ -1418,7 +1416,7 @@ namespace SIPSorcery.SIP
             }
             catch
             {
-                throw new SIPValidationException(SIPValidationFieldsEnum.Unknown, $"One of the SIP SIPMultiUriHeaders was invalid, header: {headerStr}");
+                throw new SIPValidationException(SIPValidationFieldsEnum.Unknown, "One of the SIP SIPMultiUriHeaders was invalid, header: " + headerStr);
             }
         }
 
@@ -1435,7 +1433,7 @@ namespace SIPSorcery.SIP
         public string FriendlyDescription()
         {
             string caller = URI.ToAOR();
-            caller = (!string.IsNullOrEmpty(Name)) ? $"{Name} {caller}" : caller;
+            caller = (!string.IsNullOrEmpty(Name)) ? Name + " " + caller : caller;
             return caller;
         }
     }
@@ -1444,12 +1442,34 @@ namespace SIPSorcery.SIP
     /// header  =  "header-name" HCOLON header-value *(COMMA header-value)
     /// field-name: field-value CRLF
     /// </bnf>
-    public class SIPHeader
+    public partial class SIPHeader
     {
         public const int DEFAULT_CSEQ = 100;
 
         private static readonly ILogger logger = LogFactory.CreateLogger<SIPHeader>();
         private static string m_CRLF = SIPConstants.CRLF;
+        private const string CRLF_WHITESPACE_REGEX_PATTERN = @"\r\n\s+";
+        private const string CR_SPACE_REGEX_PATTERN = @"\r ";
+        private const string CRLF_SPLIT_REGEX_PATTERN = @"\r\n";
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(CRLF_WHITESPACE_REGEX_PATTERN, RegexOptions.Singleline)]
+        private static partial Regex CRLFWhitespaceRegex();
+
+        [GeneratedRegex(CR_SPACE_REGEX_PATTERN, RegexOptions.Singleline)]
+        private static partial Regex CRSpaceRegex();
+
+        [GeneratedRegex(CRLF_SPLIT_REGEX_PATTERN)]
+        private static partial Regex CRLFSplitRegex();
+#else
+        private static readonly Regex m_crlfWhitespaceRegex = new Regex(CRLF_WHITESPACE_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex m_crSpaceRegex = new Regex(CR_SPACE_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex m_crlfSplitRegex = new Regex(CRLF_SPLIT_REGEX_PATTERN, RegexOptions.Compiled);
+
+        private static Regex CRLFWhitespaceRegex() => m_crlfWhitespaceRegex;
+        private static Regex CRSpaceRegex() => m_crSpaceRegex;
+        private static Regex CRLFSplitRegex() => m_crlfSplitRegex;
+#endif
 
         // RFC SIP headers.
         public string Accept;
@@ -1590,7 +1610,7 @@ namespace SIPSorcery.SIP
             Contact = contact;
             CallId = callId;
 
-            if (cseq >= 0 && cseq < Int32.MaxValue)
+            if (cseq is >= 0 and < int.MaxValue)
             {
                 CSeq = cseq;
             }
@@ -1602,71 +1622,13 @@ namespace SIPSorcery.SIP
 
         public static string[] SplitHeaders(string message)
         {
-            static string NormalizeFoldedHeaderLines(string headerBlock)
-            {
-                var normalised = default(StringBuilder);
-                var segmentStart = 0;
-                var position = 0;
-
-                while (position < headerBlock.Length)
-                {
-                    if (position + 2 < headerBlock.Length &&
-                        headerBlock[position] == '\r' &&
-                        headerBlock[position + 1] == '\n' &&
-                        char.IsWhiteSpace(headerBlock[position + 2]))
-                    {
-                        normalised ??= new StringBuilder(headerBlock.Length);
-                        normalised.Append(headerBlock, segmentStart, position - segmentStart);
-                        normalised.Append(' ');
-
-                        position += 2;
-                        while (position < headerBlock.Length && char.IsWhiteSpace(headerBlock[position]))
-                        {
-                            position++;
-                        }
-
-                        segmentStart = position;
-                        continue;
-                    }
-
-                    if (position + 1 < headerBlock.Length &&
-                        headerBlock[position] == '\r' &&
-                        headerBlock[position + 1] == ' ')
-                    {
-                        normalised ??= new StringBuilder(headerBlock.Length);
-                        normalised.Append(headerBlock, segmentStart, position - segmentStart);
-                        normalised.Append(m_CRLF);
-
-                        position += 2;
-                        segmentStart = position;
-                        continue;
-                    }
-
-                    position++;
-                }
-
-                if (normalised is null)
-                {
-                    return headerBlock;
-                }
-
-                normalised.Append(headerBlock, segmentStart, headerBlock.Length - segmentStart);
-                return normalised.ToString();
-            }
-
             // SIP headers can be extended across lines if the first character of the next line is at least on whitespace character.
-            // Some user agents couldn't get the \r\n bit right; normalise those at the same time.
-            message = NormalizeFoldedHeaderLines(message);
+            message = CRLFWhitespaceRegex().Replace(message, " ");
 
-            var headers = new List<string>();
-            var messageSpan = message.AsSpan();
+            // Some user agents couldn't get the \r\n bit right.
+            message = CRSpaceRegex().Replace(message, m_CRLF);
 
-            foreach (var headerRange in messageSpan.Split(m_CRLF.AsSpan()))
-            {
-                headers.Add(messageSpan[headerRange].ToString());
-            }
-
-            return headers.ToArray();
+            return CRLFSplitRegex().Split(message);
         }
 
         public static SIPHeader ParseSIPHeaders(string[] headersCollection)

--- a/src/SIPSorcery/core/SIP/SIPReplacesParameter.cs
+++ b/src/SIPSorcery/core/SIP/SIPReplacesParameter.cs
@@ -18,19 +18,41 @@ using System.Text.RegularExpressions;
 
 namespace SIPSorcery.SIP
 {
-    public class SIPReplacesParameter
+    public partial class SIPReplacesParameter
     {
         public string CallID;
         public string ToTag;
         public string FromTag;
+        private const string CALL_ID_REGEX_PATTERN = "^(?<callid>.*?);";
+        private const string TO_TAG_REGEX_PATTERN = "to-tag=(?<totag>.*?)(;|$)";
+        private const string FROM_TAG_REGEX_PATTERN = "from-tag=(?<fromtag>.*?)(;|$)";
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(CALL_ID_REGEX_PATTERN)]
+        private static partial Regex CallIDRegex();
+
+        [GeneratedRegex(TO_TAG_REGEX_PATTERN, RegexOptions.IgnoreCase)]
+        private static partial Regex ToTagRegex();
+
+        [GeneratedRegex(FROM_TAG_REGEX_PATTERN, RegexOptions.IgnoreCase)]
+        private static partial Regex FromTagRegex();
+#else
+        private static readonly Regex m_callIdRegex = new Regex(CALL_ID_REGEX_PATTERN, RegexOptions.Compiled);
+        private static readonly Regex m_toTagRegex = new Regex(TO_TAG_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex m_fromTagRegex = new Regex(FROM_TAG_REGEX_PATTERN, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static Regex CallIDRegex() => m_callIdRegex;
+        private static Regex ToTagRegex() => m_toTagRegex;
+        private static Regex FromTagRegex() => m_fromTagRegex;
+#endif
 
         public static SIPReplacesParameter Parse(string replaces)
         {
-            var callIDMatch = Regex.Match(replaces, "^(?<callid>.*?);");
+            var callIDMatch = CallIDRegex().Match(replaces);
             if (replaces.IndexOf(';') != -1)
             {
-                var toTagMatch = Regex.Match(replaces, "to-tag=(?<totag>.*?)(;|$)", RegexOptions.IgnoreCase);
-                var fromTagMatch = Regex.Match(replaces, "from-tag=(?<fromtag>.*?)(;|$)", RegexOptions.IgnoreCase);
+                var toTagMatch = ToTagRegex().Match(replaces);
+                var fromTagMatch = FromTagRegex().Match(replaces);
 
                 if (toTagMatch.Success && fromTagMatch.Success)
                 {

--- a/src/SIPSorcery/core/SIP/SIPURI.cs
+++ b/src/SIPSorcery/core/SIP/SIPURI.cs
@@ -26,7 +26,7 @@ namespace SIPSorcery.SIP
     /// Implements the SIP URI concept from the SIP RFC3261.
     /// </summary>
     [DataContract]
-    public class SIPURI
+    public partial class SIPURI
     {
         public static SIPURI None = new SIPURI();
 
@@ -37,9 +37,18 @@ namespace SIPSorcery.SIP
         private const char HEADER_TAG_DELIMITER = '&';
         private const char TAG_NAME_VALUE_SEPERATOR = '=';
 
-        private static ILogger logger = LogFactory.CreateLogger<SIPURI>();
+        private static readonly ILogger logger = LogFactory.CreateLogger<SIPURI>();
 
         private static char[] m_invalidSIPHostChars = new char[] { ',', '"' };
+        private const string SIP_SCHEME_REGEX_PATTERN = @"^(sip|sips):\S+";
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(SIP_SCHEME_REGEX_PATTERN)]
+        private static partial Regex SIPSchemeRegex();
+#else
+        private static readonly Regex m_sipSchemeRegex = new Regex(SIP_SCHEME_REGEX_PATTERN, RegexOptions.Compiled);
+        private static Regex SIPSchemeRegex() => m_sipSchemeRegex;
+#endif
 
         private static SIPProtocolsEnum m_defaultSIPTransport = SIPProtocolsEnum.udp;
         private static SIPSchemesEnum m_defaultSIPScheme = SIPSchemesEnum.sip;
@@ -454,9 +463,7 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                string regexSchemePattern = $"^({SIPSchemesEnum.sip}|{SIPSchemesEnum.sips}):";
-
-                if (Regex.Match(partialURI, $@"{regexSchemePattern}\S+").Success)
+                if (SIPSchemeRegex().IsMatch(partialURI))
                 {
                     // The partial uri is already valid.
                     return SIPURI.ParseSIPURI(partialURI);


### PR DESCRIPTION
Refactored SIP classes to use pre-compiled or source-generated Regex via [GeneratedRegex] for improved performance and maintainability. Introduced constants for Regex patterns and conditional compilation for .NET 7+ compatibility. Updated string operations and equality checks for consistency and modern C# style. Minor code cleanups included.