### PR TITLE
RTCP: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/net/RTCP/RTCPCompoundPacket.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPCompoundPacket.cs
@@ -16,8 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
@@ -74,7 +72,7 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
-                    var buffer = packet.Skip(offset).ToArray();
+                    var buffer = packet.AsSpan(offset).ToArray();
 
                     // The payload type field is the second byte in the RTCP header.
                     byte packetTypeID = buffer[1];
@@ -237,7 +235,7 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
-                    var buffer = packet.Skip(offset).ToArray();
+                    var buffer = packet.AsSpan(offset).ToArray();
 
                     // The payload type field is the second byte in the RTCP header.
                     byte packetTypeID = buffer[1];

--- a/src/SIPSorcery/net/RTCP/RTCPReceiverReport.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPReceiverReport.cs
@@ -87,15 +87,13 @@ namespace SIPSorcery.Net
 
             SSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.AsSpan(4));
 
-            int rrIndex = 8;
-            for (int i = 0; i < Header.ReceptionReportCount; i++)
+            var remaining = packet.AsSpan(8);
+            for (var i = 0; (remaining.Length >= ReceptionReportSample.PAYLOAD_SIZE) && (i < Header.ReceptionReportCount); i++)
             {
-                var pkt = packet.AsSpan(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
-                if (pkt.Length >= ReceptionReportSample.PAYLOAD_SIZE)
-                {
-                    var rr = new ReceptionReportSample(pkt);
-                    ReceptionReports.Add(rr);
-                }
+                var rr = new ReceptionReportSample(remaining.Slice(0, ReceptionReportSample.PAYLOAD_SIZE).ToArray());
+                ReceptionReports.Add(rr);
+
+                remaining = remaining.Slice(ReceptionReportSample.PAYLOAD_SIZE);
             }
         }
 

--- a/src/SIPSorcery/net/RTCP/RTCPReceiverReport.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPReceiverReport.cs
@@ -47,7 +47,6 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SIPSorcery.Net
 {
@@ -91,7 +90,7 @@ namespace SIPSorcery.Net
             int rrIndex = 8;
             for (int i = 0; i < Header.ReceptionReportCount; i++)
             {
-                var pkt = packet.Skip(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
+                var pkt = packet.AsSpan(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
                 if (pkt.Length >= ReceptionReportSample.PAYLOAD_SIZE)
                 {
                     var rr = new ReceptionReportSample(pkt);

--- a/src/SIPSorcery/net/RTCP/RTCPSenderReport.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPSenderReport.cs
@@ -106,16 +106,13 @@ namespace SIPSorcery.Net
             PacketCount = BinaryPrimitives.ReadUInt32BigEndian(packet.AsSpan(20));
             OctetCount = BinaryPrimitives.ReadUInt32BigEndian(packet.AsSpan(24));
 
-            int rrIndex = 28;
-            for (int i = 0; i < Header.ReceptionReportCount; i++)
+            var remaining = packet.AsSpan(28);
+            for (var i = 0; (remaining.Length >= ReceptionReportSample.PAYLOAD_SIZE) && (i < Header.ReceptionReportCount); i++)
             {
-                var pkt = packet.AsSpan(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
-                if (pkt.Length >= ReceptionReportSample.PAYLOAD_SIZE)
-                {
-                    var rr = new ReceptionReportSample(pkt);
-                    ReceptionReports.Add(rr);
-                }
-                
+                var rr = new ReceptionReportSample(remaining.Slice(0, ReceptionReportSample.PAYLOAD_SIZE).ToArray());
+                ReceptionReports.Add(rr);
+
+                remaining = remaining.Slice(ReceptionReportSample.PAYLOAD_SIZE);
             }
         }
 

--- a/src/SIPSorcery/net/RTCP/RTCPSenderReport.cs
+++ b/src/SIPSorcery/net/RTCP/RTCPSenderReport.cs
@@ -47,7 +47,6 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SIPSorcery.Net
 {
@@ -110,7 +109,7 @@ namespace SIPSorcery.Net
             int rrIndex = 28;
             for (int i = 0; i < Header.ReceptionReportCount; i++)
             {
-                var pkt = packet.Skip(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
+                var pkt = packet.AsSpan(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
                 if (pkt.Length >= ReceptionReportSample.PAYLOAD_SIZE)
                 {
                     var rr = new ReceptionReportSample(pkt);


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.