### PR TITLE
Refactor PrintBuffer for efficiency and clarity

### DIFF
--- a/src/SIPSorcery/net/STUN/STUNAppState.cs
+++ b/src/SIPSorcery/net/STUN/STUNAppState.cs
@@ -1,4 +1,4 @@
-// ============================================================================
+﻿// ============================================================================
 // FileName: STUNLog.cs
 //
 // Description:
@@ -15,6 +15,8 @@
 // ============================================================================
 
 using System;
+using System.Globalization;
+using System.Text;
 
 namespace SIPSorcery.Net
 {
@@ -32,32 +34,41 @@ namespace SIPSorcery.Net
 
         public static string PrintBuffer(byte[] buffer)
         {
-            string bufferStr = null;
-
-            for (int index = 0; index < buffer.Length; index++)
+            if (buffer.Length == 0)
             {
-                string byteStr = buffer[index].ToString("X");
-
-                if (byteStr.Length == 1)
-                {
-                    bufferStr += $"0{byteStr}";
-                }
-                else
-                {
-                    bufferStr += byteStr;
-                }
-
-                if ((index + 1) % 4 == 0)
-                {
-                    bufferStr += "\n";
-                }
-                else
-                {
-                    bufferStr += " | ";
-                }
+                return null;
             }
 
-            return bufferStr;
+            var fullGroups = buffer.Length / 4;
+            var remainder = buffer.Length % 4;
+            var outputLength = (fullGroups * 18) + (remainder * 5);
+
+            return string.Create(
+                outputLength,
+                buffer,
+                static (output, bytes) =>
+                {
+                    const string UPPER_HEX_DIGITS = "0123456789ABCDEF";
+                    var outputIndex = 0;
+
+                    for (var index = 0; index < bytes.Length; index++)
+                    {
+                        var value = bytes[index];
+                        output[outputIndex++] = UPPER_HEX_DIGITS[value >> 4];
+                        output[outputIndex++] = UPPER_HEX_DIGITS[value & 0x0f];
+
+                        if ((index + 1) % 4 == 0)
+                        {
+                            output[outputIndex++] = '\n';
+                        }
+                        else
+                        {
+                            output[outputIndex++] = ' ';
+                            output[outputIndex++] = '|';
+                            output[outputIndex++] = ' ';
+                        }
+                    }
+                });
         }
     }
 }


### PR DESCRIPTION
Rewrote the PrintBuffer method to use string.Create for efficient buffer formatting, eliminated string concatenation in loops, and improved output grouping. Now handles empty buffers early and formats output in four-byte groups with clear separators. Uses a constant for hex digits and processes the buffer in a single pass for better performance and readability.