### PR TITLE
STUN: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/net/STUN/STUNMessage.cs
+++ b/src/SIPSorcery/net/STUN/STUNMessage.cs
@@ -96,7 +96,7 @@ namespace SIPSorcery.Net
             if (buffer != null && buffer.Length > 0 && buffer.Length >= bufferLength)
             {
                 STUNMessage stunMessage = new STUNMessage();
-                stunMessage._receivedBuffer = buffer.Take(bufferLength).ToArray();
+                stunMessage._receivedBuffer = buffer.AsSpan(0, bufferLength).ToArray();
                 stunMessage.Header = STUNHeader.ParseSTUNHeader(buffer);
 
                 if (stunMessage.Header.MessageLength > 0)
@@ -116,7 +116,7 @@ namespace SIPSorcery.Net
                     // Check fingerprint.
                     var fingerprintAttribute = stunMessage.Attributes.Last();
 
-                    var input = buffer.Take(bufferLength - STUNAttribute.STUNATTRIBUTE_HEADER_LENGTH - FINGERPRINT_ATTRIBUTE_CRC32_LENGTH).ToArray();
+                    var input = buffer.AsSpan(0, bufferLength - STUNAttribute.STUNATTRIBUTE_HEADER_LENGTH - FINGERPRINT_ATTRIBUTE_CRC32_LENGTH).ToArray();
 
                     uint crc = Crc32.Compute(input) ^ FINGERPRINT_XOR;
                     var fingerPrint = new byte[4];

--- a/test/unit/net/STUN/STUNUnitTest.cs
+++ b/test/unit/net/STUN/STUNUnitTest.cs
@@ -175,7 +175,7 @@ namespace SIPSorcery.Net.UnitTests
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
             STUNMessage stunResponse = new STUNMessage(STUNMessageTypesEnum.BindingSuccessResponse);
-            stunResponse.Header.TransactionId = Guid.NewGuid().ToByteArray().Take(12).ToArray();
+            stunResponse.Header.TransactionId = Guid.NewGuid().ToByteArray().AsSpan(0, 12).ToArray();
             //stunResponse.AddFingerPrintAttribute();
             stunResponse.AddXORMappedAddressAttribute(IPAddress.Parse("127.0.0.1"), 1234);
 
@@ -344,8 +344,8 @@ namespace SIPSorcery.Net.UnitTests
 
             var buffer = stunRequest.ToByteBufferStringKey(icePassword, true);
 
-            //logger.LogDebug($"HMAC: {buffer.Skip(buffer.Length - ).Take(20).ToArray().HexStr()}.");
-            //logger.LogDebug($"Fingerprint: {buffer.Skip(buffer.Length -4).ToArray().HexStr()}.");
+            //logger.LogDebug($"HMAC: {buffer.AsSpan(buffer.Length - , 20).ToArray().HexStr()}.");
+            //logger.LogDebug($"Fingerprint: {buffer.AsSpan(buffer.Length -4).ToArray().HexStr()}.");
 
             STUNMessage rndTripReq = STUNMessage.ParseSTUNMessage(buffer, buffer.Length);
 


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.