### PR TITLE
Fix nasty bug in STUN URI equals

### DIFF
--- a/src/SIPSorcery/net/STUN/STUNUri.cs
+++ b/src/SIPSorcery/net/STUN/STUNUri.cs
@@ -299,7 +299,7 @@ namespace SIPSorcery.Net
 
         public override bool Equals(object obj)
         {
-            return Equals(this, (STUNUri)obj);
+            return obj is STUNUri other && this == other;
         }
 
         public static bool operator ==(STUNUri uri1, STUNUri uri2)
@@ -314,6 +314,11 @@ namespace SIPSorcery.Net
             }
             else if (uri1.Host == null || uri2.Host == null)
             {
+                return false;
+            }
+            else if (!string.Equals(uri1.Host, uri2.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                // DNS hostnames are case-insensitive (RFC 4343).
                 return false;
             }
             else if (uri1.Scheme != uri2.Scheme)
@@ -343,7 +348,8 @@ namespace SIPSorcery.Net
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Scheme, Transport, Host, Port, ExplicitPort);
+            // Host must be hashed with the same case-insensitive semantics used by operator ==.
+            return HashCode.Combine(Scheme, Transport, Host == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(Host), Port, ExplicitPort);
         }
     }
 }

--- a/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
@@ -119,6 +119,15 @@ namespace SIPSorcery.Net.UnitTests
         /// <summary>
         /// Tests that a send/receive works correctly if the initial DATA chunk is dropped.
         /// </summary>
+        /// <remarks>
+        /// The original version of this test asserted that the receiver's cumulative ACK was still null a
+        /// fixed 100ms after the (dropped) first send, with the sender's RTO set to 250ms. That negative
+        /// assertion raced the RTO timer: under CI load Task.Delay can resume well past the 250ms RTO, by
+        /// which time the chunk had been retransmitted, delivered and SACKed (intermittent "Expected: null,
+        /// Actual: initialTSN" failures). The drop of the first transmission is guaranteed by the relay
+        /// predicate and verified from the delivery log instead, and the positive outcomes are polled for
+        /// rather than asserted after fixed sleeps.
+        /// </remarks>
         [Fact]
         public async Task InitialDataChunkDropped()
         {
@@ -133,8 +142,12 @@ namespace SIPSorcery.Net.UnitTests
             sender._rtoMaximumMilliseconds = 250;
             sender.StartSending();
 
+            var delivered = new ConcurrentBag<(uint tsn, int sendCount)>();
+
             // This local function replicates a data chunk being sent from a data
-            // sender to the receiver of a remote peer and the return of the SACK. 
+            // sender to the receiver of a remote peer and the return of the SACK.
+            // The first transmission of the first chunk is dropped; its RTO retransmit
+            // (SendCount > 1) and everything else is delivered.
             Action<SctpDataChunk> doSend = (chunk) =>
             {
                 if (chunk.TSN == initialTSN && chunk.SendCount == 1)
@@ -143,30 +156,32 @@ namespace SIPSorcery.Net.UnitTests
                 }
                 else
                 {
+                    delivered.Add((chunk.TSN, chunk.SendCount));
                     receiver.OnDataChunk(chunk);
                     sender.GotSack(receiver.GetSackChunk());
                 }
             };
             sender._sendDataChunk = doSend;
 
+            // The first chunk's initial transmission is dropped, so the cumulative ACK can only reach
+            // initialTSN via the RTO retransmit - reaching it proves the retransmit path ran.
             sender.SendData(0, 0, new byte[] { 0x55 });
             Assert.Equal(initialTSN + 1, sender.TSN);
-            await Task.Delay(100);
-            Assert.Null(receiver.CumulativeAckTSN);
-
-            await Task.Delay(500);
+            await WaitForConditionAsync(() => receiver.CumulativeAckTSN == initialTSN, TimeSpan.FromSeconds(5));
+            Assert.Equal(initialTSN, receiver.CumulativeAckTSN);
 
             sender.SendData(0, 0, new byte[] { 0x55 });
             Assert.Equal(initialTSN + 2, sender.TSN);
-            await Task.Delay(1250);
+            await WaitForConditionAsync(() => receiver.CumulativeAckTSN == initialTSN + 1, TimeSpan.FromSeconds(5));
             Assert.Equal(initialTSN + 1, receiver.CumulativeAckTSN);
