### PR TITLE
Refactor: replace most Regex usage with modern alternatives in tests …

### DIFF
--- a/examples/Softphone/Signalling/SIPClient.cs
+++ b/examples/Softphone/Signalling/SIPClient.cs
@@ -29,7 +29,7 @@ using SIPSorceryMedia.Windows;
 
 namespace SIPSorcery.SoftPhone
 {
-    public class SIPClient
+    public partial class SIPClient
     {
         private static string _sdpMimeContentType = SDP.SDP_MIME_CONTENTTYPE;
         private static int TRANSFER_RESPONSE_TIMEOUT_SECONDS = 10;
@@ -45,6 +45,9 @@ namespace SIPSorcery.SoftPhone
         private CancellationTokenSource _cts = new CancellationTokenSource();
 
         private int m_audioOutDeviceIndex = SIPSoftPhoneState.AudioOutDeviceIndex;
+
+        [GeneratedRegex(@"^SIP/2\.0 (?<statusCode>\d{3})")]
+        private static partial Regex SipFragStatusCodeRegex();
 
         public event Action<SIPClient> CallAnswer;                 // Fires when an outgoing SIP call is answered.
         public event Action<SIPClient> CallEnded;                  // Fires when an incoming or outgoing call is over.
@@ -382,7 +385,7 @@ namespace SIPSorcery.SoftPhone
             }
             else
             {
-                Match statusCodeMatch = Regex.Match(sipFrag, @"^SIP/2\.0 (?<statusCode>\d{3})");
+                var statusCodeMatch = SipFragStatusCodeRegex().Match(sipFrag);
                 if (statusCodeMatch.Success)
                 {
                     int statusCode = Int32.Parse(statusCodeMatch.Result("${statusCode}"));

--- a/examples/WebRTCExamples/WebRTCGetStartedDataChannel/Program.cs
+++ b/examples/WebRTCExamples/WebRTCGetStartedDataChannel/Program.cs
@@ -34,7 +34,7 @@ using WebSocketSharp.Server;
 
 namespace demo
 {
-    class Program
+    partial class Program
     {
         private const int WEBSOCKET_PORT = 8081;
         private const string STUN_URL = "stun:stun.sipsorcery.com";
@@ -46,6 +46,9 @@ namespace demo
 
         private static uint _loadTestPayloadSize = 0;
         private static int _loadTestCount = 0;
+
+        [GeneratedRegex(@"^\s*(?<sendSize>\d+)\s*x\s*(?<testCount>\d+)")]
+        private static partial Regex LoadTestCommandRegex();
 
         static void Main()
         {
@@ -114,7 +117,7 @@ namespace demo
                             var msg = Encoding.UTF8.GetString(data);
                             logger.LogInformation($"Data channel {datachan.label} message {type} received: {msg}.");
 
-                            var loadTestMatch = Regex.Match(msg, @"^\s*(?<sendSize>\d+)\s*x\s*(?<testCount>\d+)");
+                            var loadTestMatch = LoadTestCommandRegex().Match(msg);
 
                             if (loadTestMatch.Success)
                             {

--- a/examples/WebRTCExamples/WebRTCGetStartedDataChannel/WebRTCGetStartedDataChannel.csproj
+++ b/examples/WebRTCExamples/WebRTCGetStartedDataChannel/WebRTCGetStartedDataChannel.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/WebRTCScenarios/DataChannelStressTest/Program.cs
+++ b/examples/WebRTCScenarios/DataChannelStressTest/Program.cs
@@ -22,7 +22,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -207,7 +206,10 @@ namespace SIPSorcery.Demo
             if (proto == DataChannelPayloadProtocols.WebRTC_String)
             {
                 Console.WriteLine($"{dc.label}: return recv stream id {dc.id}, send# {Encoding.UTF8.GetString(data)}");
-                int pairID = int.Parse(Regex.Match(dc.label, @".*-(?<id>\d+)-.*").Result("${id}"));
+                if (!TryParsePairId(dc.label, out var pairID))
+                {
+                    throw new FormatException($"Unable to parse data channel label '{dc.label}'.");
+                }
                 connectionPairs.Single(x => x.ID == pairID).StreamSendConfirmed[dc.id.Value].Set();
             }
             else if (proto == DataChannelPayloadProtocols.WebRTC_Binary)
@@ -244,6 +246,32 @@ namespace SIPSorcery.Demo
             {
                 Marshal.FreeHGlobal(ptr);
             }
+        }
+
+        private static bool TryParsePairId(string label, out int pairID)
+        {
+            pairID = 0;
+
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                return false;
+            }
+
+            var labelSpan = label.AsSpan();
+            var firstSeparatorIndex = labelSpan.IndexOf('-');
+            if (firstSeparatorIndex == -1)
+            {
+                return false;
+            }
+
+            labelSpan = labelSpan[(firstSeparatorIndex + 1)..];
+            var secondSeparatorIndex = labelSpan.IndexOf('-');
+            if (secondSeparatorIndex == -1)
+            {
+                return false;
+            }
+
+            return int.TryParse(labelSpan[..secondSeparatorIndex], out pairID);
         }
 
         /// <summary>

--- a/examples/sipcmdline/Program.cs
+++ b/examples/sipcmdline/Program.cs
@@ -80,7 +80,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
@@ -365,7 +364,7 @@ namespace SIPSorcery
             SIPURI dstUri = null;
 
             // Don't attempt a SIP URI parse for serialised SIPEndPoints.
-            if (Regex.IsMatch(dst, "^(udp|tcp|tls|ws|wss)") == false && SIPURI.TryParse(dst, out var argUri))
+            if (!HasTransportPrefix(dst) && SIPURI.TryParse(dst, out var argUri))
             {
                 dstUri = argUri;
             }
@@ -376,6 +375,20 @@ namespace SIPSorcery
             }
 
             return dstUri;
+        }
+
+        private static bool HasTransportPrefix(string destination)
+        {
+            if (string.IsNullOrEmpty(destination))
+            {
+                return false;
+            }
+
+            return (destination.Length >= 3 && "udp".StartsWith(destination[..3], StringComparison.Ordinal)) ||
+                   (destination.Length >= 3 && "tcp".StartsWith(destination[..3], StringComparison.Ordinal)) ||
+                   (destination.Length >= 3 && "tls".StartsWith(destination[..3], StringComparison.Ordinal)) ||
+                   (destination.Length >= 2 && "ws".StartsWith(destination[..2], StringComparison.Ordinal)) ||
+                   (destination.Length >= 3 && "wss".StartsWith(destination[..3], StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/test/unit/core/SIP/SIPHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPHeaderUnitTest.cs
@@ -9,7 +9,6 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
 using Xunit;
@@ -210,7 +209,7 @@ namespace SIPSorcery.SIP.UnitTests
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", xtenInviteHeaders);
 
-            string[] headersCollection = Regex.Split(xtenInviteHeaders, "\r\n");
+            string[] headersCollection = xtenInviteHeaders.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
 
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
 
@@ -248,7 +247,7 @@ namespace SIPSorcery.SIP.UnitTests
                 $"Via: SIP/2.0/UDP 213.168.225.135:5060;branch=z9hG4bK8Z4EIWBeY45fRGwC0qIeu/xpw3A={m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5065;received=220.240.255.198:64091;branch=z9hG4bK4E0728C26A0640E7830D7C9179D08D67{m_CRLF}Record-Route: <sip:213.168.225.133:5060;lr>,<sip:220.240.255.198:64091;lr>{m_CRLF}From: bluesipd <sip:bluesipd@bluesipd:5065>;tag=457825353{m_CRLF}To: <sip:303@bluesipd>;tag=as02a64a42{m_CRLF}Call-ID: 8A702FA2-18F0-4DFC-AED5-C1A883EADB84@192.168.1.2{m_CRLF}CSeq: 38002 INVITE{m_CRLF}User-Agent: asterisk{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 350{m_CRLF}";
             logger.LogDebug("Original SIP Headers:\n{Headers}", xtenInviteHeaders);
 
-            string[] headersCollection = Regex.Split(xtenInviteHeaders, "\r\n");
+            string[] headersCollection = xtenInviteHeaders.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
 
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
 
@@ -303,7 +302,7 @@ namespace SIPSorcery.SIP.UnitTests
                 $"SIP/2.0 407 Proxy Authentication Required{m_CRLF}Via: SIP/2.0/UDP 192.168.1.2:5066;received=220.240.255.198:64066;branch=65cacee9-25b6-405c-8f82-e40427438af7{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>;tag=as67b6416e{m_CRLF}Contact: <sip:303@213.168.225.133>{m_CRLF}Call-ID: 5bcb927f-9571-47d0-a2a1-36226bcf7665@192.168.1.2{m_CRLF}CSeq: 908 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}User-Agent: asterisk{m_CRLF}Proxy-Authenticate: Digest realm=\"asterisk\", nonce=\"15aeff81\"{m_CRLF}Record-Route: <sip:213.168.225.135:5060;lr>{m_CRLF}Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY{m_CRLF}{m_CRLF}";
             logger.LogDebug("Original SIP Headers:\n{Headers}", authReqdHeaders);
 
-            string[] headersCollection = Regex.Split(authReqdHeaders, "\r\n");
+            string[] headersCollection = authReqdHeaders.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
 
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
 
@@ -323,7 +322,7 @@ namespace SIPSorcery.SIP.UnitTests
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", noViaHeaders);
 
-            string[] headersCollection = Regex.Split(noViaHeaders, "\r\n");
+            string[] headersCollection = noViaHeaders.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
 
             Assert.Throws<SIPValidationException>(() => SIPHeader.ParseSIPHeaders(headersCollection));
 
@@ -341,7 +340,7 @@ namespace SIPSorcery.SIP.UnitTests
 
             logger.LogDebug("Original SIP Headers:\n{Headers}", sipMsg);
 
-            string[] headersCollection = Regex.Split(sipMsg, "\r\n");
+            string[] headersCollection = sipMsg.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
 
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
 
@@ -368,7 +367,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("{SipHeader}", sipHeader.ToString());
             logger.LogDebug("{AuthenticationHeader}", sipHeader.AuthenticationHeaders[0].ToString());
 
-            Assert.True(Regex.Match(sipHeader.AuthenticationHeaders[0].ToString(), "nonce").Success, "The WWW-Authenticate header was not correctly parsed across multiple lines.");
+            Assert.True(sipHeader.AuthenticationHeaders[0].ToString().Contains("nonce"), "The WWW-Authenticate header was not correctly parsed across multiple lines.");
 
             logger.LogDebug("-----------------------------------------");
         }
@@ -849,7 +848,7 @@ namespace SIPSorcery.SIP.UnitTests
             string inviteHeaders =
                 $"Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}User-Agent: X-PRO release 1103v{m_CRLF}Content-Length: 271{m_CRLF}Require: abcd, 100rel, xyz{m_CRLF}Supported: 100rel, other{m_CRLF}";
 
-            string[] headersCollection = Regex.Split(inviteHeaders, "\r\n");
+            string[] headersCollection = inviteHeaders.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
 
             Assert.True(sipHeader.RequiredExtensions.Contains(SIPExtensions.Prack), "The required header extensions was missing Prack.");
@@ -910,7 +909,7 @@ namespace SIPSorcery.SIP.UnitTests
             string inviteWithServerHeader =
                 $"Via: SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001{m_CRLF}From: SER Test X <sip:aaronxten@sip.blueface.ie:5065>;tag=196468136{m_CRLF}To: <sip:303@sip.blueface.ie>{m_CRLF}Contact: <sip:aaronxten@192.168.1.2:5065>{m_CRLF}Call-ID: A3DF9A04-0EFE-47E4-98B1-E18AA186F3D6@192.168.1.2{m_CRLF}CSeq: 49429 INVITE{m_CRLF}Max-Forwards: 70{m_CRLF}Content-Type: application/sdp{m_CRLF}Content-Length: 271{m_CRLF}Server: {expectedServerValue}{m_CRLF}";
 
-            string[] headersCollection = Regex.Split(inviteWithServerHeader, "\r\n");
+            string[] headersCollection = inviteWithServerHeader.Split(new[] { m_CRLF }, System.StringSplitOptions.None);
             SIPHeader sipHeader = SIPHeader.ParseSIPHeaders(headersCollection);
             Assert.True(sipHeader.Server == expectedServerValue, "The Server value was not parsed properly");
 

--- a/test/unit/core/SIP/SIPParametersUnitTest.cs
+++ b/test/unit/core/SIP/SIPParametersUnitTest.cs
@@ -9,7 +9,6 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
 using Xunit;
@@ -180,7 +179,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Parameter 1={Parameter1}.", testParam1.ToString());
 
             Assert.True(testParam1.Has("emptykey"), "The empty parameter \"emptykey\" was not correctly extracted from the parameter string.");
-            Assert.True(Regex.Match(testParam1.ToString(), "emptykey").Success, "The emptykey name was not in the output parameter string.");
+            Assert.True(testParam1.ToString().Contains("emptykey"), "The emptykey name was not in the output parameter string.");
         }
 
         /// <summary>

--- a/test/unit/core/SIP/SIPResponseUnitTest.cs
+++ b/test/unit/core/SIP/SIPResponseUnitTest.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Ocsp;
 using SIPSorcery.Sys;
@@ -292,7 +291,7 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("{Resp}", resp.ToString());
 
             Assert.Equal(0, resp.Header.CSeq);
-            Assert.True(Regex.Match(resp.ToString(), "CSeq: 0 OPTIONS", RegexOptions.Multiline).Success);
+            Assert.Contains("CSeq: 0 OPTIONS", resp.ToString());
         }
 
         [Fact]

--- a/test/unit/core/SIP/SIPViaHeaderUnitTest.cs
+++ b/test/unit/core/SIP/SIPViaHeaderUnitTest.cs
@@ -9,7 +9,6 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
 using Xunit;
@@ -194,8 +193,8 @@ namespace SIPSorcery.SIP.UnitTests
             logger.LogDebug("Via Header={ViaHeader}.", sipViaHeaders[0].ToString());
 
             //Assert.True(Regex.Match(sipViaHeaders[0].ToString(), "rport").Success, "The Via header did not maintain the unknown rport parameter.");
-            Assert.True(Regex.Match(sipViaHeaders[0].ToString(), "unknown=12234").Success, "The Via header did not maintain the unrecognised unknown parameter.");
-            Assert.True(Regex.Match(sipViaHeaders[0].ToString(), "unknown2").Success, "The Via header did not maintain the unrecognised unknown2 parameter.");
+            Assert.True(sipViaHeaders[0].ToString().Contains("unknown=12234"), "The Via header did not maintain the unrecognised unknown parameter.");
+            Assert.True(sipViaHeaders[0].ToString().Contains("unknown2"), "The Via header did not maintain the unrecognised unknown2 parameter.");
 
             //Assert.True("SIP/2.0/UDP 192.168.1.2:5065;rport;branch=z9hG4bKFBB7EAC06934405182D13950BD51F001" == sipViaHeader.ToString(), "The Via header was not parsed correctly.");
 

--- a/test/unit/net/Helpers/SdpNormaliser.cs
+++ b/test/unit/net/Helpers/SdpNormaliser.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: SdpNormaliser.cs
 //
 // Description: Replaces the non-deterministic fields in a serialised SDP
@@ -44,62 +44,113 @@ namespace SIPSorcery.Net.UnitTests.Helpers
     /// Strips non-deterministic fields from a serialised SDP so the rest
     /// can be compared as a golden-master fixture. See file header.
     /// </summary>
-    public static class SdpNormaliser
+    public static partial class SdpNormaliser
     {
         // Capture the *positional* fields of an o= line; per RFC 4566:
         //   o=<username> <sess-id> <sess-version> <nettype> <addrtype> <unicast-address>
-        private static readonly Regex s_oLine = new Regex(
-            @"^o=(?<user>\S+)\s+\S+\s+\S+\s+(?<net>\S+)\s+(?<addr>\S+)\s+(?<host>\S+)$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string OLinePattern = @"^o=(?<user>\S+)\s+\S+\s+\S+\s+(?<net>\S+)\s+(?<addr>\S+)\s+(?<host>\S+)$";
 
-        private static readonly Regex s_mLine = new Regex(
-            @"^m=(?<kind>\S+)\s+(?<port>\d+)(?<rest>(\s+.*)?)$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string MLinePattern = @"^m=(?<kind>\S+)\s+(?<port>\d+)(?<rest>(\s+.*)?)$";
 
-        private static readonly Regex s_cLine = new Regex(
-            @"^c=(?<net>\S+)\s+(?<addr>\S+)\s+(?<host>\S+)$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string CLinePattern = @"^c=(?<net>\S+)\s+(?<addr>\S+)\s+(?<host>\S+)$";
 
-        private static readonly Regex s_iceUfrag = new Regex(
-            @"^a=ice-ufrag:\S+$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string IceUfragPattern = @"^a=ice-ufrag:\S+$";
 
-        private static readonly Regex s_icePwd = new Regex(
-            @"^a=ice-pwd:\S+$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string IcePwdPattern = @"^a=ice-pwd:\S+$";
 
-        private static readonly Regex s_fingerprint = new Regex(
-            @"^a=fingerprint:(?<alg>\S+)\s+\S+$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string FingerprintPattern = @"^a=fingerprint:(?<alg>\S+)\s+\S+$";
 
-        private static readonly Regex s_ssrc = new Regex(
-            @"^a=ssrc:\d+(?<rest>(\s+.*)?)$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string SsrcPattern = @"^a=ssrc:\d+(?<rest>(\s+.*)?)$";
 
-        private static readonly Regex s_ssrcGroup = new Regex(
-            @"^a=ssrc-group:(?<sem>\S+)(?<rest>(\s+\d+)+)$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string SsrcGroupPattern = @"^a=ssrc-group:(?<sem>\S+)(?<rest>(\s+\d+)+)$";
 
-        private static readonly Regex s_candidate = new Regex(
-            @"^a=candidate:.+$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string CandidatePattern = @"^a=candidate:.+$";
 
         // a=crypto:<tag> <suite> inline:<key>|<lifetime>|<mki>
-        private static readonly Regex s_cryptoInline = new Regex(
-            @"^(a=crypto:\S+\s+\S+\s+inline:)\S+",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string CryptoInlinePattern = @"^(a=crypto:\S+\s+\S+\s+inline:)\S+";
 
         // cname:<guid|hash> shows up inside a=ssrc lines and (rarely) on
         // its own a=cname: line. CNAMEs are randomised per-session per RFC
         // 3550 so always volatile.
-        private static readonly Regex s_cname = new Regex(
-            @"cname:\S+",
-            RegexOptions.Compiled);
+        private const string CNamePattern = @"cname:\S+";
 
         // a=msid:<stream-id> <track-id> — both ids are volatile.
-        private static readonly Regex s_msid = new Regex(
-            @"^a=msid:\S+(?<rest>(\s+\S+)*)$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+        private const string MsidPattern = @"^a=msid:\S+(?<rest>(\s+\S+)*)$";
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(OLinePattern, RegexOptions.Multiline)]
+        private static partial Regex OLineRegex();
+
+        [GeneratedRegex(MLinePattern, RegexOptions.Multiline)]
+        private static partial Regex MLineRegex();
+
+        [GeneratedRegex(CLinePattern, RegexOptions.Multiline)]
+        private static partial Regex CLineRegex();
+
+        [GeneratedRegex(IceUfragPattern, RegexOptions.Multiline)]
+        private static partial Regex IceUfragRegex();
+
+        [GeneratedRegex(IcePwdPattern, RegexOptions.Multiline)]
+        private static partial Regex IcePwdRegex();
+
+        [GeneratedRegex(FingerprintPattern, RegexOptions.Multiline)]
+        private static partial Regex FingerprintRegex();
+
+        [GeneratedRegex(SsrcPattern, RegexOptions.Multiline)]
+        private static partial Regex SsrcRegex();
+
+        [GeneratedRegex(SsrcGroupPattern, RegexOptions.Multiline)]
+        private static partial Regex SsrcGroupRegex();
+
+        [GeneratedRegex(CandidatePattern, RegexOptions.Multiline)]
+        private static partial Regex CandidateRegex();
+
+        [GeneratedRegex(CryptoInlinePattern, RegexOptions.Multiline)]
+        private static partial Regex CryptoInlineRegex();
+
+        [GeneratedRegex(CNamePattern)]
+        private static partial Regex CNameRegex();
+
+        [GeneratedRegex(MsidPattern, RegexOptions.Multiline)]
+        private static partial Regex MsidRegex();
+#else
+        private static readonly Regex s_oLine = new Regex(OLinePattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_mLine = new Regex(MLinePattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_cLine = new Regex(CLinePattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_iceUfrag = new Regex(IceUfragPattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_icePwd = new Regex(IcePwdPattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_fingerprint = new Regex(FingerprintPattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_ssrc = new Regex(SsrcPattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_ssrcGroup = new Regex(SsrcGroupPattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_candidate = new Regex(CandidatePattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_cryptoInline = new Regex(CryptoInlinePattern, RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_cname = new Regex(CNamePattern, RegexOptions.Compiled);
+        private static readonly Regex s_msid = new Regex(MsidPattern, RegexOptions.Multiline | RegexOptions.Compiled);
+
+        private static Regex OLineRegex() => s_oLine;
+
+        private static Regex MLineRegex() => s_mLine;
+
+        private static Regex CLineRegex() => s_cLine;
+
+        private static Regex IceUfragRegex() => s_iceUfrag;
+
+        private static Regex IcePwdRegex() => s_icePwd;
+
+        private static Regex FingerprintRegex() => s_fingerprint;
+
+        private static Regex SsrcRegex() => s_ssrc;
+
+        private static Regex SsrcGroupRegex() => s_ssrcGroup;
+
+        private static Regex CandidateRegex() => s_candidate;
+
+        private static Regex CryptoInlineRegex() => s_cryptoInline;
+
+        private static Regex CNameRegex() => s_cname;
+
+        private static Regex MsidRegex() => s_msid;
+#endif
 
         /// <summary>
         /// Returns a normalised copy of the SDP with the volatile fields
@@ -113,36 +164,36 @@ namespace SIPSorcery.Net.UnitTests.Helpers
             // anchored so they don't bleed across lines.
             string s = sdp.Replace("\r\n", "\n");
 
-            s = s_oLine.Replace(s, m =>
+            s = OLineRegex().Replace(s, m =>
                 $"o={m.Groups["user"].Value} <SID> <SVER> {m.Groups["net"].Value} {m.Groups["addr"].Value} {m.Groups["host"].Value}");
 
-            s = s_mLine.Replace(s, m =>
+            s = MLineRegex().Replace(s, m =>
                 $"m={m.Groups["kind"].Value} <PORT>{m.Groups["rest"].Value}");
 
-            s = s_cLine.Replace(s, m =>
+            s = CLineRegex().Replace(s, m =>
                 $"c={m.Groups["net"].Value} {m.Groups["addr"].Value} <IP>");
 
-            s = s_iceUfrag.Replace(s, "a=ice-ufrag:<UFRAG>");
-            s = s_icePwd.Replace(s, "a=ice-pwd:<PWD>");
+            s = IceUfragRegex().Replace(s, "a=ice-ufrag:<UFRAG>");
+            s = IcePwdRegex().Replace(s, "a=ice-pwd:<PWD>");
 
-            s = s_fingerprint.Replace(s, m =>
+            s = FingerprintRegex().Replace(s, m =>
                 $"a=fingerprint:{m.Groups["alg"].Value} <HASH>");
 
-            s = s_ssrc.Replace(s, m =>
+            s = SsrcRegex().Replace(s, m =>
                 $"a=ssrc:<SSRC>{m.Groups["rest"].Value}");
 
-            s = s_ssrcGroup.Replace(s, m =>
+            s = SsrcGroupRegex().Replace(s, m =>
                 $"a=ssrc-group:{m.Groups["sem"].Value} <SSRC>");
 
-            s = s_candidate.Replace(s, "a=candidate:<CANDIDATE>");
+            s = CandidateRegex().Replace(s, "a=candidate:<CANDIDATE>");
 
-            s = s_cryptoInline.Replace(s, "$1<CRYPTO_KEY>");
+            s = CryptoInlineRegex().Replace(s, "$1<CRYPTO_KEY>");
 
-            s = s_cname.Replace(s, "cname:<CNAME>");
+            s = CNameRegex().Replace(s, "cname:<CNAME>");
 
             // msid keeps the structure (one or two tokens) but replaces
             // the random ids with stable labels so two runs match.
-            s = s_msid.Replace(s, m =>
+            s = MsidRegex().Replace(s, m =>
             {
                 // If the line has a track id (two tokens), keep both as placeholders.
                 if (!string.IsNullOrEmpty(m.Groups["rest"].Value))


### PR DESCRIPTION
…and examples

Replaced Regex.Match/Split with string ops or [GeneratedRegex] partials for performance and clarity. Updated SdpNormaliser to use pattern constants and partials. Refactored unit tests to use string.Split/Contains. Added helper methods for parsing. Set LangVersion to 14.0 for [GeneratedRegex] support. Modernizes codebase and improves .NET compatibility.