### PR TITLE
Fix NullReferenceException for re-INVITE with no SDP body

### DIFF
--- a/src/SIPSorcery/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/SIPSorcery/app/SIPUserAgents/SIPUserAgent.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Filename: SIPUserAgent.cs
 //
 // Description: A "full" SIP user agent that encompasses both client and server 
@@ -1098,9 +1098,12 @@ namespace SIPSorcery.SIP.App
                     {
                         bool streamAdded = false;
 
-                        // Process both video and text streams
-                        HandleStreamChange(SDPMediaTypesEnum.video, offer, ref streamAdded);
-                        HandleStreamChange(SDPMediaTypesEnum.text, offer, ref streamAdded);
+                        // Process both video and text streams if offer exists
+                        if (offer != null)
+                        {
+                            HandleStreamChange(SDPMediaTypesEnum.video, offer, ref streamAdded);
+                            HandleStreamChange(SDPMediaTypesEnum.text, offer, ref streamAdded);
+                        }
 
                         // TODO: We should accept an empty re-INVITE body and send a new offer in the response. The remote peer can then send
                         // back the SDP answer in the ACK.


### PR DESCRIPTION
Empty SDP body in a re-INVITE causes an exception in `HandleStreamChange`, because `offer` is null.
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at SIPSorcery.SIP.App.SIPUserAgent.HandleStreamChange(SDPMediaTypesEnum type, SDP offer, Boolean& streamAdded)
   at SIPSorcery.SIP.App.SIPUserAgent.DialogRequestReceivedAsync(SIPRequest sipRequest)
```
It seems the surrounding code can handle the case of an empty body, so the fix should be simply to avoid executing code that works with the SDP offer.