### PR TITLE
HEP: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/net/HEP/HepPacket.cs
+++ b/src/SIPSorcery/net/HEP/HepPacket.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -287,7 +286,7 @@ namespace SIPSorcery.Net
             // Length
             BinaryPrimitives.WriteUInt16BigEndian(packetBuffer.AsSpan(4), (ushort)offset);
 
-            return packetBuffer.Take(offset).ToArray();
+            return packetBuffer.AsSpan(0, offset).ToArray();
         }
     }
 }


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.