### PR TITLE
Refactor logger fields to static/readonly for safety for tests and examples

### DIFF
--- a/examples/Softphone/Signalling/SIPTransportManager.cs
+++ b/examples/Softphone/Signalling/SIPTransportManager.cs
@@ -34,7 +34,7 @@ namespace SIPSorcery.SoftPhone
         private static string HOMER_SERVER_ADDRESS = null; //"192.168.11.49";
         private static int HOMER_SERVER_PORT = 9060;
 
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<SIPTransportManager>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<SIPTransportManager>();
 
         private XmlNode m_sipSocketsNode = SIPSoftPhoneState.SIPSocketsNode;    // Optional XML node that can be used to configure the SIP channels used with the SIP transport layer.
 

--- a/examples/Softphone/Signalling/STUNClient.cs
+++ b/examples/Softphone/Signalling/STUNClient.cs
@@ -24,7 +24,7 @@ namespace SIPSorcery.SoftPhone
 {
     public class SoftphoneSTUNClient
     {
-        private ILogger logger = SIPSorcery.LogFactory.CreateLogger<SoftphoneSTUNClient>();
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<SoftphoneSTUNClient>();
 
         private Timer updateTimer;
 

--- a/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/WebSocketSignalingServer.cs
+++ b/examples/WebRTCExamples/RtspToWebRTCAudioAndVideo/WebSocketSignalingServer.cs
@@ -15,7 +15,7 @@ namespace RtspToWebRtcRestreamer
 {
     internal class WebSocketSignalingServer : IDisposable
     {
-        private ILogger<WebSocketSignalingServer> _logger;
+        private static readonly ILogger<WebSocketSignalingServer> _logger;
         private int _port;
         private WebSocketServer _ws;
         private FFmpegListener _ffmpegListener;

--- a/examples/WebRTCLightningExamples/WebRTCLightningGetStarted/Services/LightningClientFactory.cs
+++ b/examples/WebRTCLightningExamples/WebRTCLightningGetStarted/Services/LightningClientFactory.cs
@@ -39,7 +39,7 @@ public interface ILightningClientFactory
 
 public class LightningClientFactory : ILightningClientFactory
 {
-    private ILogger _logger;
+    private readonly ILogger _logger;
     private IConfiguration _config;
 
     private readonly string _lndUrl;

--- a/examples/WebRTCLightningExamples/WebRTCLightningGetStarted/Services/LightningService.cs
+++ b/examples/WebRTCLightningExamples/WebRTCLightningGetStarted/Services/LightningService.cs
@@ -42,7 +42,7 @@ public interface ILightningService
 
 public class LightningService : ILightningService
 {
-    private ILogger _logger;
+    private readonly ILogger _logger;
 
     private readonly ILightningClientFactory _lightningClientFactory;
 

--- a/test/integration/net/ICE/MockTurnServer.cs
+++ b/test/integration/net/ICE/MockTurnServer.cs
@@ -25,7 +25,7 @@ namespace SIPSorcery.Net.IntegrationTests
 {
     public class MockTurnServer : IDisposable
     {
-        private readonly ILogger logger = LogFactory.CreateLogger<MockTurnServer>();
+        private static readonly ILogger logger = LogFactory.CreateLogger<MockTurnServer>();
 
         private int _listenPort = STUNConstants.DEFAULT_STUN_PORT;
         private IPAddress _listenAddress = IPAddress.Loopback;

--- a/test/unit/net/RTP/ReorderBufferUnitTest.cs
+++ b/test/unit/net/RTP/ReorderBufferUnitTest.cs
@@ -13,7 +13,7 @@ namespace SIPSorcery.UnitTests.Net
     [Trait("Category", "unit")]
     public class ReorderBufferUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public ReorderBufferUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpAssociationUnitTest.cs
+++ b/test/unit/net/SCTP/SctpAssociationUnitTest.cs
@@ -27,7 +27,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpAssociationUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpAssociationUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpChunkUnitTest.cs
+++ b/test/unit/net/SCTP/SctpChunkUnitTest.cs
@@ -23,7 +23,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpChunkUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpChunkUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpDataReceiverUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataReceiverUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: SctpDataReceiverUnitTest.cs
 //
 // Description: Unit tests for the SctpDataReceiver class.
@@ -22,7 +22,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpDataReceiverUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpDataReceiverUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
@@ -27,7 +27,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpDataSendRecvUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpDataSendRecvUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: SctpDataSenderUnitTest.cs
 //
 // Description: Unit tests for the SctpDataSender class.
@@ -27,7 +27,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpDataSenderUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpDataSenderUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpHeaderUnitTest.cs
+++ b/test/unit/net/SCTP/SctpHeaderUnitTest.cs
@@ -21,7 +21,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpHeaderUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpHeaderUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpPacketUnitTest.cs
+++ b/test/unit/net/SCTP/SctpPacketUnitTest.cs
@@ -23,7 +23,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpPacketUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpPacketUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/SCTP/SctpTransportUnitTest.cs
+++ b/test/unit/net/SCTP/SctpTransportUnitTest.cs
@@ -25,7 +25,7 @@ namespace SIPSorcery.Net.UnitTests
 {
     public class SctpTransportUnitTest
     {
-        private ILogger logger = null;
+        private readonly ILogger logger;
 
         public SctpTransportUnitTest(Xunit.Abstractions.ITestOutputHelper output)
         {

--- a/test/unit/net/TURN/TurnServerUnitTest.cs
+++ b/test/unit/net/TURN/TurnServerUnitTest.cs
@@ -29,7 +29,7 @@ namespace SIPSorcery.Net.UnitTests
     [Trait("Category", "unit")]
     public class TurnServerUnitTest : IDisposable
     {
-        private ILogger logger = null;
+        private readonly ILogger logger = null;
         private readonly List<TurnServer> _servers = new List<TurnServer>();
 
         private const string TEST_USERNAME = "testuser";


### PR DESCRIPTION
Updated logger fields to be static or readonly across the codebase, enhancing thread safety and code clarity. Also applied minor formatting fixes and improved immutability in test classes. Aligns with best practices for logger usage.