### PR TITLE
Update SIP TLS handshake failure logging to structured format

### DIFF
--- a/src/SIPSorcery/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPTLSChannel.cs
@@ -122,7 +122,7 @@ namespace SIPSorcery.SIP
 
                     if (resultTask.IsFaulted)
                     {
-                        logger.LogWarning($"SIP TLS Channel failed to connect to remote host. The authentication handshake failed. Error: {resultTask.Exception?.Message} {resultTask.Exception?.InnerException?.Message} {resultTask.Exception?.StackTrace}");
+                        logger.LogWarning(resultTask.Exception, "SIP TLS Channel failed to connect to remote host. The authentication handshake failed.");
                         sslStream.Close();
                         return;
                     }


### PR DESCRIPTION
Replaced interpolated string logging with structured logging for TLS authentication handshake failures, passing the exception directly to improve log clarity and consistency.