### PR TITLE
IPSocket: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/sys/Net/IPSocket.cs
+++ b/src/SIPSorcery/sys/Net/IPSocket.cs
@@ -19,7 +19,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 
@@ -289,7 +288,7 @@ namespace SIPSorcery.Sys
                 //could [a:b:c]:d
                 if (values[0].StartsWith("[") && values[values.Length - 2].EndsWith("]"))
                 {
-                    string ipaddressstring = string.Join(":", values.Take(values.Length - 1).ToArray());
+                    string ipaddressstring = string.Join(":", values.AsSpan(0, values.Length - 1).ToArray());
                     ipaddr = IPAddress.Parse(ipaddressstring);
                     port = getPort(values[values.Length - 1]);
                     host = ipaddr.ToString();
@@ -367,7 +366,7 @@ namespace SIPSorcery.Sys
                 //could [a:b:c]:d
                 if (values[0].StartsWith("[") && values[values.Length - 2].EndsWith("]"))
                 {
-                    string ipaddressstring = string.Join(":", values.Take(values.Length - 1).ToArray());
+                    string ipaddressstring = string.Join(":", values.AsSpan(0, values.Length - 1).ToArray());
                     ipaddr = IPAddress.Parse(ipaddressstring);
                     port = getPort(values[values.Length - 1]);
                 }


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.