### PR TITLE
FFmpeg Media: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorceryMedia.FFmpeg/FFmpegAudioSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegAudioSource.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using FFmpeg.AutoGen;
 using Microsoft.Extensions.Logging;
@@ -166,7 +165,8 @@ namespace SIPSorceryMedia.FFmpeg
             if(dstSampleCount > 0)
             {
                 // FFmpeg AV_SAMPLE_FMT_S16 will store the bytes in the correct endianess for the underlying platform.
-                short[] pcm = buffer.Take(dstSampleCount * 2).Where((x, i) => i % 2 == 0).Select((y, i) => BitConverter.ToInt16(buffer, i * 2)).ToArray();
+                short[] pcm = new short[dstSampleCount];
+                Buffer.BlockCopy(buffer, 0, pcm, 0, dstSampleCount * sizeof(short));
                 _incomingSamples.Write(pcm);
 
                 while (_incomingSamples.Available() >= frameSize)


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.