### PR TITLE
Windows Media: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
+++ b/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
@@ -348,7 +348,7 @@ namespace SIPSorceryMedia.Windows
             // https://github.com/naudio/NAudio/blob/master/NAudio/Wave/WaveOutputs/WaveBuffer.cs
 
             short[] pcm = new short[args.BytesRecorded / sizeof(short)];
-            Buffer.BlockCopy(args.Buffer, 0, pcm, 0, args.BytesRecorded * sizeof(short));
+            Buffer.BlockCopy(args.Buffer, 0, pcm, 0, args.BytesRecorded);
             byte[] encodedSample = _audioEncoder.EncodeAudio(pcm, _audioFormatManager.SelectedFormat);
             
             OnAudioSourceEncodedSample?.Invoke((uint)encodedSample.Length, encodedSample);

--- a/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
+++ b/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
@@ -347,7 +347,7 @@ namespace SIPSorceryMedia.Windows
             // Note NAudio.Wave.WaveBuffer.ShortBuffer does not take into account little endian.
             // https://github.com/naudio/NAudio/blob/master/NAudio/Wave/WaveOutputs/WaveBuffer.cs
 
-            short[] pcm = new short[args.BytesRecorded];
+            short[] pcm = new short[args.BytesRecorded / sizeof(short)];
             Buffer.BlockCopy(args.Buffer, 0, pcm, 0, args.BytesRecorded * sizeof(short));
             byte[] encodedSample = _audioEncoder.EncodeAudio(pcm, _audioFormatManager.SelectedFormat);
             

--- a/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
+++ b/src/SIPSorceryMedia.Windows/WindowsAudioEndPoint.cs
@@ -347,8 +347,8 @@ namespace SIPSorceryMedia.Windows
             // Note NAudio.Wave.WaveBuffer.ShortBuffer does not take into account little endian.
             // https://github.com/naudio/NAudio/blob/master/NAudio/Wave/WaveOutputs/WaveBuffer.cs
 
-            byte[] buffer = args.Buffer.Take(args.BytesRecorded).ToArray();
-            short[] pcm = buffer.Where((x, i) => i % 2 == 0).Select((y, i) => BitConverter.ToInt16(buffer, i * 2)).ToArray();
+            short[] pcm = new short[args.BytesRecorded];
+            Buffer.BlockCopy(args.Buffer, 0, pcm, 0, args.BytesRecorded * sizeof(short));
             byte[] encodedSample = _audioEncoder.EncodeAudio(pcm, _audioFormatManager.SelectedFormat);
             
             OnAudioSourceEncodedSample?.Invoke((uint)encodedSample.Length, encodedSample);


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.