### PR TITLE
SIP: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -376,7 +376,7 @@ namespace SIPSorcery.SIP
                         if (receiveTask.IsCompleted)
                         {
                             logger.LogDebug("Client web socket connection to {ServerUri} received {BytesReceived} bytes.", conn.ServerUri, receiveTask.Result.Count);
-                            //SIPMessageReceived(this, conn.LocalEndPoint, conn.RemoteEndPoint, conn.ReceiveBuffer.Take(receiveTask.Result.Count).ToArray()).Wait();
+                            //SIPMessageReceived(this, conn.LocalEndPoint, conn.RemoteEndPoint, conn.ReceiveBuffer.AsSpan(0, receiveTask.Result.Count).ToArray()).Wait();
                             ExtractSIPMessages(this, conn, conn.ReceiveBuffer, receiveTask.Result.Count);
                             conn.ReceiveTask = conn.Client.ReceiveAsync(conn.ReceiveBuffer, m_cts.Token);
                         }

--- a/src/SIPSorcery/core/SIP/Channels/SIPWebSocketChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPWebSocketChannel.cs
@@ -123,7 +123,7 @@ namespace SIPSorcery.SIP
 
             public void Send(byte[] buffer, int offset, int length)
             {
-                base.Send(buffer.Skip(offset).Take(length).ToArray());
+                base.Send(buffer.AsSpan(offset, length).ToArray());
             }
         }
 


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.