### PR TITLE
Examples: replace LINQ slicing with Span for perf gains

### DIFF
--- a/examples/OpenAIExamples/AliceAndBob/AudioScope/AudioScope.cs
+++ b/examples/OpenAIExamples/AliceAndBob/AudioScope/AudioScope.cs
@@ -15,7 +15,6 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using System.Numerics;
 using MathNet.Numerics;
 using MathNet.Numerics.IntegralTransforms;
@@ -114,7 +113,7 @@ namespace AudioScope
 
             _timeIndex = (_timeIndex + samples.Length) % FFT_SIZE;
 
-            var freqBuffer = _timeRingBuffer.Skip(_timeIndex).Take(FFT_SIZE).ToArray();
+            var freqBuffer = _timeRingBuffer.AsSpan(_timeIndex, FFT_SIZE).ToArray();
 
             Fourier.Forward(freqBuffer, FourierOptions.NoScaling);
 
@@ -127,7 +126,7 @@ namespace AudioScope
 
             float scale = (float)FFT_SIZE;
 
-            var complexAnalyticBuffer = freqBuffer.Skip(FFT_SIZE - BUFFER_SIZE).Take(BUFFER_SIZE).ToArray();
+            var complexAnalyticBuffer = freqBuffer.AsSpan(FFT_SIZE - BUFFER_SIZE, BUFFER_SIZE).ToArray();
             var data = new float[BUFFER_SIZE * DISPLAY_ARRAY_STRIDE + PREVIOUS_SAMPLES_LENGTH];
 
             for (int k = 0; k < complexAnalyticBuffer.Length; k++)
@@ -148,7 +147,7 @@ namespace AudioScope
             Array.Copy(_previousResults, 0, data, 0, PREVIOUS_SAMPLES_LENGTH);
             _lastSample = data;
 
-            _previousResults = data.Skip(data.Length - PREVIOUS_SAMPLES_LENGTH).ToArray();
+            _previousResults = data.AsSpan(data.Length - PREVIOUS_SAMPLES_LENGTH).ToArray();
         }
 
         public static float GetAngle(Complex v, Complex u)

--- a/examples/WebRTCExamples/WebRTCAudioScope/AudioScope/AudioScope.cs
+++ b/examples/WebRTCExamples/WebRTCAudioScope/AudioScope/AudioScope.cs
@@ -16,7 +16,6 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using System.Numerics;
 using MathNet.Numerics;
 using MathNet.Numerics.IntegralTransforms;
@@ -122,7 +121,7 @@ namespace AudioScope
 
             _timeIndex = (_timeIndex + samples.Length) % FFT_SIZE;
 
-            var freqBuffer = _timeRingBuffer.Skip(_timeIndex).Take(FFT_SIZE).ToArray();
+            var freqBuffer = _timeRingBuffer.AsSpan(_timeIndex, FFT_SIZE).ToArray();
 
             Fourier.Forward(freqBuffer, FourierOptions.NoScaling);
 
@@ -152,7 +151,7 @@ namespace AudioScope
             const int DISPLAY_ADJACENCY = PREVIOUS_SAMPLES_LENGTH / DISPLAY_ARRAY_STRIDE;
             int displayCount = BUFFER_SIZE + DISPLAY_ADJACENCY;
             int analyticOffset = (FFT_SIZE - displayCount) / 2;
-            var complexAnalyticBuffer = freqBuffer.Skip(analyticOffset).Take(displayCount).ToArray();
+            var complexAnalyticBuffer = freqBuffer.AsSpan(analyticOffset, displayCount).ToArray();
             var data = new float[displayCount * DISPLAY_ARRAY_STRIDE];
 
             for (int k = 0; k < complexAnalyticBuffer.Length; k++)


### PR DESCRIPTION
Replaced most usages of .Skip(), .Take(), and .Where() for array slicing with Span-based alternatives to reduce allocations and improve performance. Updated audio buffer conversions to use Buffer.BlockCopy instead of LINQ. Removed unnecessary System.Linq usings. Added launchSettings.json with a CloudflareTurn profile for development.