### PR TITLE
RTP: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/net/RTP/Packetisation/H264Packetiser.cs
+++ b/src/SIPSorcery/net/RTP/Packetisation/H264Packetiser.cs
@@ -30,8 +30,8 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SIPSorcery.Net
 {
@@ -74,7 +74,7 @@ namespace SIPSorcery.Net
                         int nalSize = endPosn - currPosn;
                         bool isLast = currPosn + nalSize == accessUnit.Length;
 
-                        yield return new H264Nal(accessUnit.Skip(currPosn).Take(nalSize).ToArray(), isLast);
+                        yield return new H264Nal(accessUnit.AsSpan(currPosn, nalSize).ToArray(), isLast);
                     }
 
                     currPosn = nalStart;
@@ -87,7 +87,7 @@ namespace SIPSorcery.Net
 
             if (currPosn < accessUnit.Length)
             {
-                yield return new H264Nal(accessUnit.Skip(currPosn).ToArray(), true);
+                yield return new H264Nal(accessUnit.AsSpan(currPosn).ToArray(), true);
             }
         }
 

--- a/src/SIPSorcery/net/RTP/Packetisation/H265Packetiser.cs
+++ b/src/SIPSorcery/net/RTP/Packetisation/H265Packetiser.cs
@@ -16,8 +16,8 @@
 // License: 
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SIPSorcery.net.RTP.Packetisation
 {
@@ -60,7 +60,7 @@ namespace SIPSorcery.net.RTP.Packetisation
                         int nalSize = endPosn - currPosn;
                         bool isLast = currPosn + nalSize == accessUnit.Length;
 
-                        yield return new H265Nal(accessUnit.Skip(currPosn).Take(nalSize).ToArray(), isLast);
+                        yield return new H265Nal(accessUnit.AsSpan(currPosn, nalSize).ToArray(), isLast);
                     }
 
                     currPosn = nalStart;
@@ -74,7 +74,7 @@ namespace SIPSorcery.net.RTP.Packetisation
 
             if (currPosn < accessUnit.Length)
             {
-                yield return new H265Nal(accessUnit.Skip(currPosn).ToArray(), true);
+                yield return new H265Nal(accessUnit.AsSpan(currPosn).ToArray(), true);
             }
         }
 

--- a/src/SIPSorcery/net/RTP/Packetisation/MJPEGPacketiser.cs
+++ b/src/SIPSorcery/net/RTP/Packetisation/MJPEGPacketiser.cs
@@ -23,8 +23,7 @@ using System.Net;
 namespace SIPSorcery.net.RTP.Packetisation
 {
     /// <summary>
-    /// This class offers packetisation of MJPEG to be sent over RTP.
-    /// @author mdr@milestone.dk
+    /// This class offers packetisation of MJPEG to be sent over RTP. @author mdr@milestone.dk
     /// </summary>
     public class MJPEGPacketiser
     {
@@ -157,30 +156,21 @@ namespace SIPSorcery.net.RTP.Packetisation
 
             jmt_SOS = 0xDA,
             jmt_DRI = 0xDD
-        } 
+        }
 
         /// <summary>
-        /// Create an RTP header for an MJPEG frame fragment. Typically it will not be a full frame
-        /// due to the frame size. This method does not support multiple frames in one packet.
+        /// Create an RTP header for an MJPEG frame fragment. Typically it will not be a full frame due to the frame
+        /// size. This method does not support multiple frames in one packet.
         /// </summary>
         /// <remarks>
-        /// Each packet contains a special JPEG header which immediately follows
-        /// the rtp header.the first 8 bytes of this header, called the "main
-        /// jpeg header", are as follows:
-        /// <code>
-        /// 0                   1                   2                   3
-        /// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-        /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        /// | type-specific |              fragment offset                  |
-        /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        /// |      type     |       q       |     width     |     height    |
-        /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        /// </code>
-        /// All fields in this header except for the fragment offset field must
-        /// remain the same in all packets that correspond to the same jpeg
-        /// frame.
-        /// A restart marker header and/or quantization table header may follow
-        /// this header, depending on the values of the type and q fields.
+        /// Each packet contains a special JPEG header which immediately follows the rtp header.the first 8 bytes of
+        /// this header, called the "main jpeg header", are as follows: <code> 0 1 2 3 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6
+        /// 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |
+        /// type-specific | fragment offset | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | type |
+        /// q | width | height | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ </code> All fields in
+        /// this header except for the fragment offset field must remain the same in all packets that correspond to the
+        /// same jpeg frame. A restart marker header and/or quantization table header may follow this header, depending
+        /// on the values of the type and q fields.
         /// </remarks>
         /// <param name="customData">The MJPEG header to be written into bytes</param>
         /// <param name="offset">The offset of current RTP package</param>
