### PR TITLE
Replace unnecessary string interpolation in log messages in STUN

### DIFF
--- a/src/SIPSorcery/net/STUN/STUNClientExtensions.cs
+++ b/src/SIPSorcery/net/STUN/STUNClientExtensions.cs
@@ -49,7 +49,7 @@ public static class STUNClientExtensions
 
         if (iceServer == null)
         {
-            logger?.LogWarning($"The STUN client was unable to resolve a server to use.");
+            logger?.LogWarning("The STUN client was unable to resolve a server to use.");
 
             return mediaStream;
         }
@@ -67,7 +67,7 @@ public static class STUNClientExtensions
             }
             else
             {
-                logger?.LogWarning($"STUN client failed to get server reflexive RTP end point.");
+                logger?.LogWarning("STUN client failed to get server reflexive RTP end point.");
             }
         }
 


### PR DESCRIPTION
Replaced interpolated strings with plain literals in two warning log statements in STUNClientExtensions, as no variables were being inserted. This simplifies the logging code.