### PR TITLE
Make loggers static in WebRTC signaling classes

### DIFF
--- a/src/SIPSorcery/net/WebRTC/WebRTCRestSignalingPeer.cs
+++ b/src/SIPSorcery/net/WebRTC/WebRTCRestSignalingPeer.cs
@@ -44,7 +44,7 @@ namespace SIPSorcery.Net
         private const int REST_SERVER_POLL_PERIOD = 2000;   // Period in milliseconds to poll the HTTP server to check for new messages.
         private const int CONNECTION_RETRY_PERIOD = 5000;   // Period in milliseconds to retry if the initial HTTP connection attempt fails.
 
-        private readonly ILogger logger = LogFactory.CreateLogger<WebRTCRestSignalingPeer>();
+        private static readonly ILogger logger = LogFactory.CreateLogger<WebRTCRestSignalingPeer>();
 
         private Uri _restServerUri;
         private string _ourID;

--- a/src/SIPSorcery/net/WebRTC/WebRTCWebSocketClient.cs
+++ b/src/SIPSorcery/net/WebRTC/WebRTCWebSocketClient.cs
@@ -37,7 +37,7 @@ namespace SIPSorcery.Net
         private const int MAX_SEND_BUFFER = 8192;
         private const int WEB_SOCKET_CONNECTION_TIMEOUT_MS = 10000;
 
-        private readonly ILogger logger = LogFactory.CreateLogger<WebRTCWebSocketClient>();
+        private static readonly ILogger logger = LogFactory.CreateLogger<WebRTCWebSocketClient>();
 
         private Uri _webSocketServerUri;
         private Func<Task<RTCPeerConnection>> _createPeerConnection;

--- a/src/SIPSorcery/net/WebRTC/WebRTCWebSocketPeer.cs
+++ b/src/SIPSorcery/net/WebRTC/WebRTCWebSocketPeer.cs
@@ -30,7 +30,7 @@ namespace SIPSorcery.Net
     /// </summary>
     public class WebRTCWebSocketPeer : WebSocketBehavior
     {
-        private readonly ILogger logger = LogFactory.CreateLogger<WebRTCWebSocketPeer>();
+        private static readonly ILogger logger = LogFactory.CreateLogger<WebRTCWebSocketPeer>();
 
         private RTCPeerConnection _pc;
         public RTCPeerConnection RTCPeerConnection => _pc;

--- a/src/SIPSorcery/net/WebRTC/WebRTCWebSocketPeerAspNet.cs
+++ b/src/SIPSorcery/net/WebRTC/WebRTCWebSocketPeerAspNet.cs
@@ -31,7 +31,7 @@ namespace SIPSorcery.Net;
 /// </summary>
 public class WebRTCWebSocketPeerAspNet
 {
-    private readonly ILogger _logger = LogFactory.CreateLogger<WebRTCWebSocketPeerAspNet>();
+    private static readonly ILogger _logger = LogFactory.CreateLogger<WebRTCWebSocketPeerAspNet>();
 
     private RTCConfiguration _peerConnectionConfig;
     private RTCPeerConnection _pc;


### PR DESCRIPTION
Updated logger fields to static readonly in WebRTCRestSignalingPeer, WebRTCWebSocketClient, WebRTCWebSocketPeer, and WebRTCWebSocketPeerAspNet to share loggers across all instances of each class. This improves efficiency and consistency in logging.