### PR TITLE
Add minimum length checks for packets received on the RTP channel and for STUN attributes

### DIFF
--- a/src/SIPSorcery/net/RTP/RTPChannel.cs
+++ b/src/SIPSorcery/net/RTP/RTPChannel.cs
@@ -390,7 +390,15 @@ public class RTPChannel : IDisposable
     /// <param name="packet">The raw packet received (note this may not be RTP if other protocols are being multiplexed).</param>
     protected virtual void OnRTPPacketReceived(UdpReceiver receiver, int localPort, IPEndPoint remoteEndPoint, byte[] packet)
     {
-        if (packet?.Length > 0)
+        // Every protocol multiplexed on the RTP/ICE socket has a minimum size of at least an RTP header:
+        // STUN is >= 20 bytes (STUNHeader.STUN_HEADER_LENGTH), a DTLS record is >= 13 bytes, RTP is >= 12
+        // bytes (RTPHeader.MIN_HEADER_LEN) and secured RTCP (SRTCP, i.e. all WebRTC RTCP) is larger still.
+        // The only smaller case is a bare unprotected RTCP report (8 bytes), which the RTP session layer
+        // (RTPSession.OnReceive) already discards as it also requires more than RTPHeader.MIN_HEADER_LEN
+        // bytes. Dropping anything shorter therefore discards only data that cannot be processed as a valid
+        // packet of any multiplexed type and, crucially, guarantees the discriminator byte reads below
+        // cannot index past the end of the buffer.
+        if (packet != null && packet.Length >= RTPHeader.MIN_HEADER_LEN)
         {
             //logger.LogDebug("RTPChannel received {Length} bytes from {RemoteEndPoint}.", packet.Length, remoteEndPoint);
 

--- a/src/SIPSorcery/net/RTP/UdpReceiver.cs
+++ b/src/SIPSorcery/net/RTP/UdpReceiver.cs
@@ -238,8 +238,14 @@ public class UdpReceiver
         { }
         catch (Exception excp)
         {
+            // A non-socket exception here almost always originates from processing a single inbound
+            // packet (e.g. a malformed STUN/RTP/TURN packet throwing in the packet-received handler).
+            // A bad packet from any remote party - including an unauthenticated one during ICE
+            // connectivity checks - must not be allowed to tear down the media session. We log and
+            // drop the offending packet and let the finally block re-arm the receive loop. This
+            // mirrors the drop-and-continue behaviour of SIPUDPChannel.EndReceiveFrom. Genuine socket
+            // failures are handled by the SocketException/ObjectDisposedException catches above.
             logger.LogError(excp, "Exception UdpReceiver.EndReceiveFrom. {ErrorMessage}", excp.Message);
-            Close(excp.Message);
         }
         finally
         {

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNAddressAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNAddressAttribute.cs
@@ -39,6 +39,11 @@ namespace SIPSorcery.Net
         public STUNAddressAttribute(byte[] attributeValue)
             : base(STUNAttributeTypesEnum.MappedAddress, attributeValue)
         {
+            if (attributeValue == null || attributeValue.Length < ADDRESS_ATTRIBUTE_IPV4_LENGTH)
+            {
+                throw new ArgumentException($"A STUN address attribute value must be at least {ADDRESS_ATTRIBUTE_IPV4_LENGTH} bytes.", nameof(attributeValue));
+            }
+
             Port = BinaryPrimitives.ReadUInt16BigEndian(attributeValue.AsSpan(2));
 
             Address = new IPAddress(new byte[] { attributeValue[4], attributeValue[5], attributeValue[6], attributeValue[7] });
@@ -56,6 +61,11 @@ namespace SIPSorcery.Net
         public STUNAddressAttribute(STUNAttributeTypesEnum attributeType, byte[] attributeValue)
             : base(attributeType, attributeValue)
         {
+            if (attributeValue == null || attributeValue.Length < ADDRESS_ATTRIBUTE_IPV4_LENGTH)
+            {
+                throw new ArgumentException($"A STUN address attribute value must be at least {ADDRESS_ATTRIBUTE_IPV4_LENGTH} bytes.", nameof(attributeValue));
+            }
+
             Port = BinaryPrimitives.ReadUInt16BigEndian(attributeValue.AsSpan(2));
 
             Address = new IPAddress(new byte[] { attributeValue[4], attributeValue[5], attributeValue[6], attributeValue[7] });

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNAttribute.cs
@@ -227,7 +227,14 @@ namespace SIPSorcery.Net
                         }
                         else if (attributeType == STUNAttributeTypesEnum.XORMappedAddress || attributeType == STUNAttributeTypesEnum.XORPeerAddress || attributeType == STUNAttributeTypesEnum.XORRelayedAddress)
                         {
-                            attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header.TransactionId);
+                            if (header == null)
+                            {
+                                logger.LogWarning("A STUN {AttributeType} attribute requires a STUN header transaction ID but the header was null and the attribute was skipped.", attributeType);
+                            }
+                            else
+                            {
+                                attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header.TransactionId);
+                            }
                         }
                         else if(attributeType == STUNAttributeTypesEnum.ConnectionId)
                         {
@@ -238,7 +245,10 @@ namespace SIPSorcery.Net
                             attribute = new STUNAttribute(attributeType, stunAttributeValue);
                         }
 
-                        attributes.Add(attribute);
+                        if (attribute != null)
+                        {
+                            attributes.Add(attribute);
+                        }
                     }
 
                     // Attributes start on 32 bit word boundaries so where an attribute length is not a multiple of 4 it gets padded.

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNAttribute.cs
@@ -114,6 +114,14 @@ namespace SIPSorcery.Net
     {
         public const short STUNATTRIBUTE_HEADER_LENGTH = 4;
 
+        /// <summary>
+        /// The minimum value length, in bytes, of an attribute whose value is a single 32 bit word.
+        /// The CHANGE-REQUEST flags, the ERROR-CODE class/number prefix and the CONNECTION-ID value all
+        /// occupy one 32 bit word and their parsers index up to the fourth byte, so their value must be at
+        /// least this long.
+        /// </summary>
+        private const int SINGLE_WORD_VALUE_LENGTH = 4;
+
         private static readonly ILogger logger = LogFactory.CreateLogger<STUNAttribute>();
 
         public STUNAttributeTypesEnum AttributeType = STUNAttributeTypesEnum.Unknown;
@@ -192,33 +200,46 @@ namespace SIPSorcery.Net
                     {
                         break;
                     }
-                    STUNAttribute attribute = null;
-                    if (attributeType == STUNAttributeTypesEnum.ChangeRequest)
+
+                    // Guard against malformed/truncated attribute values before handing them to the typed
+                    // parsers below, several of which index the value bytes without their own length checks.
+                    // A value shorter than the minimum its type requires (including a zero-length value for
+                    // a type that needs one) is skipped rather than allowed to throw on untrusted input.
+                    int stunAttributeValueLength = stunAttributeValue?.Length ?? 0;
+                    if (stunAttributeValueLength < GetMinimumValueLength(attributeType))
                     {
-                        attribute = new STUNChangeRequestAttribute(stunAttributeValue);
-                    }
-                    else if (attributeType == STUNAttributeTypesEnum.MappedAddress || attributeType == STUNAttributeTypesEnum.AlternateServer)
-                    {
-                        attribute = new STUNAddressAttribute(attributeType, stunAttributeValue);
-                    }
-                    else if (attributeType == STUNAttributeTypesEnum.ErrorCode)
-                    {
-                        attribute = new STUNErrorCodeAttribute(stunAttributeValue);
-                    }
-                    else if (attributeType == STUNAttributeTypesEnum.XORMappedAddress || attributeType == STUNAttributeTypesEnum.XORPeerAddress || attributeType == STUNAttributeTypesEnum.XORRelayedAddress)
-                    {
-                        attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header.TransactionId);
-                    }
-                    else if(attributeType == STUNAttributeTypesEnum.ConnectionId)
-                    {
-                        attribute = new STUNConnectionIdAttribute(stunAttributeValue);
+                        logger.LogWarning("A STUN {AttributeType} attribute had a value length of {ValueLength} bytes which is below the minimum required and was skipped.", attributeType, stunAttributeValueLength);
                     }
                     else
                     {
-                        attribute = new STUNAttribute(attributeType, stunAttributeValue);
-                    }
+                        STUNAttribute attribute = null;
+                        if (attributeType == STUNAttributeTypesEnum.ChangeRequest)
+                        {
+                            attribute = new STUNChangeRequestAttribute(stunAttributeValue);
+                        }
+                        else if (attributeType == STUNAttributeTypesEnum.MappedAddress || attributeType == STUNAttributeTypesEnum.AlternateServer)
+                        {
+                            attribute = new STUNAddressAttribute(attributeType, stunAttributeValue);
+                        }
+                        else if (attributeType == STUNAttributeTypesEnum.ErrorCode)
+                        {
+                            attribute = new STUNErrorCodeAttribute(stunAttributeValue);
+                        }
+                        else if (attributeType == STUNAttributeTypesEnum.XORMappedAddress || attributeType == STUNAttributeTypesEnum.XORPeerAddress || attributeType == STUNAttributeTypesEnum.XORRelayedAddress)
+                        {
+                            attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header.TransactionId);
+                        }
+                        else if(attributeType == STUNAttributeTypesEnum.ConnectionId)
+                        {
+                            attribute = new STUNConnectionIdAttribute(stunAttributeValue);
+                        }
+                        else
+                        {
+                            attribute = new STUNAttribute(attributeType, stunAttributeValue);
+                        }
 
