### PR TITLE
AudioEncoder: replace LINQ slicing with Span for perf gains

### DIFF
--- a/src/SIPSorcery/app/Media/Codecs/AudioEncoder.cs
+++ b/src/SIPSorcery/app/Media/Codecs/AudioEncoder.cs
@@ -199,7 +199,7 @@ namespace SIPSorcery.Media
                 short[] decodedPcm = new short[encodedSample.Length * 2];
                 int decodedSampleCount = _g722Decoder.Decode(_g722DecoderState, decodedPcm, encodedSample, encodedSample.Length);
 
-                return decodedPcm.Take(decodedSampleCount).ToArray();
+                return decodedPcm.AsSpan(0, decodedSampleCount).ToArray();
             }
             if (format.Codec == AudioCodecsEnum.G729)
             {


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.