### PR TITLE
Refactor logging to use structured logging patterns for Windows media

### DIFF
--- a/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
+++ b/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
@@ -46,7 +46,7 @@ namespace SIPSorceryMedia.Windows
 
         public readonly static AudioSamplingRatesEnum DefaultAudioPlaybackRate = AudioSamplingRatesEnum.Rate8KHz;
 
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<WindowsAudioEndPoint>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<WindowsAudioEndPoint>();
 
         private WaveFormat _waveSinkFormat;
         private WaveFormat _waveSourceFormat;
@@ -170,7 +170,9 @@ namespace SIPSorceryMedia.Windows
                 if (_waveSourceFormat.SampleRate != _audioFormatManager.SelectedFormat.ClockRate)
                 {
                     // Reinitialise the audio capture device.
-                    logger.LogDebug($"Windows audio end point adjusting capture rate from {_waveSourceFormat.SampleRate} to {_audioFormatManager.SelectedFormat.ClockRate}.");
+                    logger.LogDebug("Windows audio end point adjusting capture rate from {CurrentCaptureRate} to {SelectedCaptureRate}.",
+                        _waveSourceFormat.SampleRate,
+                        _audioFormatManager.SelectedFormat.ClockRate);
 
                     InitCaptureDevice(_audioInDeviceIndex, _audioFormatManager.SelectedFormat.ClockRate, _audioFormatManager.SelectedFormat.ChannelCount);
                 }
@@ -186,7 +188,9 @@ namespace SIPSorceryMedia.Windows
                 if (_waveSinkFormat.SampleRate != _audioFormatManager.SelectedFormat.ClockRate)
                 {
                     // Reinitialise the audio output device.
-                    logger.LogDebug($"Windows audio end point adjusting playback rate from {_waveSinkFormat.SampleRate} to {_audioFormatManager.SelectedFormat.ClockRate}.");
+                    logger.LogDebug("Windows audio end point adjusting playback rate from {CurrentPlaybackRate} to {SelectedPlaybackRate}.",
+                        _waveSinkFormat.SampleRate,
+                        _audioFormatManager.SelectedFormat.ClockRate);
 
                     InitPlaybackDevice(_audioOutDeviceIndex, _audioFormatManager.SelectedFormat.ClockRate, _audioFormatManager.SelectedFormat.ChannelCount);
                 }
@@ -322,7 +326,9 @@ namespace SIPSorceryMedia.Windows
                 }
                 else
                 {
-                    logger.LogWarning($"The requested audio input device index {audioInDeviceIndex} exceeds the maximum index of {WaveInEvent.DeviceCount - 1}.");
+                    logger.LogWarning("The requested audio input device index {AudioInputDeviceIndex} exceeds the maximum index of {MaximumDeviceIndex}.",
+                        audioInDeviceIndex,
+                        WaveInEvent.DeviceCount - 1);
                     OnAudioSourceError?.Invoke($"The requested audio input device index {audioInDeviceIndex} exceeds the maximum index of {WaveInEvent.DeviceCount - 1}.");
                 }
             }

--- a/src/SIPSorceryMedia.Windows/WindowsVideoEndPoint.cs
+++ b/src/SIPSorceryMedia.Windows/WindowsVideoEndPoint.cs
@@ -449,15 +449,21 @@ namespace SIPSorceryMedia.Windows
                 MediaCapture mediaCapture = new MediaCapture();
                 await mediaCapture.InitializeAsync(mediaCaptureSettings);
 
-                foreach (var srcFmtList in mediaCapture.FrameSources.Values.Select(x => x.SupportedFormats).Select(y => y.ToList()))
+                if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    foreach (var srcFmt in srcFmtList)
+                    foreach (var srcFmtList in mediaCapture.FrameSources.Values)
                     {
-                        var vidFmt = srcFmt.VideoFormat;
-                        float vidFps = vidFmt.MediaFrameFormat.FrameRate.Numerator / vidFmt.MediaFrameFormat.FrameRate.Denominator;
-                        string pixFmt = vidFmt.MediaFrameFormat.Subtype == MF_I420_PIXEL_FORMAT ? "I420" : vidFmt.MediaFrameFormat.Subtype;
-                        logger.LogDebug("Video Capture device {VideoDeviceName} format {Width}x{Height} {Fps:0.##}fps {PixelFormat}",
-                            vidCapDevice.Name, vidFmt.Width, vidFmt.Height, vidFps, pixFmt);
+                        foreach (var srcFmt in srcFmtList.SupportedFormats)
+                        {
+                            var vidFps = srcFmt.VideoFormat.MediaFrameFormat.FrameRate.Numerator / srcFmt.VideoFormat.MediaFrameFormat.FrameRate.Denominator;
+                            var pixFmt = srcFmt.VideoFormat.MediaFrameFormat.Subtype == MF_I420_PIXEL_FORMAT ? "I420" : srcFmt.VideoFormat.MediaFrameFormat.Subtype;
+                            logger.LogDebug("Video Capture device {VideoDeviceName} format {Width}x{Height} {FrameRate:0.##}fps {PixelFormat}",
+                                vidCapDevice.Name,
+                                srcFmt.VideoFormat.Width,
+                                srcFmt.VideoFormat.Height,
+                                vidFps,
+                                pixFmt);
+                        }
                     }
                 }
             }
@@ -678,17 +684,21 @@ namespace SIPSorceryMedia.Windows
         /// </summary>
         private void PrintFrameSourceInfo(MediaFrameSource frameSource)
         {
-            var width = frameSource.CurrentFormat.VideoFormat.Width;
-            var height = frameSource.CurrentFormat.VideoFormat.Height;
-            var fpsNumerator = frameSource.CurrentFormat.FrameRate.Numerator;
-            var fpsDenominator = frameSource.CurrentFormat.FrameRate.Denominator;
+            if (!logger.IsEnabled(LogLevel.Information))
+            {
+                return;
+            }
 
-            double fps = fpsNumerator / fpsDenominator;
-            string pixFmt = frameSource.CurrentFormat.Subtype;
-            string deviceName = frameSource.Info.DeviceInformation.Name;
+            var currentFormat = frameSource.CurrentFormat;
+            var videoFormat = currentFormat.VideoFormat;
+            var frameRate = currentFormat.FrameRate;
 
             logger.LogInformation("Video capture device {VideoDeviceName} successfully initialised: {Width}x{Height} {Fps:0.##}fps pixel format {PixelFormat}.",
-                deviceName, width, height, fps, pixFmt);
+                frameSource.Info.DeviceInformation.Name,
+                videoFormat.Width,
+                videoFormat.Height,
+                frameRate.Numerator / frameRate.Denominator,
+                currentFormat.Subtype);
         }
 
         public void Dispose()


### PR DESCRIPTION
Update all logging statements to use structured logging with named placeholders and argument lists. Add logger.IsEnabled checks to guard value processing. Change logger in WindowsAudioEndPoint to static. Refactor video format logging in WindowsVideoEndPoint to only run when debug logging is enabled and use structured logging.