-
-            await Task.Delay(500);
 
             sender.SendData(0, 0, new byte[] { 0x55 });
             Assert.Equal(initialTSN + 3, sender.TSN);
-            await Task.Delay(100);
+            await WaitForConditionAsync(() => receiver.CumulativeAckTSN == initialTSN + 2, TimeSpan.FromSeconds(5));
             Assert.Equal(initialTSN + 2, receiver.CumulativeAckTSN);
+
+            // The first transmission of the initial chunk must never have reached the receiver.
+            Assert.DoesNotContain(delivered, d => d.tsn == initialTSN && d.sendCount == 1);
         }
 
         /// <summary>

--- a/test/unit/net/STUN/STUNClientUnitTest.cs
+++ b/test/unit/net/STUN/STUNClientUnitTest.cs
@@ -32,13 +32,13 @@ namespace SIPSorcery.Net.UnitTests
         /// <summary>
         /// Tests that the STUN client can get it's public IP address from a known STUN server.
         /// </summary>
-        [Fact(Skip = "STUN server isn't kept running all the time.")]
+        [Fact()]
         public void GetPublicIPStunClientTestMethod()
         {
             logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
             logger.BeginScope(TestHelper.GetCurrentMethodName());
 
-            var publicIP = STUNClient.GetPublicIPAddress("stun.sipsorcery.com");
+            var publicIP = STUNClient.GetPublicIPAddress("stun.cloudflare.com");
 
             logger.LogDebug("Public IP address {publicIP}.", publicIP);
         }

--- a/test/unit/net/STUN/STUNUriUnitTest.cs
+++ b/test/unit/net/STUN/STUNUriUnitTest.cs
@@ -209,5 +209,61 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(STUNProtocolsEnum.tcp, stunUri.Transport);
             Assert.Equal(ProtocolType.Tcp, stunUri.Protocol);
         }
+
+        /// <summary>
+        /// Tests that URIs differing only by host are NOT equal. The equality operator previously
+        /// omitted the host comparison, which caused distinct ICE servers to be sporadically
+        /// de-duplicated when their host strings happened to land in the same dictionary hash bucket
+        /// (string hash codes are randomised per process, hence the intermittent failures).
+        /// </summary>
+        [Fact]
+        public void EqualityComparesHostTestMethod()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            Assert.True(STUNUri.TryParse("stun:1.2.3.4:3478", out var uri1));
+            Assert.True(STUNUri.TryParse("stun:1.2.3.5:3478", out var uri2));
+
+            Assert.False(uri1 == uri2);
+            Assert.True(uri1 != uri2);
+            Assert.False(uri1.Equals(uri2));
+        }
+
+        /// <summary>
+        /// Tests that the host comparison is case-insensitive (RFC 4343) and that equal URIs
+        /// produce identical hash codes, as required for use as dictionary keys.
+        /// </summary>
+        [Fact]
+        public void EqualityHostCaseInsensitiveTestMethod()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            Assert.True(STUNUri.TryParse("stun:STUN.sipsorcery.com:3478", out var uri1));
+            Assert.True(STUNUri.TryParse("stun:stun.sipsorcery.com:3478", out var uri2));
+
+            Assert.True(uri1 == uri2);
+            Assert.Equal(uri1.GetHashCode(), uri2.GetHashCode());
+        }
+
+        /// <summary>
+        /// Tests the object overload of Equals. The previous implementation called
+        /// object.Equals(this, obj) which dispatched straight back into itself (stack overflow) and
+        /// threw InvalidCastException for non STUNUri arguments.
+        /// </summary>
+        [Fact]
+        public void EqualsObjectOverloadTestMethod()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            Assert.True(STUNUri.TryParse("stun:1.2.3.4:3478", out var uri1));
+            Assert.True(STUNUri.TryParse("stun:1.2.3.4:3478", out var uri2));
+
+            Assert.True(uri1.Equals((object)uri2));
+            Assert.False(uri1.Equals("not a stun uri"));
+            Assert.False(uri1.Equals(null));
+        }
     }
 }


### PR DESCRIPTION
Fixes to an SCTP unit test and re-enable a STUN DNS lookup test.