### PR TITLE
Make loggers static in VP8Codec and Vp8NetVideoEncoderEndPoint

### DIFF
--- a/src/SIPSorcery.VP8/VP8Codec.cs
+++ b/src/SIPSorcery.VP8/VP8Codec.cs
@@ -23,7 +23,7 @@ namespace Vpx.Net
 {
     public class VP8Codec : IVideoEncoder, IDisposable
     {
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<VP8Codec>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<VP8Codec>();
 
         private static readonly List<VideoFormat> _supportedFormats = new List<VideoFormat>
         {

--- a/src/SIPSorcery.VP8/Vp8NetVideoEncoderEndPoint.cs
+++ b/src/SIPSorcery.VP8/Vp8NetVideoEncoderEndPoint.cs
@@ -28,7 +28,7 @@ namespace Vpx.Net
         private const int DEFAULT_FRAMES_PER_SECOND = 30;
         private const int VP8_FORMAT_ID = 96;
 
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<Vp8NetVideoEncoderEndPoint>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<Vp8NetVideoEncoderEndPoint>();
 
         public static readonly List<VideoFormat> SupportedFormats = new List<VideoFormat>
         {


### PR DESCRIPTION
Changed logger fields from instance to static in both VP8Codec and Vp8NetVideoEncoderEndPoint classes to share a single logger across all instances. No other logic was modified.