### PR TITLE
SCTP: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/net/SCTP/SctpDataReceiver.cs
+++ b/src/SIPSorcery/net/SCTP/SctpDataReceiver.cs
@@ -15,10 +15,8 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace SIPSorcery.Net
@@ -523,7 +521,7 @@ namespace SIPSorcery.Net
                     tsn++;
                 }
 
-                frame.UserData = frame.UserData.Take(posn).ToArray();
+                frame.UserData = frame.UserData.AsSpan(0, posn).ToArray();
 
                 return frame;
             }

--- a/test/unit/net/SCTP/SctpAssociationUnitTest.cs
+++ b/test/unit/net/SCTP/SctpAssociationUnitTest.cs
@@ -301,7 +301,7 @@ namespace SIPSorcery.Net.UnitTests
 
         public override void Send(string associationID, byte[] buffer, int offset, int length)
         {
-            _output.Add(buffer.Skip(offset).Take(length).ToArray());
+            _output.Add(buffer.AsSpan(offset, length).ToArray());
         }
 
         public void Close()


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.