-                    attributes.Add(attribute);
+                        attributes.Add(attribute);
+                    }
 
                     // Attributes start on 32 bit word boundaries so where an attribute length is not a multiple of 4 it gets padded.
                     int padding = (stunAttributeLength % 4 != 0) ? 4 - (stunAttributeLength % 4) : 0;
@@ -231,6 +252,33 @@ namespace SIPSorcery.Net
             else
             {
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the minimum number of value bytes the typed parser for a given attribute requires in order
+        /// to be constructed without indexing past the end of the value. Attributes whose value is shorter
+        /// than this are treated as malformed and skipped during parsing. A return value of 0 means the
+        /// attribute type imposes no minimum (its parser handles an empty or arbitrary length value safely).
+        /// </summary>
+        private static int GetMinimumValueLength(STUNAttributeTypesEnum attributeType)
+        {
+            switch (attributeType)
+            {
+                case STUNAttributeTypesEnum.MappedAddress:
+                case STUNAttributeTypesEnum.AlternateServer:
+                case STUNAttributeTypesEnum.XORMappedAddress:
+                case STUNAttributeTypesEnum.XORPeerAddress:
+                case STUNAttributeTypesEnum.XORRelayedAddress:
+                    // Reserved byte, address family, 2 byte port and a 4 byte IPv4 address. An attribute
+                    // declaring the IPv6 family requires more and is validated again in the address parser.
+                    return STUNAddressAttributeBase.ADDRESS_ATTRIBUTE_IPV4_LENGTH;
+                case STUNAttributeTypesEnum.ChangeRequest:
+                case STUNAttributeTypesEnum.ErrorCode:
+                case STUNAttributeTypesEnum.ConnectionId:
+                    return SINGLE_WORD_VALUE_LENGTH;
+                default:
+                    return 0;
             }
         }
 

--- a/src/SIPSorcery/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
+++ b/src/SIPSorcery/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
@@ -50,6 +50,11 @@ namespace SIPSorcery.Net
         public STUNXORAddressAttribute(STUNAttributeTypesEnum attributeType, byte[] attributeValue, byte[] transactionId)
             : base(attributeType, attributeValue)
         {
+            if (attributeValue == null || attributeValue.Length < ADDRESS_ATTRIBUTE_IPV4_LENGTH)
+            {
+                throw new ArgumentException($"A STUN XOR address attribute value must be at least {ADDRESS_ATTRIBUTE_IPV4_LENGTH} bytes.", nameof(attributeValue));
+            }
+
             Family = attributeValue[1];
             AddressAttributeLength = Family == 1 ? ADDRESS_ATTRIBUTE_IPV4_LENGTH : ADDRESS_ATTRIBUTE_IPV6_LENGTH;
             TransactionId = transactionId;
@@ -61,7 +66,8 @@ namespace SIPSorcery.Net
             address = new byte[4];
             BinaryPrimitives.WriteUInt32BigEndian(address, xorAddrBE);
 
-            if (Family == STUNAttributeConstants.IPv6AddressFamily[0] && TransactionId != null)
+            if (Family == STUNAttributeConstants.IPv6AddressFamily[0] && TransactionId != null
+                && attributeValue.Length >= ADDRESS_ATTRIBUTE_IPV6_LENGTH && TransactionId.Length >= 12)
             {
                 address = address.Concat(BitConverter.GetBytes(BitConverter.ToUInt32(attributeValue, 08) ^ BitConverter.ToUInt32(TransactionId, 0)))
                                  .Concat(BitConverter.GetBytes(BitConverter.ToUInt32(attributeValue, 12) ^ BitConverter.ToUInt32(TransactionId, 4)))

--- a/src/SIPSorcery/net/STUN/STUNMessage.cs
+++ b/src/SIPSorcery/net/STUN/STUNMessage.cs
@@ -101,7 +101,14 @@ namespace SIPSorcery.Net
 
                 if (stunMessage.Header.MessageLength > 0)
                 {
-                    stunMessage.Attributes = STUNAttribute.ParseMessageAttributes(buffer, STUNHeader.STUN_HEADER_LENGTH, bufferLength, stunMessage.Header);
+                    // The header claims there are attributes, so attempt to parse them. ParseMessageAttributes
+                    // returns null (rather than an empty list) when the buffer is too short or malformed to
+                    // contain any attributes. The "?? stunMessage.Attributes" guards against that null: the
+                    // Attributes field is initialised to an empty list when the STUNMessage is constructed, so
+                    // on a null result we fall back to that empty list rather than overwriting it with null.
+                    // This keeps Attributes non-null so the "stunMessage.Attributes.Count" access below (and
+                    // any caller that enumerates Attributes) cannot throw a NullReferenceException.
+                    stunMessage.Attributes = STUNAttribute.ParseMessageAttributes(buffer, STUNHeader.STUN_HEADER_LENGTH, bufferLength, stunMessage.Header) ?? stunMessage.Attributes;
                 }
 
                 if (stunMessage.Attributes.Count > 0 && stunMessage.Attributes.Last().AttributeType == STUNAttributeTypesEnum.FingerPrint)

--- a/test/unit/net/RTP/RTPChannelUnitTest.cs
+++ b/test/unit/net/RTP/RTPChannelUnitTest.cs
@@ -95,7 +95,8 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug("Attempting to send packet from {LocalEndPoint} to {RemoteEndPoint}.", channel1.RTPLocalEndPoint, channel2Dst);
 
-            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x02 }); // 0x00 & 0x01 are STUN packets.
+            // 12 byte packet (RTP minimum header length) starting 0x02 (0x00 & 0x01 are STUN packets).
+            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
 
             logger.LogDebug("Send result {SendResult}.", sendResult);
 
@@ -139,7 +140,8 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug("Attempting to send packet from {LocalEndPoint} to {RemoteEndPoint}.", channel1.RTPLocalEndPoint, channel2Dst);
 
-            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x02 }); // 0x00 & 0x01 are STUN packets.
+            // 12 byte packet (RTP minimum header length) starting 0x02 (0x00 & 0x01 are STUN packets).
+            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
 
             logger.LogDebug("Send result {SendResult}.", sendResult);
 
