### PR TITLE
Refactor RTSP header appending to use StringBuilder

### DIFF
--- a/src/SIPSorcery/net/RTSP/RTSPHeader.cs
+++ b/src/SIPSorcery/net/RTSP/RTSPHeader.cs
@@ -503,7 +503,7 @@ namespace SIPSorcery.Net
                 var headersBuilder = new StringBuilder();
 
                 void AppendHeader<T>(string headerName, T headerValue) =>
-                    headersBuilder.Append($"{headerName}: {headerValue}{m_CRLF}");
+                    headersBuilder.Append(headerName).Append(": ").Append(headerValue).Append(m_CRLF);
 
                 if (CSeq > 0)
                 {


### PR DESCRIPTION
Replaced string interpolation with StringBuilder.Append for constructing RTSP headers, improving performance and following best practices for string concatenation in critical code paths.