@@ -232,8 +222,7 @@ namespace SIPSorcery.net.RTP.Packetisation
         }
 
         /// <summary>
-        /// Scans the frame for markers and builds the RTPHeader data.
-        /// Returns the raw frame data.
+        /// Scans the frame for markers and builds the RTPHeader data. Returns the raw frame data.
         /// </summary>
         /// <param name="jpegFrame">The entire frame data</param>
         /// <param name="customData">RTPHeader data in a readable structure</param>
@@ -259,7 +248,12 @@ namespace SIPSorcery.net.RTP.Packetisation
                     {
                         if (currentMarker.StartPosition > 0)
                         {
-                            currentMarker.MarkerBytes = jpegFrame.AsSpan(currentMarker.StartPosition, index + 1).ToArray();
+                            var markerBytes = jpegFrame.AsSpan(currentMarker.StartPosition);
+                            if (markerBytes.Length > index + 1)
+                            {
+                                markerBytes = markerBytes.Slice(0, index + 1);
+                            }
+                            currentMarker.MarkerBytes = markerBytes.ToArray();
                             markers.Add(currentMarker);
                             currentMarker = new Marker();
                         }
@@ -276,7 +270,12 @@ namespace SIPSorcery.net.RTP.Packetisation
             }
             if (currentMarker.StartPosition > 0)
             {
-                currentMarker.MarkerBytes = jpegFrame.AsSpan(currentMarker.StartPosition, index).ToArray();
+                var markerBytes = jpegFrame.AsSpan(currentMarker.StartPosition);
+                if (markerBytes.Length > index)
+                {
+                    markerBytes = markerBytes.Slice(0, index);
+                }
+                currentMarker.MarkerBytes = markerBytes.ToArray();
                 markers.Add(currentMarker);
             }
 

--- a/src/SIPSorcery/net/RTP/Packetisation/MJPEGPacketiser.cs
+++ b/src/SIPSorcery/net/RTP/Packetisation/MJPEGPacketiser.cs
@@ -259,7 +259,7 @@ namespace SIPSorcery.net.RTP.Packetisation
                     {
                         if (currentMarker.StartPosition > 0)
                         {
-                            currentMarker.MarkerBytes = jpegFrame.Skip(currentMarker.StartPosition).Take(index + 1).ToArray();
+                            currentMarker.MarkerBytes = jpegFrame.AsSpan(currentMarker.StartPosition, index + 1).ToArray();
                             markers.Add(currentMarker);
                             currentMarker = new Marker();
                         }
@@ -276,7 +276,7 @@ namespace SIPSorcery.net.RTP.Packetisation
             }
             if (currentMarker.StartPosition > 0)
             {
-                currentMarker.MarkerBytes = jpegFrame.Skip(currentMarker.StartPosition).Take(index).ToArray();
+                currentMarker.MarkerBytes = jpegFrame.AsSpan(currentMarker.StartPosition, index).ToArray();
                 markers.Add(currentMarker);
             }
 
@@ -317,7 +317,7 @@ namespace SIPSorcery.net.RTP.Packetisation
         private static MJPEGData ProcessJpegSos(Marker marker, MJPEG mjpeg)
         {
             var hdrLength = (marker.MarkerBytes[0] << 8) | marker.MarkerBytes[1];
-            var bytes = marker.MarkerBytes.Skip(hdrLength).ToArray();
+            var bytes = marker.MarkerBytes.AsSpan(hdrLength).ToArray();
             return new MJPEGData() { Data = bytes };
         }
 
@@ -335,7 +335,7 @@ namespace SIPSorcery.net.RTP.Packetisation
             var qCount = (hdrLength - QTableHeaderLength) / QTableBlockLength8Bit;
             for (var i = 0; i < qCount; i++)
             {
-                var bytes = marker.MarkerBytes.Skip(QTableHeaderLength + i * QTableBlockLength8Bit + QTableParamsLength).Take(QTableLength8Bit).ToArray();
+                var bytes = marker.MarkerBytes.AsSpan(QTableHeaderLength + i * QTableBlockLength8Bit + QTableParamsLength, QTableLength8Bit).ToArray();
                 mjpeg.QTables.Add(bytes);
                 mjpeg.MjpegHeaderQTable.SetLength(mjpeg.MjpegHeaderQTable.GetLength() + bytes.Length);
             }

--- a/src/SIPSorcery/net/RTP/Packetisation/RtpVideoFramer.cs
+++ b/src/SIPSorcery/net/RTP/Packetisation/RtpVideoFramer.cs
@@ -17,10 +17,8 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.net.RTP.Packetisation;
-using SIPSorcery.Sys;
 using SIPSorceryMedia.Abstractions;
 
 namespace SIPSorcery.Net