@@ -194,7 +196,8 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug("Attempting to send packet from {LocalEndPoint} to {RemoteEndPoint}.", channel1.RTPLocalEndPoint, channel2Dst);
 
-            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x02 }); // 0x00 & 0x01 are STUN packets.
+            // 12 byte packet (RTP minimum header length) starting 0x02 (0x00 & 0x01 are STUN packets).
+            var sendResult = channel1.Send(RTPChannelSocketsEnum.RTP, channel2Dst, new byte[] { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
 
             logger.LogDebug("Send result {SendResult}.", sendResult);
 
@@ -204,6 +207,59 @@ namespace SIPSorcery.Net.UnitTests
 
             channel1.Close("normal");
             channel2.Close("normal");
+
+            logger.LogDebug("Test complete.");
+        }
+
+        /// <summary>
+        /// Regression test for a remotely exploitable denial-of-service issue. A single malformed inbound
+        /// UDP packet (here a 1 byte packet) used to throw in the packet receive handler which the UDP
+        /// receive loop converted into a channel Close, terminating the media session. The receive loop
+        /// must now drop the offending packet and keep the channel open.
+        /// </summary>
+        [Fact]
+        public async Task RtpChannelMalformedPacketDoesNotCloseChannelUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            RTPChannel channel = new RTPChannel(false, IPAddress.Loopback);
+
+            string closedReason = null;
+            channel.OnClosed += reason => closedReason = reason;
+
+            channel.Start();
+
+            // Give the socket receive task time to fire up.
+            await Task.Delay(1000);
+
+            using (var attacker = new UdpClient())
+            {
+                // A 1 byte 0x00 packet. The old handler read packet[1] after only checking the packet was
+                // non-empty, throwing IndexOutOfRangeException which tore the channel down.
+                attacker.Send(new byte[] { 0x00 }, 1, new IPEndPoint(IPAddress.Loopback, channel.RTPPort));
+            }
+
+            // Allow time for the packet to be received and (previously) close the channel.
+            await Task.Delay(1000);
+
+            Assert.False(channel.IsClosed, $"The RTP channel was closed by a malformed packet. Reason: {closedReason ?? "(none)"}.");
+
+            // The channel must still be usable - confirm it can receive a subsequent valid RTP packet.
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            channel.OnRTPDataReceived += (lep, rep, pkt) => tcs.TrySetResult(true);
+
+            using (var sender = new UdpClient())
+            {
+                // A 12 byte packet (RTP minimum header length) starting 0x02 so it is not treated as STUN.
+                sender.Send(new byte[] { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, 12, new IPEndPoint(IPAddress.Loopback, channel.RTPPort));
+            }
+
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(TEST_TIMEOUT_SECONDS)));
+
+            channel.Close("normal");
+
+            Assert.True(completed == tcs.Task && await tcs.Task, "The RTP channel did not receive a valid packet after a malformed packet was dropped.");
 
             logger.LogDebug("Test complete.");
         }

