### PR TITLE
Refactor logging to use structured logging for FFmpeg media

### DIFF
--- a/src/SIPSorceryMedia.FFmpeg/FFmpegAudioDecoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegAudioDecoder.cs
@@ -10,7 +10,7 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegAudioDecoder : IDisposable
     {
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegAudioDecoder>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegAudioDecoder>();
 
         unsafe private AVInputFormat* _inputFormat = null;
 
@@ -94,8 +94,11 @@ namespace SIPSorceryMedia.FFmpeg
                     return false;
                 }
 
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug("FFmpeg file source decoder {CodecName} audio codec for stream {AudioStreamIndex}.", ffmpeg.avcodec_get_name(audCodec->id), _audioStreamIndex);
+                }
 
-                logger.LogDebug($"FFmpeg file source decoder {ffmpeg.avcodec_get_name(audCodec->id)} audio codec for stream {_audioStreamIndex}.");
                 _audDecCtx = ffmpeg.avcodec_alloc_context3(audCodec);
                 if (_audDecCtx == null)
                 {
@@ -315,7 +318,7 @@ namespace SIPSorceryMedia.FFmpeg
                 }
                 else
                 {
-                    logger.LogDebug($"FFmpeg end of file for source {_sourceUrl}.");
+                    logger.LogDebug("FFmpeg end of file for source {SourceUrl}.", _sourceUrl);
 
                     if (!_isClosed && _repeat)
                     {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegAudioSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegAudioSource.cs
@@ -71,7 +71,7 @@ namespace SIPSorceryMedia.FFmpeg
 
         private void AudioDecoder_OnError(string errorMessage)
         {
-            logger.LogDebug($"Audio - Source error for {path} - ErrorMessage:[{errorMessage}]");
+            logger.LogDebug("Audio - Source error for {Path} - ErrorMessage:[{ErrorMessage}]", path, errorMessage);
             OnAudioSourceError?.Invoke(errorMessage);
             Dispose();
         }
@@ -92,7 +92,10 @@ namespace SIPSorceryMedia.FFmpeg
 
         public void SetAudioSourceFormat(AudioFormat audioFormat)
         {
-            logger.LogDebug($"Setting audio source format to {audioFormat.FormatID}:{audioFormat.Codec} {audioFormat.ClockRate}.");
+            logger.LogDebug("Setting audio source format to {FormatId}:{Codec} {ClockRate}.",
+                audioFormat.FormatID,
+                audioFormat.Codec,
+                audioFormat.ClockRate);
             _audioFormatManager.SetSelectedFormat(audioFormat);
             InitialiseDecoder();
         }

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegFileSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegFileSource.cs
@@ -105,7 +105,10 @@ namespace SIPSorceryMedia.FFmpeg
         {
             if (_FFmpegAudioSource != null)
             {
-                logger.LogDebug($"Setting audio source format to {audioFormat.FormatID}:{audioFormat.Codec} {audioFormat.ClockRate}.");
+                logger.LogDebug("Setting audio source format to {FormatId}:{Codec} {ClockRate}.",
+                    audioFormat.FormatID,
+                    audioFormat.Codec,
+                    audioFormat.ClockRate);
                 _FFmpegAudioSource.SetAudioSourceFormat(audioFormat);
             }
         }
@@ -161,7 +164,10 @@ namespace SIPSorceryMedia.FFmpeg
         {
             if (_FFmpegVideoSource != null)
             {
-                logger.LogDebug($"Setting video source format to {videoFormat.FormatID}:{videoFormat.Codec} {videoFormat.ClockRate}.");
+                logger.LogDebug("Setting video source format to {FormatId}:{Codec} {ClockRate}.",
+                    videoFormat.FormatID,
+                    videoFormat.Codec,
+                    videoFormat.ClockRate);
                 _FFmpegVideoSource.SetVideoSourceFormat(videoFormat);
             }
         }

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoDecoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoDecoder.cs
@@ -9,7 +9,7 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegVideoDecoder : IDisposable
     {
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoDecoder>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoDecoder>();
 
         unsafe private AVInputFormat* _inputFormat = null;
 
@@ -82,8 +82,10 @@ namespace SIPSorceryMedia.FFmpeg
                 {
                     foreach (String key in decoderOptions.Keys)
                     {
-                        if(ffmpeg.av_dict_set(&options, key, decoderOptions[key], 0) < 0)
-                            logger.LogWarning($"Cannot set option [{key}]=[{decoderOptions[key]}]");
+                        if (ffmpeg.av_dict_set(&options, key, decoderOptions[key], 0) < 0)
+                        {
+                            logger.LogWarning("Cannot set option [{OptionKey}]=[{OptionValue}]", key, decoderOptions[key]);
+                        }
                     }
                 }
 
@@ -114,7 +116,15 @@ namespace SIPSorceryMedia.FFmpeg
                     return false;
                 }
 
-                logger.LogDebug($"FFmpeg file source decoder [{ffmpeg.avcodec_get_name(vidCodec->id)}] video codec for stream [{_videoStreamIndex}] - url:[{_sourceUrl}].");
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    string codecName = ffmpeg.avcodec_get_name(vidCodec->id);
+                    logger.LogDebug("FFmpeg file source decoder [{CodecName}] video codec for stream [{VideoStreamIndex}] - url:[{SourceUrl}].",
+                        codecName,
+                        _videoStreamIndex,
+                        _sourceUrl);
+                }
+
                 _vidDecCtx = ffmpeg.avcodec_alloc_context3(vidCodec);
                 if (_vidDecCtx == null)
                 {
@@ -305,7 +315,7 @@ namespace SIPSorceryMedia.FFmpeg
                     }
                     else
                     {
-                        logger.LogDebug($"FFmpeg end of file for source {_sourceUrl}.");
+                        logger.LogDebug("FFmpeg end of file for source {SourceUrl}.", _sourceUrl);
 
                         if (!_isClosed && _repeat)
                         {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -55,7 +55,7 @@ namespace SIPSorceryMedia.FFmpeg
         private int _pts = 0;
         private bool _isDisposed;
 
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoEncoder>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoEncoder>();
 
         public FFmpegVideoEncoder(Dictionary<string, string>? encoderOptions = null, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
         {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEndPoint.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEndPoint.cs
@@ -10,7 +10,7 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegVideoEndPoint : IVideoSink, IDisposable
     {
-        public ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoEndPoint>();
+        public static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoEndPoint>();
 
         public static readonly List<VideoFormat> _supportedFormats = Helper.GetSupportedVideoFormats();
 
@@ -118,7 +118,7 @@ namespace SIPSorceryMedia.FFmpeg
 
                     if (imageRawSamples == null || width == 0 || height == 0)
                     {
-                        logger.LogWarning($"Decode of video sample failed, width {width}, height {height}.");
+                        logger.LogWarning("Decode of video sample failed, width {Width}, height {Height}.", width, height);
                     }
                     else
                     {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoSource.cs
@@ -66,7 +66,7 @@ namespace SIPSorceryMedia.FFmpeg
 
         internal void VideoDecoder_OnError(string errorMessage)
         {
-            logger.LogDebug($"Video - Source error for {path} - ErrorMessage:[{errorMessage}]");
+            logger.LogDebug("Video - Source error for {Path} - ErrorMessage:[{ErrorMessage}]", path, errorMessage);
             OnVideoSourceError?.Invoke(errorMessage);
             Dispose();
         }
@@ -85,7 +85,11 @@ namespace SIPSorceryMedia.FFmpeg
 
         public void SetVideoSourceFormat(VideoFormat videoFormat)
         {
-            logger.LogDebug($"Setting video source format to {videoFormat.FormatID}:{videoFormat.Codec} {videoFormat.ClockRate}.");
+            logger.LogDebug("Setting video source format to {FormatId}:{Codec} {ClockRate}.",
+                videoFormat.FormatID,
+                videoFormat.Codec,
+                videoFormat.ClockRate);
+
             _videoFormatManager.SetSelectedFormat(videoFormat);
             InitialiseDecoder();
         }

--- a/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
@@ -83,7 +83,11 @@ namespace SIPSorceryMedia.FFmpeg
 
             RegisterFFmpegBinaries(libPath);
 
-            logger.LogInformation("FFmpeg version info: {VersionInfo}", ffmpeg.av_version_info());
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                string versionInfo = ffmpeg.av_version_info();
+                logger.LogInformation("FFmpeg version info: {VersionInfo}", versionInfo);
+            }
 
             if (logLevel.HasValue)
             {


### PR DESCRIPTION
Refactored all FFmpeg-related classes to use structured logging with named placeholders instead of string interpolation or formatting. Added logger.IsEnabled checks where appropriate to optimize performance. Changed logger fields to static for single-instance usage per class. Updated log messages to follow user preferences for structured logging. In FfmpegInit.cs, guarded FFmpeg version info logging with a log level check and used a local variable for the version string.