@@ -95,7 +93,7 @@ namespace SIPSorcery.Net
 
                     if (rtpPacket.Header.MarkerBit > 0)
                     {
-                        var frame = _currVideoFrame.Take(_currVideoFramePosn).ToArray();
+                        var frame = _currVideoFrame.AsSpan(0, _currVideoFramePosn).ToArray();
 
                         _currVideoFramePosn = 0;
 

--- a/src/SIPSorcery/net/RTP/RTPHeader.cs
+++ b/src/SIPSorcery/net/RTP/RTPHeader.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Linq;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net;
@@ -159,7 +158,7 @@ public class RTPHeader
                     invalid = true;
                     return null;
                 }
-                ext = new RTPHeaderExtensionData(id, ExtensionPayload.Skip(position).Take(len).ToArray(), type);
+                ext = new RTPHeaderExtensionData(id, ExtensionPayload.AsSpan(position, len).ToArray(), type);
                 position += len;
             }
             else

--- a/src/SIPSorcery/net/RTP/RTPSession.cs
+++ b/src/SIPSorcery/net/RTP/RTPSession.cs
@@ -2512,7 +2512,7 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
-                    buffer = buffer.Take(outBufLen).ToArray();
+                    buffer = buffer.AsSpan(0, outBufLen).ToArray();
                 }
             }
 

--- a/src/SIPSorcery/net/RTP/Streams/MediaStream.cs
+++ b/src/SIPSorcery/net/RTP/Streams/MediaStream.cs
@@ -323,7 +323,7 @@ namespace SIPSorcery.Net
 
                 if (res == 0)
                 {
-                    return (true, buffer.Take(outBufLen).ToArray());
+                    return (true, buffer.AsSpan(0, outBufLen).ToArray());
                 }
                 else
                 {
@@ -522,7 +522,7 @@ namespace SIPSorcery.Net
                     }
                     else
                     {
-                        rtpBuffer = rtpBuffer.Take(outBufLen).ToArray();
+                        rtpBuffer = rtpBuffer.AsSpan(0, outBufLen).ToArray();
                     }
                 }
 
@@ -710,7 +710,7 @@ namespace SIPSorcery.Net
                         //logger.LogDebug("Sending key {MediaType} RTCP packet size {Size} to {EndPoint}.",
                         //    MediaType, outBufLen, ControlDestinationEndPoint);
 
-                        rtpChannel.Send(sendOnSocket, ControlDestinationEndPoint, sendBuffer.Take(outBufLen).ToArray());
+                        rtpChannel.Send(sendOnSocket, ControlDestinationEndPoint, sendBuffer.AsSpan(0, outBufLen).ToArray());
                     }
                 }
             }

--- a/src/SIPSorcery/net/RTP/Streams/VideoStream.cs
+++ b/src/SIPSorcery/net/RTP/Streams/VideoStream.cs
@@ -153,7 +153,7 @@ namespace SIPSorcery.Net
             //logger.LogDebug($"Send NAL {nal.Length}, is last {isLastNal}, timestamp {videoTrack.Timestamp}.");
             //logger.LogDebug($"nri {nalNri:X2}, type {nalType:X2}.");
             var naluHeaderSize = is265 ? 2 : 1;
-            byte[] naluHeader = is265 ? nal.Take(2).ToArray() : nal.Take(1).ToArray();
+            byte[] naluHeader = is265 ? nal.AsSpan(0, 2).ToArray() : nal.Take(1).ToArray();
 
             if (nal.Length <= RTPSession.RTP_MAX_PAYLOAD)
             {
@@ -174,7 +174,7 @@ namespace SIPSorcery.Net
             }
             else
             {
-                nal = nal.Skip(naluHeaderSize).ToArray();
+                nal = nal.AsSpan(naluHeaderSize).ToArray();
                 //logger.LogTrace("Fragmenting");
 
                 // Send as Fragmentation Unit A (FU-A):
@@ -330,14 +330,14 @@ namespace SIPSorcery.Net
                         {
                             var dataSize = RTPSession.RTP_MAX_PAYLOAD - rtpHeader.Length;
                             var isLast = dataSize >= restBytes.Length;
-                            var data = isLast ? restBytes : restBytes.Take(dataSize).ToArray();
+                            var data = isLast ? restBytes : restBytes.AsSpan(0, dataSize).ToArray();
                             var markerBit = isLast ? 0 : 1;
                             var payload = rtpHeader.Concat(data).ToArray();
                             SendRtpRaw(payload, LocalTrack.Timestamp, markerBit, payloadID, true);
 
                             offset += RTPSession.RTP_MAX_PAYLOAD;
                             rtpHeader = MJPEGPacketiser.GetMJPEGRTPHeader(customData, offset);
-                            restBytes = restBytes.Skip(data.Length).ToArray();
+                            restBytes = restBytes.AsSpan(data.Length).ToArray();
                         }
                     }
                 }


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.