--- a/test/unit/net/STUN/STUNUnitTest.cs
+++ b/test/unit/net/STUN/STUNUnitTest.cs
@@ -435,5 +435,92 @@ namespace SIPSorcery.Net.UnitTests
             Assert.True(stunRequest.isFingerprintValid);
             //Assert.True(stunRequest.CheckIntegrity(System.Text.Encoding.UTF8.GetBytes(icePassword)));
         }
+
+        /// <summary>
+        /// Regression test for a denial-of-service issue. A STUN message carrying an XOR address attribute
+        /// with a value shorter than the minimum required (0 to 7 bytes) used to throw while indexing the
+        /// untrusted value bytes (NullReferenceException for a zero-length value, IndexOutOfRange/
+        /// ArgumentOutOfRange for 1 to 7 bytes). Such an attribute must now be skipped rather than throw.
+        /// </summary>
+        [Theory]
+        [InlineData(0x0020)] // XOR-MAPPED-ADDRESS
+        [InlineData(0x0012)] // XOR-PEER-ADDRESS
+        [InlineData(0x0016)] // XOR-RELAYED-ADDRESS
+        public void ParseShortXorAddressAttributeDoesNotThrowUnitTest(int attributeType)
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            for (int valueLength = 0; valueLength <= 7; valueLength++)
+            {
+                byte[] stun = BuildStunWithAttribute((ushort)attributeType, valueLength);
+
+                var ex = Record.Exception(() =>
+                {
+                    var msg = STUNMessage.ParseSTUNMessage(stun, stun.Length);
+                    // The malformed attribute should have been skipped, not parsed.
+                    Assert.DoesNotContain(msg.Attributes, a => a.AttributeType == STUNAttributeTypes.GetSTUNAttributeTypeForId((ushort)attributeType));
+                });
+
+                Assert.Null(ex);
+            }
+        }
+
+        /// <summary>
+        /// Regression test for a denial-of-service issue. A truncated STUN message whose header declares a
+        /// non-zero length but whose body is too short for any attributes used to dereference a null
+        /// attribute list. ParseSTUNMessage must return a message with an empty attribute list instead.
+        /// </summary>
+        [Fact]
+        public void ParseTruncatedStunMessageDoesNotThrowUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            // Valid 20 byte header declaring a message length of 8 but with no attribute bytes following.
+            byte[] stun =
+            {
+                0x00, 0x01,             // Binding Request.
+                0x00, 0x08,             // Message length > 0.
+                0x21, 0x12, 0xA4, 0x42, // Magic cookie.
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 // Transaction id.
+            };
+
+            var ex = Record.Exception(() =>
+            {
+                var msg = STUNMessage.ParseSTUNMessage(stun, stun.Length);
+                Assert.NotNull(msg);
+                Assert.NotNull(msg.Attributes);
+                Assert.Empty(msg.Attributes);
+            });
+
+            Assert.Null(ex);
+        }
+
+        /// <summary>
+        /// Builds a STUN binding request containing a single attribute of the supplied type whose value is
+        /// <paramref name="valueLength"/> bytes long, with enough trailing bytes for the attribute parse
+        /// loop to enter.
+        /// </summary>
+        private static byte[] BuildStunWithAttribute(ushort attributeType, int valueLength)
+        {
+            byte[] header =
+            {
+                0x00, 0x01,             // Binding Request.
+                0x00, 0x10,             // Message length (just needs to be > 0).
+                0x21, 0x12, 0xA4, 0x42, // Magic cookie.
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 // Transaction id.
+            };
+
+            int padding = (valueLength % 4 != 0) ? 4 - (valueLength % 4) : 0;
+
+            byte[] attribute = new byte[4 + valueLength + padding + 4]; // attr header + value + padding + trailing bytes.
+            attribute[0] = (byte)(attributeType >> 8);
+            attribute[1] = (byte)(attributeType & 0xff);
+            attribute[2] = (byte)(valueLength >> 8);
+            attribute[3] = (byte)(valueLength & 0xff);
+
+            return header.Concat(attribute).ToArray();
+        }
     }
 }


### PR DESCRIPTION
The UdpReceiver behaviour has also been changed to NOT close when an exception occurs processing a single packet. This was a potential DoS vector.

Thanks to @Lougarou for the notification.